### PR TITLE
cluster-ctrl: reset cluster deployment with current cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,55 +32,32 @@ jobs:
     - go: "1.11"
       sudo: required
       env:
-        - "TEST_SUITE=csi"
         - "TEST_CLUSTER=kind"
         - "INSTALL_METHOD=olm"
-      name: OLM - CSI setup on Kind (k8s-1.13)
-      script: ./test/e2e.sh $TEST_CLUSTER $TEST_SUITE $INSTALL_METHOD
+      name: OLM on KinD (k8s-1.13)
+      script: ./test/e2e.sh $TEST_CLUSTER $INSTALL_METHOD
     - &base-test
       go: "1.11"
       sudo: required
       env:
-        - "TEST_SUITE=csi"
         - "TEST_CLUSTER=minikube"
         - "INSTALL_METHOD=none"
-      name: CSI setup on Minikube (k8s-1.10)
-      script: ./test/e2e.sh $TEST_CLUSTER $TEST_SUITE $INSTALL_METHOD
+      name: Minikube (k8s-1.10)
+      script: ./test/e2e.sh $TEST_CLUSTER $INSTALL_METHOD
     - <<: *base-test
       env:
-        - "TEST_SUITE=csi"
         - "TEST_CLUSTER=openshift"
         - "INSTALL_METHOD=none"
-      name: CSI setup on OpenShift-3.11 (k8s-1.11)
+      name: OpenShift-3.11 (k8s-1.11)
     - <<: *base-test
       env:
-        - "TEST_SUITE=csi"
         - "TEST_CLUSTER=kind"
         - "INSTALL_METHOD=none"
-      name: CSI setup on Kind (k8s-1.13)
-    - <<: *base-test
-      env:
-        - "TEST_SUITE=intree"
-        - "TEST_CLUSTER=minikube"
-        - "INSTALL_METHOD=none"
-      name: In-tree plugin setup on Minikube (k8s-1.10)
-    - <<: *base-test
-      env:
-        - "TEST_SUITE=intree"
-        - "TEST_CLUSTER=openshift"
-        - "INSTALL_METHOD=none"
-      name: In-tree plugin setup on OpenShift-3.11 (k8s-1.11)
-    - <<: *base-test
-      env:
-        - "TEST_SUITE=intree"
-        - "TEST_CLUSTER=kind"
-        - "INSTALL_METHOD=none"
-      name: In-tree plugin setup on Kind (k8s-1.13)
+      name: KinD (k8s-1.13)
     - stage: deploy
       go: "1.11"
       sudo: required
       env:
-        - "TEST_SUITE=csi"
         - "TEST_CLUSTER=kind"
         - "INSTALL_METHOD=none"
       name: Publish Container Image

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -107,6 +107,9 @@ func (r *ReconcileStorageOSCluster) IsCurrentCluster(cluster *storageosv1alpha1.
 // ResetCurrentCluster resets the current cluster of the controller.
 func (r *ReconcileStorageOSCluster) ResetCurrentCluster() {
 	r.currentCluster = nil
+	// Reset deployment as well. Deployments are specific to the current
+	// cluster.
+	r.deployment = nil
 }
 
 // Reconcile reads that state of the cluster for a StorageOSCluster object and makes changes based on the state read

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -210,7 +210,7 @@ main() {
         docker exec $x bash -c "docker load < /cluster-operator.tar"
     fi
 
-    if [ "$3" = "olm" ]; then
+    if [ "$2" = "olm" ]; then
         source ./deploy/olm/olm.sh
         # Not using quick install here because the order in which the resources
         # are created is unreliable and results in flaky test setup. Hard to
@@ -238,7 +238,7 @@ main() {
         # Tags are passed to test local command to run e2e test packages only with
         # specific config.
         # Tag "intree" would run k8s intree plugin test setup.
-        # Tag "csi" woul run csi test setup.
+        # Tag "csi" would run csi test setup.
         # The cluster-operator container image used in the e2e setup is based on the
         # operator container image in the manifest file deploy/operator.yaml. The
         # deploy manifests are combined and applied to deploy the operator before
@@ -247,7 +247,15 @@ main() {
         # NOTE: Append this test command with `|| true` to debug by inspecting the
         # resource details. Also comment `defer ctx.Cleanup()` in the cluster to
         # avoid resouce cleanup.
-        operator-sdk test local ./test/e2e --go-test-flags "-v -tags $2" --namespace storageos-operator
+        operator-sdk test local ./test/e2e --go-test-flags "-v -tags intree" --namespace storageos-operator
+
+        echo "Deleting namespace storageos..."
+        kubectl delete ns storageos --ignore-not-found=true
+
+        operator-sdk test local ./test/e2e --go-test-flags "-v -tags csi" --namespace storageos-operator
+
+        echo "Deleting namespace storageos..."
+        kubectl delete ns storageos --ignore-not-found=true
 
         # echo "**** Resource details for storageos-operator namespace ****"
         # print_pod_details_and_logs storageos-operator

--- a/test/e2e/clusterCSI_test.go
+++ b/test/e2e/clusterCSI_test.go
@@ -19,6 +19,7 @@ import (
 func TestClusterCSI(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
+	resourceNS := "storageos"
 
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
@@ -28,7 +29,7 @@ func TestClusterCSI(t *testing.T) {
 	clusterSpec := storageos.StorageOSClusterSpec{
 		SecretRefName:      "storageos-api",
 		SecretRefNamespace: "default",
-		ResourceNS:         "storageos",
+		ResourceNS:         resourceNS,
 		CSI: storageos.StorageOSClusterCSI{
 			Enable: true,
 		},
@@ -59,7 +60,7 @@ func TestClusterCSI(t *testing.T) {
 
 	testutil.ClusterStatusCheck(t, testStorageOS.Status, 1)
 
-	daemonset, err := f.KubeClient.AppsV1().DaemonSets("storageos").Get("storageos-daemonset", metav1.GetOptions{IncludeUninitialized: true})
+	daemonset, err := f.KubeClient.AppsV1().DaemonSets(resourceNS).Get("storageos-daemonset", metav1.GetOptions{IncludeUninitialized: true})
 	if err != nil {
 		t.Fatalf("failed to get storageos-daemonset: %v", err)
 	}

--- a/test/e2e/clusterInTreePlugin_test.go
+++ b/test/e2e/clusterInTreePlugin_test.go
@@ -17,6 +17,7 @@ import (
 func TestClusterInTreePlugin(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
+	resourceNS := "storageos"
 
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
@@ -26,7 +27,7 @@ func TestClusterInTreePlugin(t *testing.T) {
 	clusterSpec := storageos.StorageOSClusterSpec{
 		SecretRefName:      "storageos-api",
 		SecretRefNamespace: "default",
-		ResourceNS:         "storageos",
+		ResourceNS:         resourceNS,
 		Tolerations: []corev1.Toleration{
 			{
 				Key:      "key",
@@ -54,7 +55,7 @@ func TestClusterInTreePlugin(t *testing.T) {
 
 	testutil.ClusterStatusCheck(t, testStorageOS.Status, 1)
 
-	daemonset, err := f.KubeClient.AppsV1().DaemonSets("storageos").Get("storageos-daemonset", metav1.GetOptions{IncludeUninitialized: true})
+	daemonset, err := f.KubeClient.AppsV1().DaemonSets(resourceNS).Get("storageos-daemonset", metav1.GetOptions{IncludeUninitialized: true})
 	if err != nil {
 		t.Fatalf("failed to get storageos-daemonset: %v", err)
 	}

--- a/test/e2e/util/cluster.go
+++ b/test/e2e/util/cluster.go
@@ -21,9 +21,9 @@ import (
 // Time constants.
 const (
 	RetryInterval        = time.Second * 5
-	Timeout              = time.Second * 60
+	Timeout              = time.Second * 90
 	CleanupRetryInterval = time.Second * 1
-	CleanupTimeout       = time.Second * 5
+	CleanupTimeout       = time.Second * 15
 )
 
 // NewStorageOSCluster returns a StorageOSCluster object, created using a given
@@ -125,13 +125,13 @@ func DeployCluster(t *testing.T, ctx *framework.TestCtx, cluster *storageos.Stor
 		return err
 	}
 
-	err = WaitForDaemonSet(t, f.KubeClient, "storageos", "storageos-daemonset", RetryInterval, Timeout*2)
+	err = WaitForDaemonSet(t, f.KubeClient, cluster.Spec.GetResourceNS(), "storageos-daemonset", RetryInterval, Timeout*2)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if cluster.Spec.CSI.Enable {
-		err = WaitForStatefulSet(t, f.KubeClient, "storageos", "storageos-statefulset", RetryInterval, Timeout*2)
+		err = WaitForStatefulSet(t, f.KubeClient, cluster.Spec.GetResourceNS(), "storageos-statefulset", RetryInterval, Timeout*2)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This resets deployment along with the current cluster. Without this, the
deployment configuration was cached and reused if clusters with
different configuration are created consecutively.

This is needed to detect any future configuration caching bug.
It also reduces the number of parallel builds.