### PR TITLE
Apply node affinity to StatefulSet

### DIFF
--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -1388,6 +1388,8 @@ func (s *Deployment) createStatefulSet() error {
 
 	podSpec := &sset.Spec.Template.Spec
 
+	s.addNodeAffinity(podSpec)
+
 	if err := s.addTolerations(podSpec); err != nil {
 		return err
 	}

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -810,6 +810,9 @@ func TestDeployNodeAffinity(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: api.StorageOSClusterSpec{
+			CSI: api.StorageOSClusterCSI{
+				Enable: true,
+			},
 			NodeSelectorTerms: []corev1.NodeSelectorTerm{
 				{
 					MatchExpressions: []corev1.NodeSelectorRequirement{
@@ -857,7 +860,24 @@ func TestDeployNodeAffinity(t *testing.T) {
 	podSpec := createdDaemonset.Spec.Template.Spec
 
 	if !reflect.DeepEqual(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, stosCluster.Spec.NodeSelectorTerms) {
-		t.Errorf("unexpected NodeSelectorTerms value:\n\t(GOT) %v\n\t(WNT) %v", stosCluster.Spec.NodeSelectorTerms, podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+		t.Errorf("unexpected DaemonSet NodeSelectorTerms value:\n\t(GOT) %v\n\t(WNT) %v", stosCluster.Spec.NodeSelectorTerms, podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+	}
+
+	createdStatefulset := &appsv1.StatefulSet{}
+
+	nsNameStatefulSet := types.NamespacedName{
+		Name:      statefulsetName,
+		Namespace: defaultNS,
+	}
+
+	if err := c.Get(context.Background(), nsNameStatefulSet, createdStatefulset); err != nil {
+		t.Fatal("failed to get the created statefulset", err)
+	}
+
+	podSpec = createdStatefulset.Spec.Template.Spec
+
+	if !reflect.DeepEqual(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, stosCluster.Spec.NodeSelectorTerms) {
+		t.Errorf("unexpected StatefulSet NodeSelectorTerms value:\n\t(GOT) %v\n\t(WNT) %v", stosCluster.Spec.NodeSelectorTerms, podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
 	}
 }
 


### PR DESCRIPTION
The CSI helpers in statefulset and CSI grpc server must run on the
same node for the CSI helpers to communicate with the CSI server.
This change ensures that the statefulset is deployed on the node where
the daemonset pods are also placed.