### PR TITLE
olm: fix the CRD version

### DIFF
--- a/deploy/olm/storageos/storageoscluster.crd.yaml
+++ b/deploy/olm/storageos/storageoscluster.crd.yaml
@@ -12,7 +12,7 @@ spec:
     shortNames:
     - stos
   scope: Namespaced
-  version: v1alpha1
+  version: v1
   additionalPrinterColumns:
   - name: Ready
     type: string

--- a/deploy/olm/storageos/storageosjob.crd.yaml
+++ b/deploy/olm/storageos/storageosjob.crd.yaml
@@ -10,4 +10,4 @@ spec:
     plural: jobs
     singular: job
   scope: Namespaced
-  version: v1alpha1
+  version: v1

--- a/deploy/olm/storageos/storageosupgrade.crd.yaml
+++ b/deploy/olm/storageos/storageosupgrade.crd.yaml
@@ -10,4 +10,4 @@ spec:
     plural: storageosupgrades
     singular: storageosupgrade
   scope: Namespaced
-  version: v1alpha1
+  version: v1


### PR DESCRIPTION
The files submitted to the community hub have the correct version.
https://github.com/operator-framework/community-operators/blob/master/upstream-community-operators/storageos/storageoscluster.crd.yaml#L15

This version check was added in operator-courier 1.3, but since the latest release is broken we can't switch to it yet.