### PR TITLE
test: run operator-courier test in container

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -121,26 +121,6 @@ install_operatorsdk() {
     echo
 }
 
-# Installs operator-courier tool to lint the OLM CSV bundle.
-install_operatorcourier() {
-    echo "Install operator-courier"
-    sudo apt-get install -y python3.4-venv
-    # Create a python virtual environment.
-    python3 -m venv test-env
-    # Turn off nounset, to avoid errors in venv activation/deactivation due to
-    # unset variables.
-    set +o nounset
-    source ./test-env/bin/activate
-    # Update setuptools to a newer version. operator-courier fails to build with
-    # older versions of setuptools.
-    pip install --upgrade setuptools
-    pip install operator-courier==1.2.1
-    deactivate
-    # Turn on nounset.
-    set -o nounset
-    echo
-}
-
 # Prints log for all pods in the specified namespace.
 # Args:
 #   $1 The namespace
@@ -232,12 +212,8 @@ main() {
 
     if [ "$2" = "olm" ]; then
         # Lint the OLM CSV bundle.
-        install_operatorcourier
-        set +o nounset
-        source ./test-env/bin/activate
-        operator-courier verify ./deploy/olm/storageos
-        deactivate
-        set -o nounset
+        docker run -it --rm -v "$PWD"/deploy/olm/storageos/:/storageos \
+            python:3 bash -c "pip install operator-courier && operator-courier verify /storageos"
 
         source ./deploy/olm/olm.sh
         # Not using quick install here because the order in which the resources

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -213,7 +213,7 @@ main() {
     if [ "$2" = "olm" ]; then
         # Lint the OLM CSV bundle.
         docker run -it --rm -v "$PWD"/deploy/olm/storageos/:/storageos \
-            python:3 bash -c "pip install operator-courier && operator-courier verify /storageos"
+            python:3 bash -c "pip install operator-courier && operator-courier verify --ui_validate_io /storageos"
 
         source ./deploy/olm/olm.sh
         # Not using quick install here because the order in which the resources


### PR DESCRIPTION
Run a python:3 container, install operator-courier and run the olm
validation.