### PR TITLE
Add explicit RBAC rules for operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Refer to the [StorageOS prerequisites docs](https://docs.storageos.com/docs/prer
 2. Run `operator-sdk generate k8s` if there's a change in api type.
 3. Build operator container with `operator-sdk build storageos/cluster-operator:<tag>`
 4. Apply the manifests in `deploy/` to install the operator
-    - Apply `service_account.yaml` and `role_binding.yaml` to create a service account and to grant all the permissions.
-    - Apply `crds/*_storageoscluster_crd.yaml` to define the custom resources.
+    - Apply `service_account.yaml`, `role.yaml` and `role_binding.yaml` to create a service account and to grant all the permissions.
+    - Apply `crds/*_crd.yaml` to define the custom resources.
     - Apply `operator.yaml` to install the operator. Change the container image in this file when installing a new operator.
     - Apply `crds/*_storageoscluster_cr.yaml` to create a `StorageOSCluster` custom resource.
 

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,21 +1,83 @@
-# Temporary role for the sdk test command to run properly. Must be removed once
-# it's fixed in the sdk.
-
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
-  creationTimestamp: null
-  name: memcached-operator
+  name: storageos-operator
 rules:
+- apiGroups:
+  - storageos.com
+  resources:
+  - storageosclusters
+  - storageosupgrades
+  - jobs
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  verbs:
+  - "*"
 - apiGroups:
   - ""
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
+  - nodes
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - serviceaccounts
+  - secrets
+  - services
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - create
+  - patch
+  - get
+  - list
+  - delete
+  - watch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - create
+  - delete
+  - watch
+  - list
+  - get
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - csi.storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - delete

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -8,5 +8,5 @@ subjects:
   namespace: storageos-operator
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: storageos-operator
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This adds RBAC rules for the operator deployment. The operator will no
longer be given cluster admin role after this.