### PR TITLE
test/e2e(openshift): add security context for statefulset

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -81,6 +81,7 @@ run_openshift() {
     # This is openshift specific permission which is required for the operator
     # to work.
     oc adm policy add-scc-to-user privileged system:serviceaccount:storageos:storageos-daemonset-sa
+    oc adm policy add-scc-to-user privileged system:serviceaccount:storageos:storageos-statefulset-sa
     echo
 }
 


### PR DESCRIPTION
CSI sidecar containers deployed as statefulset need permissions to
create volume hostpath.