### PR TITLE
e2e: Update KinD to latest with k8s 1.14.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
       env:
         - "TEST_CLUSTER=kind"
         - "INSTALL_METHOD=olm"
-      name: OLM on KinD (k8s-1.14)
+      name: OLM on KinD (k8s-1.13)
       script: ./test/e2e.sh $TEST_CLUSTER $INSTALL_METHOD
     - go: "1.11"
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
       env:
         - "TEST_CLUSTER=kind"
         - "INSTALL_METHOD=olm"
-      name: OLM on KinD (k8s-1.13)
+      name: OLM on KinD (k8s-1.14)
       script: ./test/e2e.sh $TEST_CLUSTER $INSTALL_METHOD
     - go: "1.11"
       sudo: required
@@ -63,7 +63,7 @@ jobs:
       env:
         - "TEST_CLUSTER=kind"
         - "INSTALL_METHOD=none"
-      name: KinD (k8s-1.13)
+      name: KinD (k8s-1.14)
     - stage: deploy
       go: "1.11"
       sudo: required

--- a/deploy/olm/olm.sh
+++ b/deploy/olm/olm.sh
@@ -27,7 +27,10 @@ install_olm() {
 
 olm_quick_install() {
     echo "Quick Install OLM"
-    kubectl create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml
+    # kubectl create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml
+
+    # Use the release manifest.
+    kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.9.0/olm.yaml
 
     # Create this cluster role binding to grant permissions to the olm web console.
     kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=system:serviceaccount:kube-system:default

--- a/docs/build-kind-node-image.md
+++ b/docs/build-kind-node-image.md
@@ -1,0 +1,37 @@
+# Building KinD node image
+
+Clone https://github.com/kubernetes-sigs/kind.
+
+Update `images/base/entrypoint` in kind repo with
+```
+mount --make-shared /sys
+```
+ in `fix_mount()` function, refer: https://github.com/darkowlzz/kind/blob/kind-17-05-19/images/base/entrypoint#L45.
+
+(Optional) Update `pkg/build/base/base.go` with:
+```
+cmd := exec.Command("docker", "build", "--no-cache", "-t", c.image, dir)
+```
+in `buildImage()`, to avoid using cache when rebuilding the container images.
+
+Build and publish kind node image:
+```
+# Download the vendor deps
+$ go mod vendor
+
+# Build KinD
+$ go build -v sigs.k8s.io/kind
+
+# Build base image with /sys as shared mount
+$ ./kind build base-image
+
+# Build node image using the new base-image
+$ ./kind build node-image --base-image kindest/base:latest
+
+# Use the new kindest/node image to create a new k8s cluster
+$ ./kind create cluster --image kindest/node:latest
+
+# Tag and push the node image:
+$ docker tag kindest/node:latest storageos/kind-node:v1.14.2
+$ docker push storageos/kind-node:v1.14.2
+```

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -3,6 +3,11 @@
 set -Eeuxo pipefail
 
 readonly REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+readonly K8S_1_14="v1.14.2"
+readonly K8S_1_13="v1.13.2"
+# Two different versions of KinD due to a breaking change between the versions.
+readonly KIND_1_14_LINK="https://docs.google.com/uc?export=download&id=1-oy-ui0ZE_T3Fglz1c8ZgnW8U-A4yS8u"
+readonly KIND_1_13_LINK="https://docs.google.com/uc?export=download&id=1C_Jrj68Y685N5KcOqDQtfjeAZNW2UvNB"
 
 enable_lio() {
     echo "Enable LIO"
@@ -17,20 +22,27 @@ enable_lio() {
 
 run_kind() {
     echo "Download kind binary..."
+
+    if [ "$1" == "$K8S_1_13" ]; then
+        KIND_LINK=$KIND_1_13_LINK
+    else
+        KIND_LINK=$KIND_1_14_LINK
+    fi
+
     # docker run --rm -it -v "$(pwd)":/go/bin golang go get sigs.k8s.io/kind && sudo mv kind /usr/local/bin/
-    wget -O kind 'https://docs.google.com/uc?export=download&id=1-oy-ui0ZE_T3Fglz1c8ZgnW8U-A4yS8u' --no-check-certificate && chmod +x kind && sudo mv kind /usr/local/bin/
+    wget -O kind $KIND_LINK --no-check-certificate && chmod +x kind && sudo mv kind /usr/local/bin/
     echo "Download kubectl..."
-    curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+    curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
     echo
 
     echo "Create Kubernetes cluster with kind..."
     # kind create cluster --image=kindest/node:"$K8S_VERSION"
-    kind create cluster --image storageos/kind-node:v1.14.2
+    kind create cluster --image storageos/kind-node:$1 --name kind-1
 
     echo "Export kubeconfig..."
     # shellcheck disable=SC2155
-    export KUBECONFIG="$(kind get kubeconfig-path)"
-    cp $(kind get kubeconfig-path) ~/.kube/config
+    export KUBECONFIG="$(kind get kubeconfig-path --name="kind-1")"
+    cp $(kind get kubeconfig-path --name="kind-1") ~/.kube/config
     echo
 
     echo "Get cluster info..."
@@ -197,14 +209,21 @@ main() {
         run_minikube
     elif [ "$1" = "openshift" ]; then
         run_openshift
-        # # TODO: Add node label for master node. This is required by the OLM
-        # # deployments to work in the next version of OLM 0.9.
-        # kubectl label nodes localhost node-role.kubernetes.io/master=
 
         # Update CR with k8sDistro set to openshift
         yq w -i deploy/storageos-operators.olm.cr.yaml spec.k8sDistro openshift
     elif [ "$1" = "kind" ]; then
-        run_kind
+        # OLM installation fails on k8s 1.14 with error "failed to connect
+        # service" in CI only. Works fine locally.
+        # Refer: https://github.com/operator-framework/operator-lifecycle-manager/issues/740
+        # Using k8s 1.13 with old KinD for OLM until that's fixed.
+        # New KinD with k8s 1.14 uses containerd and has an incompatible node
+        # image.
+        if [ "$2" = "olm" ]; then
+            run_kind $K8S_1_13
+        else
+            run_kind $K8S_1_14
+        fi
     fi
 
     install_operatorsdk
@@ -221,14 +240,18 @@ main() {
     # Move the operator container inside Kind container so that the image is
     # available to the docker in docker environment.
     if [ "$1" = "kind" ]; then
-        x=$(docker ps -f name=kind-control-plane -q)
+        x=$(docker ps -f name=kind-1-control-plane -q)
         docker save storageos/cluster-operator:test > cluster-operator.tar
         docker cp cluster-operator.tar $x:/cluster-operator.tar
-        # Docker load image from tar archive (KinD with docker).
-        #   docker exec $x bash -c "docker load < /cluster-operator.tar"
-        #
-        # containerd load image from tar archive (KinD with containerd).
-        docker exec $x bash -c "ctr -n k8s.io images import --base-name docker.io/storageos/cluster-operator:test /cluster-operator.tar"
+
+        if [ "$2" = "olm" ]; then
+            # kind-olm runs on old KinD with docker.
+            # Docker load image from tar archive (KinD with docker).
+            docker exec $x bash -c "docker load < /cluster-operator.tar"
+        else
+            # containerd load image from tar archive (KinD with containerd).
+            docker exec $x bash -c "ctr -n k8s.io images import --base-name docker.io/storageos/cluster-operator:test /cluster-operator.tar"
+        fi
     fi
 
     if [ "$2" = "olm" ]; then
@@ -239,14 +262,10 @@ main() {
         make metadata-bundle-lint
 
         source ./deploy/olm/olm.sh
-        # Not using quick install here because the order in which the resources
-        # are created is unreliable and results in flaky test setup. Hard to
-        # reproduce it locally. The errors are mostly due to the CRD being
-        # used before it's created.
-        install_olm
+        olm_quick_install
 
         # Wait for all the OLM resources to be created and ready.
-        sleep 10
+        sleep 20
 
         install_storageos_operator
 


### PR DESCRIPTION
Updates KinD to the latest version(1d85e92) which uses containerd
directly instead of docker. This improves the startup time of k8s
cluster.
The new k8s 1.14.2 container image compatible with KinD is available
at storageos/kind-node:v1.14.2. This image is built with /sys as shared
mount, which is required for storageos to run.

Also add KinD node image building docs.