### PR TITLE
DNSPolicy for HostNetwork pods

### DIFF
--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -521,6 +521,7 @@ func (s *Deployment) createDaemonSet() error {
 					ServiceAccountName: "storageos-daemonset-sa",
 					HostPID:            true,
 					HostNetwork:        true,
+					DNSPolicy: "ClusterFirstWithHostNet",
 					InitContainers: []v1.Container{
 						{
 							Name:  "enable-lio",


### PR DESCRIPTION
We need that StorageOS pods access the Cluster DNS. Because StorageOS runs with HostNetwork the default resolution doesn't work because the DNS pods and StorageOS pods run in different subnets.

To be able to access the etcd containers, we need reverse resolution (etcd pods are deployed exposing its advertise url with dns names). 