### PR TITLE
pkg/storageos: register all the resource schemes

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -233,8 +233,8 @@ main() {
     # echo "**** Resource details for storageos-operator namespace ****"
     # print_pod_details_and_logs storageos-operator
 
-    echo "**** Resource details for storageos namespace ****"
-    print_pod_details_and_logs storageos
+    # echo "**** Resource details for storageos namespace ****"
+    # print_pod_details_and_logs storageos
 
     echo "Done Testing!"
 }


### PR DESCRIPTION
This change adds a test setup function that runs before all the tests in
storageos package to register all the necessary resource schemes.
Also, adds error checks for Deploy() calls in the tests.

Disabling print pod details and logs for storageos namespace. This
results in tests exiting with non-zero code when the print function
tries to fetch the pods after all the resources are deleted, sometimes.