### PR TITLE
Add OCP SCC support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
         fi
       fi
   - sudo apt -y update && sudo apt install -y jq
+  - curl -Lo yq https://github.com/mikefarah/yq/releases/download/2.3.0/yq_linux_amd64 && chmod +x yq && sudo mv yq /usr/local/bin/
   - curl -Lo storageos https://github.com/storageos/go-cli/releases/download/1.0.0/storageos_linux_amd64 && chmod +x storageos && sudo mv storageos /usr/local/bin/
 #  - docker run -d -p 2399:2399 quay.io/coreos/etcd:v3.3.10 /usr/local/bin/etcd -advertise-client-urls http://0.0.0.0:2399 -listen-client-urls http://0.0.0.0:2399
 
@@ -37,6 +38,13 @@ jobs:
         - "TEST_CLUSTER=kind"
         - "INSTALL_METHOD=olm"
       name: OLM on KinD (k8s-1.13)
+      script: ./test/e2e.sh $TEST_CLUSTER $INSTALL_METHOD
+    - go: "1.11"
+      sudo: required
+      env:
+        - "TEST_CLUSTER=openshift"
+        - "INSTALL_METHOD=olm"
+      name: OLM on OpenShift (k8s-1.11)
       script: ./test/e2e.sh $TEST_CLUSTER $INSTALL_METHOD
     - &base-test
       go: "1.11"

--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -287,6 +287,17 @@ spec:
           verbs:
           - create
           - delete
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - delete
+          - update
+          - get
+          resourceNames:
+          - privileged
       deployments:
       - name: storageos-operator
         spec:

--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -296,6 +296,7 @@ spec:
           - delete
           - update
           - get
+          - use
           resourceNames:
           - privileged
       deployments:

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -287,6 +287,17 @@ spec:
           verbs:
           - create
           - delete
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - delete
+          - update
+          - get
+          resourceNames:
+          - privileged
       deployments:
       - name: storageos-operator
         spec:

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -296,6 +296,7 @@ spec:
           - delete
           - update
           - get
+          - use
           resourceNames:
           - privileged
       deployments:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -93,3 +93,16 @@ rules:
   verbs:
   - create
   - delete
+# OpenShift specific rule.
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - create
+  - delete
+  - update
+  - get
+  - use
+  resourceNames:
+  - privileged

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -504,6 +504,7 @@ data:
                 - delete
                 - update
                 - get
+                - use
                 resourceNames:
                 - privileged
             deployments:

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -495,6 +495,17 @@ data:
                 verbs:
                 - create
                 - delete
+              - apiGroups:
+                - security.openshift.io
+                resources:
+                - securitycontextconstraints
+                verbs:
+                - create
+                - delete
+                - update
+                - get
+                resourceNames:
+                - privileged
             deployments:
             - name: storageos-operator
               spec:

--- a/pkg/storageos/delete.go
+++ b/pkg/storageos/delete.go
@@ -1,5 +1,7 @@
 package storageos
 
+import "strings"
+
 // Delete deletes all the storageos resources.
 // This explicit delete is implemented instead of depending on the garbage
 // collector because sometimes the garbage collector deletes the resources
@@ -74,6 +76,17 @@ func (s *Deployment) Delete() error {
 		}
 
 		if err := s.deleteCSISecrets(); err != nil {
+			return err
+		}
+	}
+
+	// Delete cluster role for openshift security context constraints.
+	if strings.Contains(s.stos.Spec.K8sDistro, k8sDistroOpenShift) {
+		if err := s.deleteClusterRoleBinding(OpenShiftSCCClusterBindingName); err != nil {
+			return err
+		}
+
+		if err := s.deleteClusterRole(OpenShiftSCCClusterRoleName); err != nil {
 			return err
 		}
 	}

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/blang/semver"
 	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
@@ -65,6 +66,9 @@ const (
 
 	defaultUsername = "storageos"
 	defaultPassword = "storageos"
+
+	// k8s distribution vendor specific keywords.
+	k8sDistroOpenShift = "openshift"
 )
 
 // Deploy deploys storageos by creating all the resources needed to run storageos.
@@ -152,6 +156,17 @@ func (s *Deployment) Deploy() error {
 		}
 
 		if err := s.createStatefulSet(); err != nil {
+			return err
+		}
+	}
+
+	// Add openshift security context constraints.
+	if strings.Contains(s.stos.Spec.K8sDistro, k8sDistroOpenShift) {
+		if err := s.createClusterRoleForSCC(); err != nil {
+			return err
+		}
+
+		if err := s.createClusterRoleBindingForSCC(); err != nil {
 			return err
 		}
 	}

--- a/scripts/openshift/.gitignore
+++ b/scripts/openshift/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/scripts/openshift/README.md
+++ b/scripts/openshift/README.md
@@ -1,0 +1,27 @@
+# Setup OpenShift Test Environment
+
+`Vagrantfile` contains configuration for creating an ubuntu trusty VM with
+enough memory and diskspace to setup openshift and run the operator tests.
+
+Create the VM:
+```console
+$ vagrant up
+```
+
+Once the VM is ready, ssh into the VM and run the setup scripts in it to setup
+everything. Read the comments in the scripts for reasons why things are done
+in certain ways. Most of the parts of the scripts is a combination of the travis
+CI configuration file and e2e.sh file, but only the parts that apply to
+openshift setup.
+
+```console
+$ vagrant ssh
+$ bash /vagrant/openshift-seutp-1.sh
+
+# Re-login
+$ exit
+$ vagrant ssh
+
+# Continue setup
+$ bash /vagrant/openshift-seutp-2.sh
+```

--- a/scripts/openshift/Vagrantfile
+++ b/scripts/openshift/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.network "private_network", type: "dhcp"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "4096"
+  end
+end

--- a/scripts/openshift/openshift-setup-1.sh
+++ b/scripts/openshift/openshift-setup-1.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -Eeuxo pipefail
+
+# This script is part one of setting up openshift test environment. At the end
+# of this script, a shell re-login is needed to be able to use docker as a
+# non-root user. Due to this, there's a second part of this script which
+# does the openshift setup.
+
+# Update and install git. Git it required to get the operator source code.
+sudo apt -y update
+sudo apt -y install git
+
+# Install docker
+sudo wget -qO- https://get.docker.com/ | sh
+sudo usermod -aG docker $USER
+
+# Downgrade to docker 18.06.1 on trusty because the latest version fails to
+# start container due to a security fix which requires certain kernel featues
+# that are not available in trusty's default kernel.
+# https://github.com/docker/for-linux/issues/591
+sudo apt install -y docker-ce=18.06.1~ce~3-0~ubuntu --force-yes
+
+# Set docker insecure registry to install openshift.
+sudo service docker stop
+sudo tee /etc/docker/daemon.json > /dev/null <<EOF
+{
+    "insecure-registries" : ["172.30.0.0/16"]
+}
+EOF
+sudo service docker start

--- a/scripts/openshift/openshift-setup-2.sh
+++ b/scripts/openshift/openshift-setup-2.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -Eeuxo pipefail
+
+# This script sets up openshift test environment on ubuntu trusty, the same
+# environment that we create in the CI.
+
+# Install kernel modules and enable LIO.
+sudo apt -y install linux-modules-extra-$(uname -r)
+sudo mount --make-shared /sys
+sudo mount --make-shared /
+sudo mount --make-shared /dev
+docker run --name enable_lio --privileged --rm --cap-add=SYS_ADMIN -v /lib/modules:/lib/modules -v /sys:/sys:rshared storageos/init:0.1
+
+# Download oc to spin up openshift on local docker instance
+curl -Lo oc.tar.gz https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+# Put oc binary in path
+tar xvzOf oc.tar.gz openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc > oc && chmod +x oc && sudo mv oc /usr/local/bin/
+# Install autocompletion
+oc completion bash > oc
+sudo mv oc /etc/bash_completion.d/
+# Start oc cluster
+oc cluster up
+# Become cluster admin
+oc login -u system:admin
+# Install kubectl
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+# Install autocompletion
+kubectl completion bash > kubectl
+sudo mv kubectl /etc/bash_completion.d/
+
+# Install go
+wget https://dl.google.com/go/go1.12.4.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.12.4.linux-amd64.tar.gz
+echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.profile
+export PATH=$PATH:/usr/local/go/bin
+
+# Install storageos-cli
+curl -Lo storageos https://github.com/storageos/go-cli/releases/download/1.0.0/storageos_linux_amd64 && chmod +x storageos && sudo mv storageos /usr/local/bin/
+
+# Install jq
+sudo apt -y update && sudo apt install -y jq
+
+# Install yq
+curl -Lo yq https://github.com/mikefarah/yq/releases/download/2.3.0/yq_linux_amd64 && chmod +x yq && sudo mv yq /usr/local/bin/
+
+# Get cluster-operator code
+go get -v -d github.com/storageos/cluster-operator
+
+# Install operator-sdk
+cd ~/go/src/github.com/storageos/cluster-operator/
+make install-operator-sdk
+cd -

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -254,24 +254,12 @@ main() {
         # NOTE: Append this test command with `|| true` to debug by inspecting the
         # resource details. Also comment `defer ctx.Cleanup()` in the cluster to
         # avoid resouce cleanup.
-        operator-sdk test local ./test/e2e --go-test-flags "-v -tags intree" --namespace storageos-operator
+        operator-sdk test local ./test/e2e --go-test-flags "-v -tags csi" --namespace storageos-operator
 
         echo "Deleting namespace storageos..."
         kubectl delete ns storageos --ignore-not-found=true
 
-        # TODO: Remove these manual SCC permissions. It works automatically in
-        # the OLM tests and in manual test runs, but fails in CI only with
-        # no statefulset pods created. Try to reproduce it and find what's
-        # causing this issue.
-        if [ "$1" = "openshift" ]; then
-        # Add storageos service account to Security Context Constraint (SCC).
-        # This is openshift specific permission which is required for the operator
-        # to work.
-        oc adm policy add-scc-to-user privileged system:serviceaccount:storageos:storageos-daemonset-sa
-        oc adm policy add-scc-to-user privileged system:serviceaccount:storageos:storageos-statefulset-sa
-        fi
-
-        operator-sdk test local ./test/e2e --go-test-flags "-v -tags csi" --namespace storageos-operator
+        operator-sdk test local ./test/e2e --go-test-flags "-v -tags intree" --namespace storageos-operator
 
         echo "Deleting namespace storageos..."
         kubectl delete ns storageos --ignore-not-found=true

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -107,11 +107,6 @@ run_openshift() {
     curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
     # Change directory to the project directory.
     cd -
-    # Add storageos service account to Security Context Constraint (SCC).
-    # This is openshift specific permission which is required for the operator
-    # to work.
-    oc adm policy add-scc-to-user privileged system:serviceaccount:storageos:storageos-daemonset-sa
-    oc adm policy add-scc-to-user privileged system:serviceaccount:storageos:storageos-statefulset-sa
     echo
 }
 
@@ -186,6 +181,12 @@ main() {
         run_minikube
     elif [ "$1" = "openshift" ]; then
         run_openshift
+        # # TODO: Add node label for master node. This is required by the OLM
+        # # deployments to work in the next version of OLM 0.9.
+        # kubectl label nodes localhost node-role.kubernetes.io/master=
+
+        # Update CR with k8sDistro set to openshift
+        yq w -i deploy/storageos-operators.olm.cr.yaml spec.k8sDistro openshift
     elif [ "$1" = "kind" ]; then
         run_kind
     fi
@@ -257,6 +258,18 @@ main() {
 
         echo "Deleting namespace storageos..."
         kubectl delete ns storageos --ignore-not-found=true
+
+        # TODO: Remove these manual SCC permissions. It works automatically in
+        # the OLM tests and in manual test runs, but fails in CI only with
+        # no statefulset pods created. Try to reproduce it and find what's
+        # causing this issue.
+        if [ "$1" = "openshift" ]; then
+        # Add storageos service account to Security Context Constraint (SCC).
+        # This is openshift specific permission which is required for the operator
+        # to work.
+        oc adm policy add-scc-to-user privileged system:serviceaccount:storageos:storageos-daemonset-sa
+        oc adm policy add-scc-to-user privileged system:serviceaccount:storageos:storageos-statefulset-sa
+        fi
 
         operator-sdk test local ./test/e2e --go-test-flags "-v -tags csi" --namespace storageos-operator
 

--- a/test/e2e/clusterCSI_test.go
+++ b/test/e2e/clusterCSI_test.go
@@ -41,6 +41,7 @@ func TestClusterCSI(t *testing.T) {
 				Effect:   corev1.TaintEffectNoSchedule,
 			},
 		},
+		K8sDistro: "openshift",
 	}
 
 	testStorageOS := testutil.NewStorageOSCluster(namespace, clusterSpec)

--- a/test/e2e/clusterInTreePlugin_test.go
+++ b/test/e2e/clusterInTreePlugin_test.go
@@ -36,6 +36,7 @@ func TestClusterInTreePlugin(t *testing.T) {
 				Effect:   corev1.TaintEffectNoSchedule,
 			},
 		},
+		K8sDistro: "openshift",
 	}
 
 	testStorageOS := testutil.NewStorageOSCluster(namespace, clusterSpec)

--- a/test/e2e/util/cluster.go
+++ b/test/e2e/util/cluster.go
@@ -3,7 +3,6 @@ package util
 import (
 	goctx "context"
 	"fmt"
-	"log"
 	"os/exec"
 	"testing"
 	"time"
@@ -216,7 +215,8 @@ func NodeLabelSyncTest(t *testing.T, kubeclient kubernetes.Interface) {
 	node.SetLabels(labels)
 	_, err = kubeclient.CoreV1().Nodes().Update(&node)
 	if err != nil {
-		t.Fatalf("failed to update node labels: %v", err)
+		t.Errorf("failed to update node labels: %v", err)
+		return
 	}
 
 	// Wait for the node-controller to update storageos node.
@@ -224,10 +224,12 @@ func NodeLabelSyncTest(t *testing.T, kubeclient kubernetes.Interface) {
 
 	out, err := exec.Command("./test/port-forward.sh").Output()
 	if err != nil {
-		log.Fatalf("failed while executing script: %v", err)
+		t.Errorf("failed while executing script: %v", err)
+		return
 	}
 	if string(out) != "0\n" {
-		log.Fatalf("unexpected script output: %v", string(out))
+		t.Errorf("unexpected script output: %v", string(out))
+		return
 	}
 
 	// Cleanup - remove the label from k8s node.
@@ -235,7 +237,8 @@ func NodeLabelSyncTest(t *testing.T, kubeclient kubernetes.Interface) {
 	// Get the latest version of node to update.
 	nodes, err = kubeclient.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
-		t.Fatalf("failed to get nodes: %v", err)
+		t.Errorf("failed to get nodes: %v", err)
+		return
 	}
 	node = nodes.Items[0]
 	labels = node.GetLabels()
@@ -243,6 +246,7 @@ func NodeLabelSyncTest(t *testing.T, kubeclient kubernetes.Interface) {
 	node.SetLabels(labels)
 	_, err = kubeclient.CoreV1().Nodes().Update(&node)
 	if err != nil {
-		t.Fatalf("failed to cleanup node labels: %v", err)
+		t.Errorf("failed to cleanup node labels: %v", err)
+		return
 	}
 }


### PR DESCRIPTION
Grant OCP(OpenShift Container Platform) SCC permission to the operator at deployment and use the
permission in operator to grant SCC permission to the daemonset and
statefulset.

The OCP specific rules are ignore when used in upstream k8s.