### PR TITLE
Add explicit deletion of resources

### DIFF
--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -1638,12 +1638,16 @@ func (s *Deployment) createStorageClass() error {
 // the existing object is updated.
 func (s *Deployment) createOrUpdateObject(obj runtime.Object) error {
 	if err := s.client.Create(context.Background(), obj); err != nil {
-		if apierrors.IsAlreadyExists(err) && s.update {
-			return s.client.Update(context.Background(), obj)
-		} else if !apierrors.IsAlreadyExists(err) {
-			kind := obj.GetObjectKind().GroupVersionKind().Kind
-			return fmt.Errorf("failed to create %s: %v", kind, err)
+		if apierrors.IsAlreadyExists(err) {
+			if s.update {
+				return s.client.Update(context.Background(), obj)
+			}
+			// Exists, no update.
+			return nil
 		}
+
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
+		return fmt.Errorf("failed to create %s: %v", kind, err)
 	}
 	return nil
 }


### PR DESCRIPTION
This change removes owner references from all the resources, making the
resources independent of each other.
Garbage collector will no longer mark the resources for deletion.
When StorageOS cluster object is deleted, the operator handles the
resource deletion.
Namespace is not deleted. All resources in the namespace not managed by
the operator stay in the namespace. This is needed to avoid deleting any
crucial resources unintentionally.