### PR TITLE
Automate OLM based releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ jobs:
             tags: true
         - provider: releases
           api_key:
-            secure: # Add encrypted Github API token with repo permission here
+            secure: mVr6wWr4Tym729atwxNDDI64PjRdocWUMEb4gOM3gOJUo1BjdJ8D0UzzZJvctW8VdDe1SVZGgpLmFGNOBjP9APBjpTl1ZfQvhJ67urlIn3DCoxjFGTB+2+FM0PVV1FX8hQawy/uTtLHOY+4jrVqm2Av2t486613u++/CNkTZeZCW4ydv/lSOCZ3nieX9eCk13/E6bhrHSQxRFD5KgL5ji+5rzuBlJQ12uzEitxRSBRnBPXU19ZPjFOoR2vbxTzI64BfvhQJSzbdNQbwwPFkmZsYuEUHyu3+ZH8N+Rng/wBL4ejt/gOXIfcHjZ5iGPIhJ3lIaVaxI9L6hHsFh3/QI24arI36Wf31XwPav7m6B4irGNBgbJRr2hS0LbPj0nsguzp/yD4vvpKUwlUtib8PwCxen5snZAQFdNB35Y7K+rdY/xkzFPVXktGZuNd9qSiVzs+kwFFzL2qDVgS5Nap7gYpUEY8Rt0urNklwbvPVdO825an8Y/2f1aXG3yT2jVoLi8z+ON1NDjXAEGJAQp9fVA25iCiW/Bbs7LY0O3EvjudUDPHv+70Lb0etpeqmJVJHavMNqC6cTaVkQ76iEzr0SACwBjAXnJBSkaeh+7KDMZJQ85iGJWPz+p4GyJGXxdLej4TGWS/YO6K5p/eNi5cK2Lbx5iSvSrTyndOFymbsLa+Q=
           file: build/_output/storageos-olm-metadata.zip
           skip_cleanup: true
           on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,19 @@ jobs:
       name: Publish Container Image
       script:
         - make image/cluster-operator
+        - make metadata-zip
       before_deploy:
         - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
       deploy:
         - provider: script
           script: bash scripts/deploy.sh tagged
+          on:
+            tags: true
+        - provider: releases
+          api_key:
+            secure: # Add encrypted Github API token with repo permission here
+          file: build/_output/storageos-olm-metadata.zip
+          skip_cleanup: true
           on:
             tags: true
         - provider: script

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ MACHINE = $(shell uname -m)
 BUILD_IMAGE = golang:1.11.5
 BASE_IMAGE = storageos/base-image:0.1.0
 
+# When this file name is modified, the new name must be added in .travis.yml
+# file as well for publishing the file at release.
+METADATA_FILE = storageos-olm-metadata.zip
+
 LDFLAGS += -X github.com/storageos/cluster-operator/pkg/controller/storageosupgrade.operatorImage=$(OPERATOR_IMAGE)
 
 all: lint unittest build/upgrader build/cluster-operator
@@ -60,12 +64,12 @@ install-operator-sdk: operator-sdk
 # Generate metadata bundle for openshift metadata scanner.
 metadata-zip:
 	# Remove any existing metadata bundle.
-	rm -f build/_output/storageos.zip
+	rm -f build/_output/$(METADATA_FILE)
 	# Ensure the target path exists.
 	mkdir -p build/_output/
 	# -j strips the parent directories and adds the files at the root. This is
 	# a requirement for the openshift metadata scanner.
-	zip -j build/_output/storageos.zip \
+	zip -j build/_output/$(METADATA_FILE) \
 		deploy/olm/storageos/storageos.package.yaml \
 		deploy/olm/storageos/storageoscluster.crd.yaml \
 		deploy/olm/storageos/storageosjob.crd.yaml \
@@ -80,4 +84,4 @@ olm-lint:
 # Create a metadata zip file and lint the bundle.
 metadata-bundle-lint: metadata-zip
 	docker run -it --rm -v $(PWD)/build/_output/:/metadata \
-		python:3 bash -c "pip install operator-courier && unzip /metadata/storageos.zip && operator-courier verify --ui_validate_io ."
+		python:3 bash -c "pip install operator-courier && unzip /metadata/$(METADATA_FILE) && operator-courier verify --ui_validate_io ."

--- a/deploy/olm/csv-rhel/README.md
+++ b/deploy/olm/csv-rhel/README.md
@@ -14,8 +14,8 @@ To create a new release:
 new operator container image and `spec.version` to the new release version
 number in `storageos.clusterserviceversion.yaml`.
 2. Run `make metadata-zip` from the root of the project to generate a metadata
-zip file at `/build/_output/storageos.zip`. This file can be directly uploaded
-to the rhel operator metadata scanner for a new release.
+zip file at `/build/_output/storageos-olm-metadata.zip`. This file can be
+directly uploaded to the rhel operator metadata scanner for a new release.
 3. Copy the modified `storageos.clusterserviceversion.yaml` file into a new file
 `storageos.<version>.clusterserviceversion.yaml` and check-in both the files in
 the repo to keep a record of the releases.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,38 @@
+# Release Process
+
+The operator release involves:
+1. Creating an operator container image.
+2. Pushing the container image to container image repositories.
+3. Generating a metadata zip file for publishing to rhel marketplace.
+4. Creating a PR to [community-operator](https://github.com/operator-framework/community-operators/)
+    for publishing to operatorhub.io.
+
+All the above steps have been automated and are run in TravisCI builds every
+time a new git tag is created.
+
+The release requires
+`deploy/olm/csv-rhel/storageos.v<version>.clusterserviceversion.yaml` and
+`deploy/olm/storageos/storageos.v<version>.clusterserviceversion.yaml` to be
+checked-in before `version` is tagged. These files should have the container
+image set to tag `version`. Once tagged, these containers are published using
+`scripts/deploy.sh`. rhel build is triggered at the same time to publish a new
+container in rhel container registry. The metadata zip for rhel release is
+generated and attached to the github release automatically. This file can then
+be submitted to the rhel metadata scanner for a new rhel operator release.
+`scripts/create-pr.sh` creates a new PR to update the community-operator with
+the new release. Once the PR is merged, a new version is released at
+operatorhub.io.
+
+
+# Deployment Secrets
+
+The TravisCI github releases deployment provider requires api_key to publish the
+generated artifacts. This api_key is encrypted and added in the `.travis.yml`
+file at `deploy.api_key.secure`. The key can be encrypted by running:
+```
+$ travis encrypt <key>
+```
+The github personal access token requires repo access permission only.
+
+For creating PR to community-operator, the same token stored as TravisCI env var
+is used.

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# This script uses github hub https://hub.github.com/ to create a pull request.
+
+# Env vars definitions:-
+# 
+# GH_USER: github username
+# GH_EMAIL: github user email
+# GH_TOKEN: github user API token with repo access permission only
+# VERSION: release version
+# TARGET_REPO: upstream community operator repo
+# COMMUNITY_REPO_PATH: community operator repo path
+# COMMUNITY_PKG_PATH: target operator dir path in the community operator repo
+# OLM_ROOT: path to the directory containing CRD, CSV and package file.
+
+
+declare -a metadatafiles=(
+  "${OLM_ROOT}/storageos.package.yaml" 
+  "${OLM_ROOT}/storageoscluster.crd.yaml"
+  "${OLM_ROOT}/storageosjob.crd.yaml"
+  "${OLM_ROOT}/storageosupgrade.crd.yaml"
+  "${OLM_ROOT}/storageos.v${VERSION}.clusterserviceversion.yaml"
+)
+
+# Setup netrc.
+echo "machine github.com
+  login $GH_USER
+  password $GH_TOKEN
+" > ~/.netrc
+
+# Configure git.
+git config --global user.email "$GH_EMAIL"
+git config --global user.name "$GH_USER"
+
+# Clone community hub repo.
+git clone $TARGET_REPO $COMMUNITY_REPO_PATH
+
+# Copy OLM package changes.
+for i in "${metadatafiles[@]}"
+do
+  echo "Copying $i"
+  # Copy the metada files to target package in community repo.
+  # Example: cp deploy/olm/storageos/storageos.package.yaml /go/src/github.com/operator-framework/community-operators/upstream-community-operators/storageos/
+  cp $i $COMMUNITY_REPO_PATH/$COMMUNITY_PKG_PATH
+done
+
+# Create branch, commit and create a PR.
+MESSAGE="Update StorageOS Operator to version ${VERSION}"
+pushd $COMMUNITY_REPO_PATH
+hub remote add fork https://github.com/$GH_USER/community-operators
+git checkout -b $VERSION
+git add *
+git commit -m "$MESSAGE"
+git push fork $VERSION
+hub pull-request -m "$MESSAGE"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,6 +9,8 @@ if [ "$1" = "tagged" ]; then
     docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:latest"
     docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:${TRAVIS_TAG}"
     docker push "${IMAGE_NAME}:latest" && docker push "${IMAGE_NAME}:${TRAVIS_TAG}"
+    # Trigger a rhel container service build.
+    curl -X POST -k -H 'Content-Type: application/json' -i https://connect.redhat.com/api/v2/projects/$RH_PID/build --data '{"tag": "'"${IMAGE_TAG}"'"}'
 elif [ "$1" = "develop" ]; then
     docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:develop"
     docker push "${IMAGE_NAME}:develop"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,15 +2,33 @@
 set -e
 
 # This script is used for publishing latest(release) and develop(canary)
-# container images of the operator. Script argument "tagged" must be passed to
-# publish a new release and "develop" must be passed to publish a canary image.
+# container images of the operator, triggering rhel container build service and
+# create a PR to update community operator version. Script argument "tagged"
+# must be passed to publish a new release and "develop" must be passed to
+# publish a canary image.
 
 if [ "$1" = "tagged" ]; then
     docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:latest"
     docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:${TRAVIS_TAG}"
     docker push "${IMAGE_NAME}:latest" && docker push "${IMAGE_NAME}:${TRAVIS_TAG}"
+
     # Trigger a rhel container service build.
     curl -X POST -k -H 'Content-Type: application/json' -i https://connect.redhat.com/api/v2/projects/$RH_PID/build --data '{"tag": "'"${IMAGE_TAG}"'"}'
+
+    # Create a PR to community-operator repo.
+    docker run --rm -ti \
+        -v $PWD:/go/src/github.com/storageos/cluster-operator \
+        -e GH_USER=$GH_USER \
+        -e GH_EMAIL=$GH_EMAIL \
+        -e GH_TOKEN=$API_TOKEN \
+        -e VERSION=$IMAGE_TAG \
+        -e TARGET_REPO="https://github.com/operator-framework/community-operators/" \
+        -e COMMUNITY_REPO_PATH="/go/src/github.com/operator-framework/community-operators/" \
+        -e COMMUNITY_PKG_PATH="upstream-community-operators/storageos/" \
+        -e OLM_ROOT=deploy/olm/storageos \
+        -w /go/src/github.com/storageos/cluster-operator \
+        tianon/github-hub:2 bash -c "./scripts/create-pr.sh"
+
 elif [ "$1" = "develop" ]; then
     docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:develop"
     docker push "${IMAGE_NAME}:develop"


### PR DESCRIPTION
Automates OLM based releases for operator to avoid error-prone manual artifact creation.
- Publish OLM metadata as github releases - The metadata zip is posted on the github releases page.
- Trigger rhel container service build - Build, scan and release new image
- Create PR to update community operator version

With this, a new tag must only be created once all the CRD, CSV and package files are updated for the new version. No two releases can have same CSV file. Every release must have a new CSV file.