### PR TITLE
Pass OPERATOR_IMAGE ARG to Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ image/cluster-operator: operator-sdk
 	docker build \
 		--build-arg BUILD_IMAGE=$(BUILD_IMAGE) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
+		--build-arg OPERATOR_IMAGE=$(OPERATOR_IMAGE) \
 		. -f build/Dockerfile -t $(OPERATOR_IMAGE)
 
 local-run: build/upgrader

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,12 +1,16 @@
-ARG BUILD_IMAGE
-ARG BASE_IMAGE
+ARG BUILD_IMAGE=golang:1.11.5
+ARG BASE_IMAGE=alpine:3.9
+ARG OPERATOR_IMAGE=storageos/cluster-operator:test
 
 FROM ${BUILD_IMAGE} AS build
+# OPERATOR_IMAGE needs to be passed to build/cluster-operator for constructing
+# the ldflags.
+ARG OPERATOR_IMAGE
 WORKDIR /go/src/github.com/storageos/cluster-operator/
 COPY . /go/src/github.com/storageos/cluster-operator/
 RUN cp build/operator-sdk /usr/local/bin/
 RUN make generate
-RUN make build/cluster-operator
+RUN make build/cluster-operator OPERATOR_IMAGE=$OPERATOR_IMAGE
 RUN make build/upgrader
 
 FROM ${BASE_IMAGE}


### PR DESCRIPTION
OPERATOR_IMAGE is needed to construct the appropriate ldflags for
upgrade controller.
Also, add defaults for ARGs.