### PR TITLE
Export rbac resource names

### DIFF
--- a/pkg/storageos/daemonset.go
+++ b/pkg/storageos/daemonset.go
@@ -36,7 +36,7 @@ func (s *Deployment) createDaemonSet() error {
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "storageos-daemonset-sa",
+					ServiceAccountName: DaemonsetSA,
 					HostPID:            true,
 					HostNetwork:        true,
 					DNSPolicy:          corev1.DNSClusterFirstWithHostNet,

--- a/pkg/storageos/delete.go
+++ b/pkg/storageos/delete.go
@@ -24,15 +24,15 @@ func (s *Deployment) Delete() error {
 		return err
 	}
 
-	if err := s.deleteRoleBinding(keyManagementBindingName); err != nil {
+	if err := s.deleteRoleBinding(KeyManagementBindingName); err != nil {
 		return err
 	}
 
-	if err := s.deleteRole(keyManagementRoleName); err != nil {
+	if err := s.deleteRole(KeyManagementRoleName); err != nil {
 		return err
 	}
 
-	if err := s.deleteServiceAccount("storageos-daemonset-sa"); err != nil {
+	if err := s.deleteServiceAccount(DaemonsetSA); err != nil {
 		return err
 	}
 
@@ -41,35 +41,35 @@ func (s *Deployment) Delete() error {
 			return err
 		}
 
-		if err := s.deleteClusterRoleBinding("csi-attacher-binding"); err != nil {
+		if err := s.deleteClusterRoleBinding(CSIAttacherClusterBindingName); err != nil {
 			return err
 		}
 
-		if err := s.deleteClusterRoleBinding("csi-provisioner-binding"); err != nil {
+		if err := s.deleteClusterRoleBinding(CSIProvisionerClusterBindingName); err != nil {
 			return err
 		}
 
-		if err := s.deleteClusterRole("csi-attacher-role"); err != nil {
+		if err := s.deleteClusterRole(CSIAttacherClusterRoleName); err != nil {
 			return err
 		}
 
-		if err := s.deleteClusterRole("csi-provisioner-role"); err != nil {
+		if err := s.deleteClusterRole(CSIProvisionerClusterRoleName); err != nil {
 			return err
 		}
 
-		if err := s.deleteServiceAccount("storageos-statefulset-sa"); err != nil {
+		if err := s.deleteServiceAccount(StatefulsetSA); err != nil {
 			return err
 		}
 
-		if err := s.deleteClusterRoleBinding("k8s-driver-registrar-binding"); err != nil {
+		if err := s.deleteClusterRoleBinding(CSIK8SDriverRegistrarClusterBindingName); err != nil {
 			return err
 		}
 
-		if err := s.deleteClusterRoleBinding("driver-registrar-binding"); err != nil {
+		if err := s.deleteClusterRoleBinding(CSIDriverRegistrarClusterBindingName); err != nil {
 			return err
 		}
 
-		if err := s.deleteClusterRole("driver-registrar-role"); err != nil {
+		if err := s.deleteClusterRole(CSIDriverRegistrarClusterRoleName); err != nil {
 			return err
 		}
 
@@ -80,11 +80,11 @@ func (s *Deployment) Delete() error {
 
 	// Delete role for Pod Fencing.
 	if !s.stos.Spec.DisableFencing {
-		if err := s.deleteClusterRoleBinding(fencingClusterBindingName); err != nil {
+		if err := s.deleteClusterRoleBinding(FencingClusterBindingName); err != nil {
 			return err
 		}
 
-		if err := s.deleteClusterRole(fencingClusterRoleName); err != nil {
+		if err := s.deleteClusterRole(FencingClusterRoleName); err != nil {
 			return err
 		}
 	}

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -27,12 +27,6 @@ const (
 	daemonsetName   = "storageos-daemonset"
 	statefulsetName = "storageos-statefulset"
 
-	keyManagementRoleName    = "key-management-role"
-	keyManagementBindingName = "key-management-binding"
-
-	fencingClusterRoleName    = "storageos:pod-fencer"
-	fencingClusterBindingName = "storageos:pod-fencer"
-
 	tlsSecretType       = "kubernetes.io/tls"
 	storageosSecretType = "kubernetes.io/storageos"
 

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -124,7 +124,7 @@ func TestCreateRoleForKeyMgmt(t *testing.T) {
 	}
 
 	nsName := types.NamespacedName{
-		Name:      "key-management-role",
+		Name:      KeyManagementRoleName,
 		Namespace: defaultNS,
 	}
 	wantRole := &rbacv1.Role{
@@ -133,7 +133,7 @@ func TestCreateRoleForKeyMgmt(t *testing.T) {
 			Kind:       "Role",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "key-management-role",
+			Name:      KeyManagementRoleName,
 			Namespace: defaultNS,
 			Labels: map[string]string{
 				"app": appName,
@@ -209,7 +209,7 @@ func TestCreateRoleBindingForKeyMgmt(t *testing.T) {
 	}
 
 	nsName := types.NamespacedName{
-		Name:      "key-management-binding",
+		Name:      KeyManagementBindingName,
 		Namespace: defaultNS,
 	}
 	createdRoleBinding := &rbacv1.RoleBinding{
@@ -218,7 +218,7 @@ func TestCreateRoleBindingForKeyMgmt(t *testing.T) {
 			Kind:       "RoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "key-management-binding",
+			Name:      KeyManagementBindingName,
 			Namespace: defaultNS,
 			Labels: map[string]string{
 				"app": appName,
@@ -239,13 +239,13 @@ func TestCreateClusterRoleBinding(t *testing.T) {
 	subjects := []rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
-			Name:      "storageos-daemonset-sa",
+			Name:      DaemonsetSA,
 			Namespace: defaultNS,
 		},
 	}
 	roleRef := rbacv1.RoleRef{
 		Kind:     "ClusterRole",
-		Name:     "driver-registrar-role",
+		Name:     CSIDriverRegistrarClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
 	if err := deploy.createClusterRoleBinding(bindingName, subjects, roleRef); err != nil {

--- a/pkg/storageos/statefulset.go
+++ b/pkg/storageos/statefulset.go
@@ -34,7 +34,7 @@ func (s *Deployment) createStatefulSet() error {
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "storageos-statefulset-sa",
+					ServiceAccountName: StatefulsetSA,
 					Containers: []corev1.Container{
 						{
 							Image:           s.stos.Spec.GetCSIExternalProvisionerImage(CSIV1Supported(s.k8sVersion)),


### PR DESCRIPTION
Exporting the resource names makes is easy to refer the resources in
different packages.
Also renames roles and role bindings to the new format.

NOTE: Will export other resource names in follow up PRs. Since there's change in naming format for roles, doing it first.