### PR TITLE
Add csinodeinfos rbac to attacher

### DIFF
--- a/deploy/olm/storageos/storageos.v0.0.11.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.v0.0.11.clusterserviceversion.yaml
@@ -192,6 +192,7 @@ spec:
           resources:
           - storageclasses
           - volumeattachments
+          - csinodeinfos
           verbs:
           - create
           - delete

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -60,6 +60,7 @@ rules:
   resources:
   - storageclasses
   - volumeattachments
+  - csinodeinfos
   verbs:
   - create
   - delete

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -351,6 +351,7 @@ data:
                 resources:
                 - storageclasses
                 - volumeattachments
+                - csinodeinfos
                 verbs:
                 - create
                 - delete

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -505,6 +505,11 @@ func (s *Deployment) createClusterRoleForAttacher() error {
 			Verbs:     []string{"get", "list", "watch", "update"},
 		},
 		{
+			APIGroups: []string{"storage.k8s.io"},
+			Resources: []string{"csinodeinfos"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
 			APIGroups: []string{""},
 			Resources: []string{"events"},
 			Verbs:     []string{"list", "watch", "create", "update", "patch"},


### PR DESCRIPTION
The csi-attacher pod complains that the service-account it uses doesn't have access to csinodeinfos.

Before merging need to check whether it validates on k8s versions before CSINodeInfo was introduced (Alpha in 1.13)