### PR TITLE
cluster: Set pod priority class

### DIFF
--- a/pkg/storageos/daemonset.go
+++ b/pkg/storageos/daemonset.go
@@ -250,6 +250,8 @@ func (s *Deployment) createDaemonSet() error {
 	podSpec := &dset.Spec.Template.Spec
 	nodeContainer := &podSpec.Containers[0]
 
+	s.addPodPriorityClass(podSpec)
+
 	s.addTLSEtcdCerts(podSpec)
 
 	s.addNodeAffinity(podSpec)

--- a/pkg/storageos/podspec.go
+++ b/pkg/storageos/podspec.go
@@ -23,6 +23,12 @@ const (
 
 	// Etcd certs volume name.
 	tlsEtcdCertsVolume = "etcd-certs"
+
+	// Name of kube-system namespace.
+	kubeSystemNamespace = "kube-system"
+
+	// Name of the critical priority class.
+	criticalPriorityClass = "system-node-critical"
 )
 
 // addSharedDir adds env var and volumes for shared dir when running kubelet in
@@ -337,5 +343,12 @@ func (s *Deployment) addTLSEtcdCerts(podSpec *corev1.PodSpec) {
 			},
 		}
 		nodeContainer.Env = append(nodeContainer.Env, envvars...)
+	}
+}
+
+func (s *Deployment) addPodPriorityClass(podSpec *corev1.PodSpec) {
+	// Set pod priority to critical only when deployed in kube-system namespace.
+	if s.stos.Spec.GetResourceNS() == kubeSystemNamespace {
+		podSpec.PriorityClassName = criticalPriorityClass
 	}
 }

--- a/pkg/storageos/statefulset.go
+++ b/pkg/storageos/statefulset.go
@@ -134,6 +134,8 @@ func (s *Deployment) createStatefulSet() error {
 
 	podSpec := &sset.Spec.Template.Spec
 
+	s.addPodPriorityClass(podSpec)
+
 	s.addNodeAffinity(podSpec)
 
 	if err := s.addTolerations(podSpec); err != nil {


### PR DESCRIPTION
This adds pod priority class to the daemonset and statefulset pods when
deployed in kube-system namespace, making the storageos resources
critical.