### PR TITLE
travis: publish develop image from master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,11 @@ jobs:
         - docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:latest"
         - docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:${TRAVIS_TAG}"
       deploy:
-        provider: script
-        script: docker push "${IMAGE_NAME}:latest" && docker push "${IMAGE_NAME}:${TRAVIS_TAG}"
-        on:
-          tags: true
+        - provider: script
+          script: docker push "${IMAGE_NAME}:latest" && docker push "${IMAGE_NAME}:${TRAVIS_TAG}"
+          on:
+            tags: true
+        - provider: script
+          script: docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:develop" && docker push "${IMAGE_NAME}:develop"
+          on:
+            branch: master


### PR DESCRIPTION
Publish `storageos/cluster-operator:develop` container image from master
branch.