### PR TITLE
Fix metadata bundle lint for operator-courier 2.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,4 +84,5 @@ olm-lint:
 # Create a metadata zip file and lint the bundle.
 metadata-bundle-lint: metadata-zip
 	docker run -it --rm -v $(PWD)/build/_output/:/metadata \
+		-w /home/test/ \
 		python:3 bash -c "pip install operator-courier && unzip /metadata/$(METADATA_FILE) && operator-courier verify --ui_validate_io ."


### PR DESCRIPTION
New operator-courier 2.x fails when there's are other files in the
directory. This change extracts the metadata bundle in a new directory
and runs verification.