### PR TITLE
pkg/apis/storageos: update default csi-provisioner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Parameter | Description | Default
 `images.initContainer` | StorageOS init container image | `storageos/init:0.1`
 `images.csiNodeDriverRegistrarContainer` | CSI Node Driver Registrar Container image | `quay.io/k8scsi/csi-node-driver-registrar:v1.0.1`
 `images.csiClusterDriverRegistrarContainer` | CSI Cluster Driver Registrar Container image | `quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1`
-`images.csiExternalProvisionerContainer` | CSI External Provisioner Container image | `quay.io/k8scsi/csi-provisioner:v1.0.1`
+`images.csiExternalProvisionerContainer` | CSI External Provisioner Container image | `storageos/csi-provisioner:v1.0.1`
 `images.csiExternalAttacherContainer` | CSI External Attacher Container image | `quay.io/k8scsi/csi-attacher:v1.0.1`
 `csi.enable` | Enable CSI setup | `false`
 `csi.enableProvisionCreds` | Enable CSI provision credentials | `false`

--- a/pkg/apis/storageos/v1alpha1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1alpha1/storageoscluster_types.go
@@ -32,11 +32,11 @@ const (
 	DefaultInitContainerImage                 = "storageos/init:0.1"
 	CSIv1ClusterDriverRegistrarContainerImage = "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1"
 	CSIv1NodeDriverRegistrarContainerImage    = "quay.io/k8scsi/csi-node-driver-registrar:v1.0.1"
-	CSIv1ExternalProvisionerContainerImage    = "quay.io/k8scsi/csi-provisioner:v1.0.1"
+	CSIv1ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v1.0.1"
 	CSIv1ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v1.0.1"
 	CSIv1LivenessProbeContainerImage          = "quay.io/k8scsi/livenessprobe:v1.0.1"
 	CSIv0DriverRegistrarContainerImage        = "quay.io/k8scsi/driver-registrar:v0.4.2"
-	CSIv0ExternalProvisionerContainerImage    = "quay.io/k8scsi/csi-provisioner:v0.4.2"
+	CSIv0ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v0.4.2"
 	CSIv0ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v0.4.2"
 
 	DefaultPluginRegistrationPath = "/var/lib/kubelet/plugins_registry"


### PR DESCRIPTION
Replace the official csi-provisioner image with a forked version that
supports PVC labels.