### PR TITLE
Add OLM e2e test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/_output
 build/_test
 build/operator-sdk
 deploy/test
+test/olm
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,38 +29,52 @@ install: true
 
 jobs:
   include:
+    - go: "1.11"
+      sudo: required
+      env:
+        - "TEST_SUITE=csi"
+        - "TEST_CLUSTER=kind"
+        - "INSTALL_METHOD=olm"
+      name: OLM - CSI setup on Kind (k8s-1.13)
+      script: ./test/e2e.sh $TEST_CLUSTER $TEST_SUITE $INSTALL_METHOD
     - &base-test
       go: "1.11"
       sudo: required
       env:
         - "TEST_SUITE=csi"
         - "TEST_CLUSTER=minikube"
+        - "INSTALL_METHOD=none"
       name: CSI setup on Minikube (k8s-1.10)
-      script: ./test/e2e.sh $TEST_CLUSTER $TEST_SUITE
+      script: ./test/e2e.sh $TEST_CLUSTER $TEST_SUITE $INSTALL_METHOD
     - <<: *base-test
       env:
         - "TEST_SUITE=csi"
         - "TEST_CLUSTER=openshift"
+        - "INSTALL_METHOD=none"
       name: CSI setup on OpenShift-3.11 (k8s-1.11)
     - <<: *base-test
       env:
         - "TEST_SUITE=csi"
         - "TEST_CLUSTER=kind"
+        - "INSTALL_METHOD=none"
       name: CSI setup on Kind (k8s-1.13)
     - <<: *base-test
       env:
         - "TEST_SUITE=intree"
         - "TEST_CLUSTER=minikube"
+        - "INSTALL_METHOD=none"
       name: In-tree plugin setup on Minikube (k8s-1.10)
     - <<: *base-test
       env:
         - "TEST_SUITE=intree"
         - "TEST_CLUSTER=openshift"
+        - "INSTALL_METHOD=none"
       name: In-tree plugin setup on OpenShift-3.11 (k8s-1.11)
     - <<: *base-test
       env:
         - "TEST_SUITE=intree"
         - "TEST_CLUSTER=kind"
+        - "INSTALL_METHOD=none"
       name: In-tree plugin setup on Kind (k8s-1.13)
     - stage: deploy
       go: "1.11"
@@ -68,6 +82,7 @@ jobs:
       env:
         - "TEST_SUITE=csi"
         - "TEST_CLUSTER=kind"
+        - "INSTALL_METHOD=none"
       name: Publish Container Image
       script:
         - make image/cluster-operator

--- a/deploy/0000_50_olm_06-olm-operator.deployment.yaml
+++ b/deploy/0000_50_olm_06-olm-operator.deployment.yaml
@@ -1,0 +1,51 @@
+# Source: olm/templates/0000_50_olm_06-olm-operator.deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: olm-operator
+  namespace: olm
+  labels:
+    app: olm-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: olm-operator
+  template:
+    metadata:
+      labels:
+        app: olm-operator
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      containers:
+        - name: olm-operator
+          command:
+          - /bin/olm
+          # Remove the args. olm 0.8.1 container doesn't support the flag.
+          #args:
+          #- -writeStatusName
+          #- ""
+          image: quay.io/coreos/olm@sha256:995a181839f301585a0e115c083619b6d73812c58a8444d7b13b8e407010325f
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          env:
+          - name: OPERATOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPERATOR_NAME
+            value: olm-operator
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        

--- a/deploy/olm-operators.configmap.yaml
+++ b/deploy/olm-operators.configmap.yaml
@@ -1,0 +1,474 @@
+##---
+# Source: olm/templates/0000_50_14-olm-operators.configmap.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: olm-operators
+  namespace: olm
+
+data:
+  customResourceDefinitions: |-
+
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: storageosclusters.storageos.com
+      spec:
+        group: storageos.com
+        names:
+          kind: StorageOSCluster
+          listKind: StorageOSClusterList
+          plural: storageosclusters
+          singular: storageoscluster
+          shortNames:
+          - stos
+        scope: Namespaced
+        version: v1alpha1
+        additionalPrinterColumns:
+        - name: Ready
+          type: string
+          description: Ready status of the storageos nodes.
+          JSONPath: .status.ready
+        - name: Status
+          type: string
+          description: Status of the whole cluster.
+          JSONPath: .status.phase
+        - name: Age
+          type: date
+          JSONPath: .metadata.creationTimestamp
+        validation:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                type: string
+              kind:
+                type: string
+              metadata: {}
+              spec:
+                properties:
+                  join:
+                    type: string
+                  namespace:
+                    type: string
+                  disableTelemetry:
+                    type: boolean
+                  images:
+                    properties:
+                      nodeContainer:
+                        type: string
+                      initContainer:
+                        type: string
+                      csiDriverRegistrarContainer:
+                        type: string
+                      csiExternalProvisionerContainer:
+                        type: string
+                      csiExternalAttacherContainer:
+                        type: string
+                  csi:
+                    properties:
+                      enable:
+                        type: boolean
+                      enableProvisionCreds:
+                        type: boolean
+                      enableControllerPublishCreds:
+                        type: boolean
+                      enableNodePublishCreds:
+                        type: boolean
+                  service:
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      externalPort:
+                        type: integer
+                        format: int32
+                      internalPort:
+                        type: integer
+                        format: int32
+                  secretRefName:
+                    type: string
+                  secretRefNamespace:
+                    type: string
+                  sharedDir:
+                    type: string
+                  ingress:
+                    properties:
+                      enable:
+                        type: boolean
+                      hostname:
+                        type: string
+                      tls:
+                        type: boolean
+                      annotations: {}
+                  kvBackend:
+                    properties:
+                      address:
+                        type: string
+                      backend:
+                        type: string
+                  pause:
+                    type: boolean
+                  debug:
+                    type: boolean
+                  nodeSelectorTerms: {}
+                  resources:
+                    properties:
+                      limits: {}
+                      requests: {}
+              status:
+                properties:
+                  phase:
+                    type: string
+                  nodeHealthStatus: {}
+                  nodes:
+                    type: array
+                    items:
+                      type: string
+                  ready:
+                    type: string
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: jobs.storageos.com
+      spec:
+        group: storageos.com
+        names:
+          kind: Job
+          listKind: JobList
+          plural: jobs
+          singular: job
+        scope: Namespaced
+        version: v1alpha1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: storageosupgrades.storageos.com
+      spec:
+        group: storageos.com
+        names:
+          kind: StorageOSUpgrade
+          listKind: StorageOSUpgradeList
+          plural: storageosupgrades
+          singular: storageosupgrade
+        scope: Namespaced
+        version: v1alpha1
+
+
+  clusterServiceVersions: |-
+
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: packageserver.v0.8.1
+        namespace: olm
+      spec:
+        displayName: Package Server
+        description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
+        minKubeVersion: 1.11.0
+        keywords: ['packagemanifests', 'olm', 'packages']
+        maintainers:
+        - name: Red Hat
+          email: openshift-operators@redhat.com
+        provider:
+          name: Red Hat
+        links:
+        - name: Package Server
+          url: https://github.com/operator-framework/operator-lifecycle-manager/tree/master/pkg/package-server
+        installModes:
+        - type: OwnNamespace
+          supported: true
+        - type: SingleNamespace
+          supported: true
+        - type: MultiNamespace
+          supported: true
+        - type: AllNamespaces
+          supported: true
+        install:
+          strategy: deployment
+          spec:
+            clusterPermissions:
+            - serviceAccountName: packageserver
+              rules:
+              - apiGroups:
+                - ""
+                resources:
+                - configmaps
+                verbs:
+                - get
+                - list
+                - watch
+              - apiGroups:
+                - "operators.coreos.com"
+                resources:
+                - catalogsources
+                verbs:
+                - get
+                - list
+                - watch
+              - apiGroups:
+                - "packages.apps.redhat.com"
+                resources:
+                - packagemanifests
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+                - patch
+                - update
+            deployments:
+            - name: packageserver
+              spec:
+                replicas: 1
+                strategy:
+                  type: RollingUpdate
+                selector:
+                  matchLabels:
+                    app: packageserver
+                template:
+                  metadata:
+                    labels:
+                      app: packageserver
+                  spec:
+                    serviceAccountName: packageserver
+                    nodeSelector:
+                      beta.kubernetes.io/os: linux
+                      
+                    containers:
+                    - name: packageserver
+                      command:
+                      - /bin/package-server
+                      - -v=4
+                      - --secure-port
+                      - "5443"
+                      - --global-namespace
+                      - olm
+                      image: quay.io/coreos/olm@sha256:995a181839f301585a0e115c083619b6d73812c58a8444d7b13b8e407010325f
+                      imagePullPolicy: Always
+                      ports:
+                      - containerPort: 5443
+                      livenessProbe:
+                          httpGet:
+                            scheme: HTTPS
+                            path: /healthz
+                            port: 5443
+                      readinessProbe:
+                          httpGet:
+                            scheme: HTTPS
+                            path: /healthz
+                            port: 5443
+        maturity: alpha
+        version: 0.8.1
+        apiservicedefinitions:
+          owned:
+          - group: packages.apps.redhat.com
+            version: v1alpha1
+            kind: PackageManifest
+            displayName: PackageManifest
+            description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
+            deploymentName: packageserver
+            containerPort: 5443
+
+    - #! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: storageosoperator.v0.0.9
+        namespace: olm
+        annotations:		
+          alm-examples: '[{"apiVersion":"storageos.com/v1","kind":"StorageOSCluster","metadata":{"name":"example","namespace":"default"},"spec":{"secretRefName":"storageos-api","secretRefNamespace": "default"}}]'
+      spec:
+        # replaces: 
+        displayName: Storageos Cluster Operator
+        description: |
+          StorageOS Cluster Operator description.
+
+        keywords: ['storageos', 'storage', 'persistent storage', 'open source']
+
+        version: 0.0.9
+        minKubeVersion: "1.10.0"
+        maturity: alpha
+        maintainers:
+        - name: StorageOS, Ltd
+          email: support@storageos.com
+
+        provider:
+          name: StorageOS, Ltd
+
+        labels:
+          alm-status-descriptors: storageosoperator.v0.0.9
+          alm-owner-storageos: storageosoperator
+          operated-by: storageosoperator
+
+        selector:
+          matchLabels:
+            alm-owner-etcd: storageosoperator
+            operated-by: storageosoperator
+
+        links:
+        - name: Documentation
+          url: https://docs.storageos.com/
+        - name: StorageOS Cluster Operator Source Code
+          url: https://github.com/storageos/cluster-operator
+
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAakAAAGpCAYAAAA3LMlbAAAX9klEQVR4nOzdT24bR9438JoX2Uc3GPkEUU5gCSC40Ca2LhAbILS1fQJbJ7CzFQhIvoCsbLQgCERzAjMniOYGygneB+2niIfjkdhNsv/8uvX5AMZMYItdItn97ar+VdX/SwAQlJACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQ1g9dNwD4X5P5+EVK6XlK6SD/2Vv560VK6S6l9HtK6XY6mt112FRozT+6bgA8ZZP5uAiitymlN9+FUpnrlNJv09HstsHmQeeEFHRkMh+/Sil93DCcvvcppXQ2Hc3ua2wahCGkoAOT+fgipfSqppdbpJReT0ezRU2vB2EIKWjZZD5+m3tQdSp6UkeCiqERUtCiyXx8mFL6o6GXL4LqmaE/hkQJOrQkF0lcNHiI4vW/NPj60DohBe15n1Lab/gYh7mUHQZBSEEL8jDf25YOV/fzLuiMkIJ2vG/xWPt6UwyFkIKG5cA4bPmwv7R8PGiEkILmdTH81nYoQiOEFDQoryrRdLHEQ/ZzNSH0mpCCZrX5LOp7Bx0eG2ohpKAhk/n4Q0e9KBgMIQUNyENtb7puB/SdkIJmvN1xdfM6WB6J3rN2H9RsMh/vp5S+dh1S09HM+U3v6UlB/XbdI6oOVkNnEIQU1ChP3I2w2oMdexkEIQU1aWGV80187roBUAchBTXIAfVHgGG+wq3NDxkKIQU7WgmoKJNnz7puANTlh64bAH2Ug+kwpfQ8pfQqSA+q8Gk6mnkexWAIKZ6EyXx8kAsafqoQKIuU0t8ppR8f6B3tBeoxfW+hF8XQmEfBYOXezqu88sPQlycqAupoOpqZwMug6EkxSLkU/OMTCKckoBgyhRMMzmQ+LsLpyxMJqEsBxZDpSTEok/n4Ig/xDd1tSulMkQRDJ6QYjB4E1P13yxWVFWGs/vvi//+Z//tWz4mnQuEEg5CfQX3puh1ZESDXKaXfi1CZjmZ3XTcI+kpI0Xu5iu+vIHOVLlNK7/R0oB6G+xiCCHs3FV5PR7PLrhsBQ6K6jyGIsAOugIIGCCl6LT+L6roX9UlAQTOEFH33S8fHv7cUETRHSNF3XU/YvVYkAc0RUvTdYcfH/1fHx4dBE1KwG3OgoEFCCoCwhBTsputnYjBoQoq+W3R8/OcdHx8GTUjRd12H1Iu8LBPQACFF33VdXVcE1PuO2wCDJaTou+s8obZLbyfzceQtQqC3hBS9lifSXnfdjpTShaCC+tmqg94LtlXHbd6qo+tnZTAIQopBmMzHb1NKH7tux4q7lYm+dTw3u88bKNounidFSDEYPdg+vg7L4c3PAounQEgxKJP5+EtK6UXX7WjJbd7HytJMDJbCCQZlOpq9zFu4PwWHKaWvCjYYMj0pBilvhngRpJiiDZ+mo9m7rhsBddOTYpCmo9l1SulZ3pCw63lUbXibi0dgUPSkeBJyz+pgZa29w2XFXMmPFn//98p//5R7Z3v59aI5UlDBkAgp2EEOvzcBNl9cuksp/Wy3YIbCcB/sYDqaXU9Hs6OiBxNkA8T9lJJhPwZDSEEN8hDbz7ksvGtvum4A1EVIQU3yENvLANuH7ClLZyiEFNRoJai6fiZkM0YGQUhBzfIKEF1PKI5SyAE7EVLQjM8dH3+/4+NDLYQUNMBWHVAPIQVAWEIKGpA3YgR2JKSgGQoXoAZCCprxS8fHjzCpGHYmpKBmk/n4IMAOwQo3GAQhBTXKz6Iuum5HgBJ4qIWQgprkgPojwBYet0rgGQohBTXIQ3wRAirljR5hEH7ougHQZzmc3gR4BrV0bdNDhkRI8WTkQNl7oDz8x9wDuk8p/VnyMj+u9JaWrxfFXUrpddeNgDrZmZdBy1tW/JJSetF1Wxp2n7eO9yyKQdGTYpByr+njE5lUK6AYLIUTDE7uPf3xRALqOqX0TEAxVHpSDEoOqAjzlJp2l1J6Nx3NrrtuCDRJSDEYTyCgFnm5o896TjwVCicYhJV5SlGq7e7zUNyfNSxRtMjb0sOToyfFUFwECqiz6Wj2oetGwBAIKXovD/NFWOmh8Ho6ml123QgYCtV9DMGbrhuQnQkoqJdnUvRafhb1tet25EVdj7puBAyNnhR9F2EliXvLEUEzhBR997zrBqSUfpuOZnddNwKGSEjRd10XTBTh9KnjNsBgCSn6ruuy8zNzmKA5Qgq2d6eaD5olpGB7dsCFhgkp+q6rgoVbvShonpCi77oKKb0oaIGQou9+7+CYRS/qtoPjwpMjpOi7LvZT0ouClggpei1Pom2zV3OpFwXtEVIMQVs9m/uU0ruWjgUIKYYg92zaGPYzcRdaJqQYite5p9OU2+loZvkjaJmQYhByD+eooaC6Sym9bOB1gRJCisGYjmaLBoKqeK2XhvmgG0KKQclB9aymir9voZdfE+iAnXkZrMl8/Cql9D6ltL/hj97nPaI+NNQ0oCIhxeBN5uMXKaVfUkqHawLrPve+frcmH8QhpHhSJvPx3gMbJd7ZWRcAgI0onAAgLCEFQFhCCoCwhBQAYQkpAMISUgCEJaQACEtIARCWkAIgLCEFQFhCCoCwhBQAYQkpAMISUgCE9UPXDSgcn5wepJT2WjjU/c3V+YNbgR+fnO5vsYNrnRY3V+f3u7zA8cnp4TY/d3N1XsdW68s2tPk+Pvp5tu345PRVSunX/J93KaXfIrTt+OT0of2z6lDp+9rxebXzObVqMh9vdX5NR7Pazq91JvNxm+/1Yjqa1fbertNZSOUL6puU0osWD1t8WY4e+bvlVuNdOcrtqyyH+695x9mtL0THJ6fF/yzy8T/veHFt9X3Mbb/O7b5u67jfteEi/96rXhyfnL6s8wZgg/Yc5p2IXzR40ar6fe3yvNr4nFqVL/ov8jm29fk1mY/T6vk1Hc1qu3nJbXzT8Gf9kJ3e2020HlL5zuoiX1jZQr4Iva/5PTzIf94en5wWX76zLi6wW3qRQ6E4+V+32YM5Pjl98UBApTwy8OX45PRZnXfzFdryseMRgd6bzMcH+X1s5PyazMfF9/NsOprtdFM1mY8/dHxj3YpWQyrf+f/R0tDe4OShm4sWep/FyXl4fHJ6nS/6rVxka1B8v74en5wWbb5s+mArn8dj9vJF5F3D7XDjV5PJfFyE09uGD1N8T79M5uPiJvDlpsNmk/n42w3QU/m8WyucyCeSgNrSSsC3OTxaHOuPfOw+ucjPiJr2vsL3+W2T719+7a9P5YLVlOLCP5mPv7YQUKuKz+yv3HPbRN29vNDarO67EFDbWQmoLsLioKdB9THfGDUivx9VL2gfG2yDG78d5Z5JV+fXt2NXDarJfPzY8PJgtRJS+WR6Mslfpzyk9KXjC9Hy+UqfLoZlQ3G72iR4Duvu2QmoWnUVUEvLoKpyUzX4Z1Dfa6sn9WtLxxmiiyAPwvcbvug34bCJHmAOnE1vuj7WHPJGJmqQn0FFGCVY3ow+KodYhLa2qq3CiSpv7G1K6V8Nt+Ou5PibeF5yobpMKf17g9f7r7blKr5NnkEty1z/rvjvf9ywfP1F0aYdq/6K9+XzDj+fcpv/md+bsgv1r/l9qUUOmm2G72orojg+Of2w4cWqiXNr3bn0/bG7sraNeYhtk2dQTZ9fB5P5+NV0NHus6KfKjdFdDedXFVU//521FVJlb+7ZzdX5h5ba8qB84a18QuULxbrf63MNJdxVey7XxcXv5up8qy/OhtVh73e88Py7hvfl288fn5y+qzBUU/cwc5Viice8PT453WkeWg7JNxX/+WU+t1q7oHxv0/OqZVWHzm5zyfhWv0fuAb2v+Czpff7cHlI2olJ8zj+3Ncm2LVGWRfrUdQOiyb2oKsN8r2+uzl/uciEqfvbm6vyoeK0K//xw25Ut6pZL4x+bnL1U2/BIhWKJRYXv8q5FFFV6j9/el5ur89ddBlRkKxN1yxThdLTLqhHT0exuOpoV59bL/Nmss1/0prY81OehBVSKElI9mofTpirP8WqdD5Rfq0pQhXnGmL87aydF1vhcqixgip7dWcmFaNciiirvfScrXfRM1YCqbYQnT96tcn79Utcxh6CtkFo7vJFnyvOfynor101MWM2vWTYTPkRPasWfJX+/c4FBhWKJyyIYcmiWPXfaqogi/0yVoXMBVa4sCG7rDKilHFRlve3HrodlN/PPt2xWaCFCajn5smclzo2puChnk6sYlL32fpNzkKKpUCxxn3tQ3+SgXxcUe1uWEpf1CO8NnVdWFva/NXjss7J/8MhitmU3H4eT+fhii8nBobVVOPF7yUPD5ZyWi7xg6K4W+c/vXS06uqOyAFg0+ayheO28Dt66L/t+mxU+HSsrlvjtgc/jrORCuE0RRZXe9YN328cnp/9/g+Ns4mhdzy0XGLU+t+fm6vwfj/1dhYv43a7r6q0zHc3uJ/PxZck18eD7UJqOZovJfHxXcn0oXvNVXtR2V/fL62jx3ZqOZp2c7630pHJQtPkLHuQP68vxyelfPRxOLDuJfm+hDWXHiNSTKhvm2Pq7V6FY4u6hytR84S4bjq17JYqmp3AMRdmITRvDpdsOUbdRXr7ahsP8Pf1rMh9/zKtztKrNwolGF9lcYz+HVZ8mopZ9EdoI/LJjhAipPOy4toexY6+zLEjWPQh/V6GIos614p5Kz7Zpm8xv3Na20xA+1Tnvb0NvN1nCqS6thVTuTXU5Xv4qDz0MQYSQ6tzKklHrbH1XXKFY4nrdUFceeit7/vDes1iqyiXmrysUUTSlCKiLNntUrW7VcXN1/u745PTvDtefKi4IlwOYO9LGF6SpY/yzhnlWe3mI71WFdm41NFqxWKJ0dODm6vzT8cnpuk3zlsepUpoMy2dTR/kGrYsRjeUQeCs3/a3Pk8rj9z93OAu9Dws0lnXn2+hulx1j2yGHV3mViF3+fMknSZVJrduW6W9TLPGYsjB7VdMEaT2yevyzhWPsFC55d9+fK8zLa8qbtnpTnWwfnyuajvLzhBcppZ9quiM4qHCivujBXWuE+RBlx+jDBOzftpkoXqFY4lvV04bBclsydPgxX3TWKQvF52vmuG17U1hlOsQuFh18l8pusNqYB1h2fpXeBOahvw+T+fhTbvPzmm5g9yq8zl6+lja+uWgnIbWU70RrfU6VLxzrtrbYK8Ix8pDfzdX5bUkp/mGTv0PFYoToE0Zvd1gPsqxYosqzsE0dHJ+cvr25Ol93PpRduF491mvLy15trIUS8ndtf5dyCfj9mmvE/mQ+PtxlKaR1cg+krOK48rmdw+q6wiT8ynIbP5aUyf9U1/HWCbEsUp3yF76spxSiMq1E2QWpyQtH2Wt3VV1U1SKvk7axLbfhqMvaIoo8ArGu17FXc7XgkJUFUJPnV9lQ9X0ezutMEXx5vcF1YdlKld/gQir9XyVh35XNh6jrOcZ/yK9ZtrZcm3M1NnWZJ5huM8y37TYcdaly/LLv9vse7qLchbKCmsMdFnp9VC7fLlvFPtL1q/MRp0GG1ECW7KnyRf1S5wUpv1aVYaxIJ9HSYmXl722fceyyDUddym4+ym4Q9vLKLUM4B5p0XeFZ2EXerr0WOaCq7KYc+SawdYMMqYr7toSWnzeVPZT8tu10HUM8+dnD1won0K4l/Hd5qGWTP1Xs7/IAvkKxRJse7U3l4eyy97/4Xb7WvWX9kOTnOFXW5/symY8/7FrJNpmP31YMqNumnoVtKodq54tJt1I4UXHB1Lr8WiGk+lCZlnJ5adnvspdX1X6T7w43mRe0yXyj1Tbt4vOmBQ05hKsUMxSBfbTlpoJVhvl2/d2Xfi05H8qKKF7nC946yx7V+3xnvu2Fr+ly7IOa1ut8yKKkV/0pD72Vffff55Lry7z01CbXj19ykUTV69/a79gjC882Yb/COdHKUGBb1X2vAs1Put9lZ9Q25YVezyq+d/u5J9Bkb6CTXV7zhNifKgb2xkFVsVjisq7do/PivWXDqsuJ5/91QczVn9cV90Ra7gob5fz7XpPPAI/WhXOu8jur2Ia9Fs6v6wq9qLKbkza1slbkUIf71on4POVR+cIYIVQXXW7xf3N1/rrinIxlUFV6VlexWKLS6hJV5cKesotRWbvKKq+oYDqafQpyTVj0YP7m91p5355iSPXxoeRRx0G1qLBNe+NyUFUZttokqKoUS5w1sHt0lQvSo0UUuT1VtiOn3OuOz69v6/H1bOv3y7ba+9RC6lMPJqH+l3xB6iqoFtuWdDfkZcX3oTSoKhZLLEom2G4lD5tWeca1rohiefMQ5bPppXyxXTs02KDie3DU9byoDVVZOLk2TymkFm2+sXVbCarGlyFZsfWco6ZsGNhlQVXlWUSTW8x8qlKpt656MwfVsw7XwhyEPHn1qOWdGorP7OeeBVThZZsbID6VkLqOdrHdRtH+POR11PDziLsa5hw1Jrep6nYFDwbVBsUSjV388+9RJQTLVqK4z8seeU61o+lo9q6FXtVdHt476tkQ310O1VZviIYeUrf5Yvsy4sV2W8WF8+bq/Fm+KNX58LJ4rSKYnkUfFt1wqOs/gmqDYonGe941FVEsX+ty5XvRt7vzMIqLcO5VHdV8ft3mcHo2Hc3aHBHZ1XJoupNeX1sl6G1f8Bb5WUKTd5Vlv1Pjd7TFRam4288X3V0m3t3WGEplr1Pbd6EIquOT06OKpdgpvz+LXJZdNpGz6e/PqtdVJqAXn3OVm63vvheHDa+xVvYedXmzs9Pnl3sM39qf5ydV2WXhIcVrLGrqNbX5yOI+Ty52wwMADxn6cB8APSakAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGEJKQDCElIAhCWkAAhLSAEQlpACICwhBUBYQgqAsIQUAGH9TwAAAP//uWVl5opI2wgAAAAASUVORK5CYII=
+          mediatype: image/png
+
+        installModes:
+        - type: OwnNamespace
+          supported: true
+        - type: SingleNamespace
+          supported: true
+        - type: MultiNamespace
+          supported: false
+        - type: AllNamespaces
+          supported: true
+
+        install:
+          strategy: deployment
+          spec:
+            clusterPermissions:
+            - serviceAccountName: storageos-operator
+              rules:
+              - apiGroups:
+                - storageos.com
+                resources:
+                - storageosclusters
+                - storageosupgrades
+                - jobs
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                - daemonsets
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - nodes
+                verbs:
+                - list
+                - watch
+                - get
+                - update
+              - apiGroups:
+                - ""
+                resources:
+                - events
+                - namespaces
+                - serviceaccounts
+                - secrets
+                - services
+                - persistentvolumeclaims
+                - persistentvolumes
+                verbs:
+                - create
+                - patch
+                - get
+                - list
+                - delete
+                - watch
+                - update
+              - apiGroups:
+                - rbac.authorization.k8s.io
+                resources:
+                - roles
+                - rolebindings
+                - clusterroles
+                - clusterrolebindings
+                verbs:
+                - create
+                - delete
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                - volumeattachments
+                verbs:
+                - create
+                - delete
+                - watch
+                - list
+                - get
+                - update
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - create
+                - delete
+              - apiGroups:
+                - csi.storage.k8s.io
+                resources:
+                - csidrivers
+                verbs:
+                - create
+                - delete
+            deployments:
+            - name: storageos-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: storageos-operator
+                template:
+                  metadata:
+                    name: storageos-operator
+                    labels:
+                      name: storageos-operator
+                  spec:
+                    serviceAccountName: storageos-operator
+                    containers:
+                    - name: storageos-operator
+                      command:
+                      - cluster-operator
+                      image: storageos/cluster-operator:test
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: OPERATOR_NAME
+                        value: "cluster-operator"
+                      ports:
+                      - containerPort: 8080
+                        name: metrics
+        customresourcedefinitions:
+          owned:
+          - name: storageosclusters.storageos.com
+            version: v1alpha1
+            kind: StorageOSCluster
+            displayName: StorageOS Cluster
+            description: Represents a cluster of StorageOS nodes.
+          - name: jobs.storageos.com
+            version: v1alpha1
+            kind: Job
+            displayName: StorageOS Job
+            description: Represents a StorageOS Job.
+          - name: storageosupgrades.storageos.com
+            version: v1alpha1
+            kind: StorageOSUpgrade
+            displayName: StorageOS Upgrade
+            description: Represents a StorageOS Upgrade.
+
+  packages: |-
+    
+    - packageName: packageserver
+      channels:
+      - name: alpha
+        currentCSV: packageserver.v0.8.1
+
+    - packageName: storageos
+      channels:
+      - name: alpha
+        currentCSV: storageosoperator.v0.0.9
+
+

--- a/deploy/stos.olm.cr.yaml
+++ b/deploy/stos.olm.cr.yaml
@@ -1,0 +1,26 @@
+apiVersion: storageos.com/v1alpha1
+kind: StorageOSCluster
+metadata:
+  name: example
+  namespace: olm
+spec:
+  secretRefName: "storageos-api"
+  secretRefNamespace: "default"
+  namespace: "storageos"
+  csi:
+    enable: true
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "storageos-api"
+  namespace: "default"
+  labels:
+    app: "storageos"
+type: "kubernetes.io/storageos"
+data:
+  # echo -n '<secret>' | base64
+  apiUsername: c3RvcmFnZW9z
+  apiPassword: c3RvcmFnZW9z

--- a/deploy/stos.subscription.yaml
+++ b/deploy/stos.subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: storageos
+  namespace: olm
+spec:
+  source: olm-operators
+  sourceNamespace: olm
+  name: storageos
+  channel: alpha

--- a/test/olm.sh
+++ b/test/olm.sh
@@ -1,0 +1,50 @@
+install_olm() {
+    echo "Install OLM"
+
+    git clone --depth 1 https://github.com/operator-framework/operator-lifecycle-manager ./test/olm
+
+    # Create the following one at a time to avoid resource not found error.
+    kubectl create -f ./test/olm/deploy/upstream/manifests/0.8.1/0000_50_olm_00-namespace.yaml
+    kubectl create -f ./test/olm/deploy/upstream/manifests/0.8.1/0000_50_olm_01-olm-operator.serviceaccount.yaml
+    for num in {02..05}; do kubectl create -f ./test/olm/deploy/upstream/manifests/0.8.1/0000_50_olm_$num*; done
+
+    # TODO: Remove this once the default olm operator container is fixed, and
+    # use the default manifest.
+    # Error: flag provided but not defined: -writeStatusName
+    kubectl create -f ./deploy/0000_50_olm_06-olm-operator.deployment.yaml
+    for num in {07..09}; do kubectl create -f ./test/olm/deploy/upstream/manifests/0.8.1/0000_50_olm_$num*; done
+
+    kubectl create -f deploy/olm-operators.configmap.yaml
+    sleep 1
+    for num in {11,12}; do kubectl create -f ./test/olm/deploy/upstream/manifests/0.8.1/0000_50_olm_$num*; done
+    sleep 5
+    kubectl create -f ./test/olm/deploy/upstream/manifests/0.8.1/0000_50_olm_13-packageserver.subscription.yaml
+
+    # Install storageos operator by creating a subscription.
+    kubectl create -f deploy/stos.subscription.yaml
+
+    # Wait for storageos operator to be ready.
+    until kubectl -n olm get deployment storageos-operator --no-headers -o go-template='{{.status.readyReplicas}}' | grep -q 1; do sleep 1; done
+
+    # Create this cluster role binding to grant permissions to the olm web console.
+    kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=system:serviceaccount:kube-system:default
+
+    echo
+}
+
+install_olm_storageos() {
+    echo "Install StorageOS via OLM"
+
+    kubectl apply -f deploy/stos.olm.cr.yaml
+    sleep 5
+
+    kubectl -n storageos get all
+
+    echo "Waiting for storageos daemonset to be ready"
+    until kubectl -n storageos get daemonset storageos-daemonset --no-headers -o go-template='{{.status.numberReady}}' | grep -q 1; do sleep 5; done
+    echo "Daemonset ready!"
+
+    echo "Waiting for storageos statefulset to be ready"
+    until kubectl -n storageos get statefulset storageos-statefulset --no-headers -o go-template='{{.status.readyReplicas}}' | grep -q 1; do sleep 5; done
+    echo "Statefulset ready!"
+}


### PR DESCRIPTION
This change adds OLM installation on a kubernetes cluster and installs
storageos operator via OLM storageos subscription. A new cluster object
is created and tested if the storageos cluster is deployed successfully.