### PR TITLE
Create image puller job in upgrade

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,13 @@
 FROM alpine:3.6
 
-USER nobody
+RUN apk --no-cache add openssl wget
+RUN \
+    wget --no-check-certificate -q https://download.docker.com/linux/static/stable/x86_64/docker-17.03.0-ce.tgz && \
+    tar -xvzf docker-17.03.0-ce.tgz && \
+    cp docker/docker /bin/ && \
+    rm -rf docker* && \
+    chmod +x /bin/docker
 
 ADD build/_output/bin/cluster-operator /usr/local/bin/cluster-operator
 ADD build/_output/bin/upgrader /usr/local/bin/upgrader
+ADD cmd/image-puller/docker-puller.sh /usr/local/bin/docker-puller.sh

--- a/cmd/image-puller/docker-puller.sh
+++ b/cmd/image-puller/docker-puller.sh
@@ -1,0 +1,17 @@
+#!/bin/ash
+
+set -euo pipefail
+
+# Gracefully handle the TERM signal sent when deleting the daemonset
+trap 'exit' TERM
+
+# This is the main command that's run by this script on
+# all the nodes.
+docker pull $1
+
+# Let the monitoring script know we're done.
+echo "done"
+
+# this is a workaround to prevent the container from exiting
+# and k8s restarting the daemonset pod
+while true; do sleep 1; done

--- a/deploy/crds/storageos_v1alpha1_job_cr.yaml
+++ b/deploy/crds/storageos_v1alpha1_job_cr.yaml
@@ -4,6 +4,7 @@ metadata:
   name: example-job
 spec:
   image: darkowlzz/cleanup:v0.0.2
-  args: ["/basetarget/storageos"]
+  args: ["/var/lib/storageos"]
   mountPath: "/var/lib"
+  hostPath: "/var/lib"
   completionWord: "done"

--- a/pkg/apis/storageos/v1alpha1/job_types.go
+++ b/pkg/apis/storageos/v1alpha1/job_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -30,6 +31,10 @@ type JobSpec struct {
 
 	// LabelSelector is the label selector for the job Pods.
 	LabelSelector string `json:"labelSelector"`
+
+	// NodeSelectorTerms is the set of placement of the job pods using node
+	// affinity requiredDuringSchedulingIgnoredDuringExecution.
+	NodeSelectorTerms []corev1.NodeSelectorTerm `json:"nodeSelectorTerms"`
 }
 
 // GetLabelSelector returns Job's pod label selector.

--- a/pkg/apis/storageos/v1alpha1/job_types.go
+++ b/pkg/apis/storageos/v1alpha1/job_types.go
@@ -18,8 +18,11 @@ type JobSpec struct {
 	// Args is an array of strings passed as an argumen to the job container.
 	Args []string `json:"args"`
 
-	// MountPath is the path that's mounted on the job container.
+	// MountPath is the path in the job container where a volume is mounted.
 	MountPath string `json:"mountPath"`
+
+	// HostPath is the path in the host that's mounted into a job container.
+	HostPath string `json:"hostPath"`
 
 	// CompletionWord is the word that's looked for in the pod logs to find out
 	// if a DaemonSet Pod has completed its task.

--- a/pkg/apis/storageos/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/storageos/v1alpha1/zz_generated.deepcopy.go
@@ -110,6 +110,13 @@ func (in *JobSpec) DeepCopyInto(out *JobSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NodeSelectorTerms != nil {
+		in, out := &in.NodeSelectorTerms, &out.NodeSelectorTerms
+		*out = make([]v1.NodeSelectorTerm, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -259,18 +259,18 @@ func newDaemonSetForCR(cr *storageosv1alpha1.Job) (*appsv1.DaemonSet, error) {
 							Args:  cr.Spec.Args,
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "basetarget",
-									MountPath: "/basetarget",
+									Name:      "target",
+									MountPath: cr.Spec.MountPath,
 								},
 							},
 						},
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: "basetarget",
+							Name: "target",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
-									Path: cr.Spec.MountPath,
+									Path: cr.Spec.HostPath,
 								},
 							},
 						},

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -238,7 +238,7 @@ func newDaemonSetForCR(cr *storageosv1alpha1.Job) (*appsv1.DaemonSet, error) {
 	// The label selector labels must be present in all the DaemonSet Pods.
 	mergedLabels := labels.Merge(defaultLabels, selectorMap)
 
-	return &appsv1.DaemonSet{
+	dset := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name + "-daemonset-job",
 			Namespace: cr.Namespace,
@@ -278,5 +278,16 @@ func newDaemonSetForCR(cr *storageosv1alpha1.Job) (*appsv1.DaemonSet, error) {
 				},
 			},
 		},
-	}, nil
+	}
+
+	// Add node affinity if defined.
+	if len(cr.Spec.NodeSelectorTerms) > 0 {
+		dset.Spec.Template.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: cr.Spec.NodeSelectorTerms,
+			},
+		}}
+	}
+
+	return dset, nil
 }


### PR DESCRIPTION
With this, the new upgrade image is pulled in all the nodes first,
before any upgrade is attempted. Upgrade starts only after the image is
downloaded in all the nodes.

This also changes the jobs spec, adding `HostPath` to set volume path on
host and `MountPath` to set the mount path in the job container.