### PR TITLE
Add k8sDistro parameter and pass to DaemonSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Parameter | Description | Default
 `nodeSelectorTerms` | Set node selector for storageos pod placement |
 `tolerations` | Set pod tolerations for storageos pod placement |
 `resources` | Set resource requirements for the containers |
+`k8sDistro` | The name of the Kubernetes distribution is use, e.g. `rancher` or `eks` |
 
 ## Upgrading a StorageOS Cluster
 
@@ -241,7 +242,7 @@ Namespace:    default
 ...
 ...
 Spec:
-  Completion Word:  
+  Completion Word:
   Args:
     /var/lib/storageos
   Host Path:            /var/lib

--- a/deploy/crds/storageos_v1_storageoscluster_cr.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_cr.yaml
@@ -7,6 +7,7 @@ spec:
   secretRefName: "storageos-api"
   secretRefNamespace: "default"
   namespace: "storageos"
+  # k8sDistro: openshift
   # tlsEtcdSecretRefName:
   # tlsEtcdSecretRefNamespace:
   # disableTelemetry: true
@@ -61,7 +62,7 @@ spec:
   #       values:
   #       - nodefoo
   # tolerations:
-  #   - key: somekey 
+  #   - key: somekey
   #     operator: "Equal"
   #     value: nodefoo
   #     effect: "NoSchedule"

--- a/deploy/crds/storageos_v1_storageoscluster_crd.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_crd.yaml
@@ -39,6 +39,8 @@ spec:
               type: string
             namespace:
               type: string
+            k8sDistro:
+              type: string
             disableFencing:
               type: boolean
             disableTelemetry:

--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -386,6 +386,11 @@ spec:
           StorageOS pods.
         displayName: Tolerations
         path: tolerations
+      - description: Name of the Kubernetes distribution in use, e.g.
+          `openshift`.  This will be included in the product telemetry (if
+          enabled), to help focus development efforts.
+        displayName: Kubernetes Distribution Name
+        path: k8sDistro
       - description: To disable anonymous usage reporting across the cluster,
           set to true. Defaults to false. To help improve the product, data such
           as API usage and StorageOS configuration information is collected.

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -386,6 +386,11 @@ spec:
           StorageOS pods.
         displayName: Tolerations
         path: tolerations
+      - description: Name of the Kubernetes distribution in use, e.g.
+          `openshift`.  This will be included in the product telemetry (if
+          enabled), to help focus development efforts.
+        displayName: Kubernetes Distribution Name
+        path: k8sDistro
       - description: To disable anonymous usage reporting across the cluster,
           set to true. Defaults to false. To help improve the product, data such
           as API usage and StorageOS configuration information is collected.

--- a/deploy/olm/storageos/storageoscluster.crd.yaml
+++ b/deploy/olm/storageos/storageoscluster.crd.yaml
@@ -39,6 +39,8 @@ spec:
               type: string
             namespace:
               type: string
+            k8sDistro:
+              type: string
             disableFencing:
               type: boolean
             disableTelemetry:

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -592,6 +592,11 @@ data:
                 StorageOS pods.
               displayName: Tolerations
               path: tolerations
+            - description: Name of the Kubernetes distribution in use, e.g.
+                `openshift`.  This will be included in the product telemetry (if
+                enabled), to help focus development efforts.
+              displayName: Kubernetes Distribution Name
+              path: k8sDistro
             - description: To disable anonymous usage reporting across the cluster,
                 set to true. Defaults to false. To help improve the product, data such
                 as API usage and StorageOS configuration information is collected.

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -156,6 +156,18 @@ type StorageOSClusterSpec struct {
 
 	// TLSEtcdSecretRefNamespace is the namespace of the etcd TLS secret object.
 	TLSEtcdSecretRefNamespace string `json:"tlsEtcdSecretRefNamespace"`
+
+	// K8sDistro is the name of the Kubernetes distribution where the operator
+	// is being deployed.  It should be in the format: `name[-1.0]`, where the
+	// version is optional and should only be appended if known.  Suitable names
+	// include: `openshift`, `rancher`, `aks`, `gke`, `eks`, or the deployment
+	// method if using upstream directly, e.g `minishift` or `kubeadm`.
+	//
+	// Setting k8sDistro is optional, and will be used to simplify cluster
+	// configuration by setting appropriate defaults for the distribution.  The
+	// distribution information will also be included in the product telemetry
+	// (if enabled), to help focus development efforts.
+	K8sDistro string `json:"k8sDistro"`
 }
 
 // StorageOSClusterStatus defines the observed state of StorageOSCluster

--- a/pkg/storageos/daemonset.go
+++ b/pkg/storageos/daemonset.go
@@ -37,6 +37,7 @@ const (
 	kvAddrEnvVar                        = "KV_ADDR"
 	kvBackendEnvVar                     = "KV_BACKEND"
 	debugEnvVar                         = "LOG_LEVEL"
+	k8sDistroEnvVar                     = "K8S_DISTRO"
 
 	sysAdminCap = "SYS_ADMIN"
 	debugVal    = "xdebug"
@@ -182,6 +183,10 @@ func (s *Deployment) createDaemonSet() error {
 								{
 									Name:  csiVersionEnvVar,
 									Value: s.stos.Spec.GetCSIVersion(CSIV1Supported(s.k8sVersion)),
+								},
+								{
+									Name:  k8sDistroEnvVar,
+									Value: s.stos.Spec.K8sDistro,
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
Allows the Kubernetes distribution name to be set during provisioning, and passes it to the node container using the `K8S_DISTRO` env var.

This will be used for pre-configuring for specific distributions and for telemetry.