### PR TITLE
Fix DaemonSet RollingUpdate MaxUnavailable

### DIFF
--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -197,18 +197,23 @@ func (r *ReconcileStorageOSCluster) reconcile(m *storageosv1alpha1.StorageOSClus
 	// Finalizers are set when an object should be deleted. Apply deploy only
 	// when finalizers is empty.
 	if len(m.GetFinalizers()) == 0 {
-		// Check if there's a new version of the cluster config and create a new
-		// deployment accordingly to update the resources that already exist.
-		updateIfExists := false
-		if r.currentCluster.GetResourceVersion() != m.GetResourceVersion() {
-			log.Println("new cluster config detected")
-			updateIfExists = true
-			r.SetCurrentCluster(m)
-		}
+		// // Check if there's a new version of the cluster config and create a new
+		// // deployment accordingly to update the resources that already exist.
+		// // TODO: Add more granular checks. Resource version check is not enough
+		// // to detect and apply changes. Maybe add an admission webhook to
+		// // perform validation when the cluster config is updated and handle the
+		// // resource update at an individual level. Updating all the resources
+		// // is dangerous.
+		// updateIfExists := false
+		// if r.currentCluster.GetResourceVersion() != m.GetResourceVersion() {
+		// 	log.Println("new cluster config detected")
+		// 	updateIfExists = true
+		// 	r.SetCurrentCluster(m)
+		// }
 
 		// TODO: Remove this after resolving the conflict between two way
 		// binding and upgrade.
-		updateIfExists = false
+		updateIfExists := false
 
 		stosDeployment := storageos.NewDeployment(r.client, m, r.recorder, r.scheme, r.k8sVersion, updateIfExists)
 		if err := stosDeployment.Deploy(); err != nil {

--- a/pkg/util/task/task.go
+++ b/pkg/util/task/task.go
@@ -9,7 +9,9 @@ import (
 // ErrTimedOut is returned when an operation times out
 var ErrTimedOut = errors.New("timed out performing task")
 
-// DoRetryWithTimeout performs given task with given timeout and timeBeforeRetry
+// DoRetryWithTimeout performs given task with given timeout and timeBeforeRetry.
+// The function t returns a result out, a boolean to retry, and an error
+// containing the reason for failure.
 func DoRetryWithTimeout(t func() (interface{}, bool, error), timeout, timeBeforeRetry time.Duration) (interface{}, error) {
 	done := make(chan bool, 1)
 	quit := make(chan bool, 1)


### PR DESCRIPTION
RollingUpdate MaxUnavailable should be set to the number of pods the
daemonset has.

It also disables checking cluster config resource version for now.
Config update needs more granualar checks before it's enabled.