### PR TITLE
e2e test: pin operator-courier to version 1.2.1

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -134,7 +134,7 @@ install_operatorcourier() {
     # Update setuptools to a newer version. operator-courier fails to build with
     # older versions of setuptools.
     pip install --upgrade setuptools
-    pip install operator-courier
+    pip install operator-courier==1.2.1
     deactivate
     # Turn on nounset.
     set -o nounset


### PR DESCRIPTION
Latest version of operator-courier(1.3.0) is broken. Pin the previous
version.

Failed travisCI job: https://travis-ci.org/storageos/cluster-operator/jobs/515784386#L2676