### PR TITLE
Add operator quick install manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 build/_output
 build/_test
 build/operator-sdk
+build/yq
 deploy/test
 test/olm
+storageos-operator.yaml
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ jobs:
       script:
         - make image/cluster-operator
         - make metadata-zip
+        - OPERATOR_IMAGE=storageos/cluster-operator:$TRAVIS_TAG make generate-install-manifest
       before_deploy:
         - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
       deploy:
@@ -84,7 +85,9 @@ jobs:
         - provider: releases
           api_key:
             secure: mVr6wWr4Tym729atwxNDDI64PjRdocWUMEb4gOM3gOJUo1BjdJ8D0UzzZJvctW8VdDe1SVZGgpLmFGNOBjP9APBjpTl1ZfQvhJ67urlIn3DCoxjFGTB+2+FM0PVV1FX8hQawy/uTtLHOY+4jrVqm2Av2t486613u++/CNkTZeZCW4ydv/lSOCZ3nieX9eCk13/E6bhrHSQxRFD5KgL5ji+5rzuBlJQ12uzEitxRSBRnBPXU19ZPjFOoR2vbxTzI64BfvhQJSzbdNQbwwPFkmZsYuEUHyu3+ZH8N+Rng/wBL4ejt/gOXIfcHjZ5iGPIhJ3lIaVaxI9L6hHsFh3/QI24arI36Wf31XwPav7m6B4irGNBgbJRr2hS0LbPj0nsguzp/yD4vvpKUwlUtib8PwCxen5snZAQFdNB35Y7K+rdY/xkzFPVXktGZuNd9qSiVzs+kwFFzL2qDVgS5Nap7gYpUEY8Rt0urNklwbvPVdO825an8Y/2f1aXG3yT2jVoLi8z+ON1NDjXAEGJAQp9fVA25iCiW/Bbs7LY0O3EvjudUDPHv+70Lb0etpeqmJVJHavMNqC6cTaVkQ76iEzr0SACwBjAXnJBSkaeh+7KDMZJQ85iGJWPz+p4GyJGXxdLej4TGWS/YO6K5p/eNi5cK2Lbx5iSvSrTyndOFymbsLa+Q=
-          file: build/_output/storageos-olm-metadata.zip
+          file:
+            - build/_output/storageos-olm-metadata.zip
+            - storageos-operator.yaml
           skip_cleanup: true
           on:
             tags: true

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,12 @@ operator-sdk:
 install-operator-sdk: operator-sdk
 	sudo cp build/operator-sdk /usr/local/bin/
 
+install-yq:
+	@if [ ! -f build/yq ]; then \
+		curl -Lo build/yq https://github.com/mikefarah/yq/releases/download/2.3.0/yq_linux_amd64 && \
+		chmod +x build/yq; \
+	fi
+
 # Generate metadata bundle for openshift metadata scanner.
 metadata-zip:
 	# Remove any existing metadata bundle.
@@ -94,5 +100,10 @@ metadata-bundle-lint: metadata-zip
 		-w /home/test/ \
 		python:3 bash -c "pip install operator-courier && unzip /metadata/$(METADATA_FILE) && operator-courier verify --ui_validate_io ."
 
+# Prepare the repo for a new release.
 release:
 	bash scripts/release-helpers/release-gen.sh $(NEW_VERSION)
+
+# Create a single manifest for installing the operator.
+generate-install-manifest: install-yq
+	bash scripts/create-manifest.sh $(OPERATOR_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ olm-lint:
 metadata-bundle-lint: metadata-zip
 	docker run -it --rm -v $(PWD)/build/_output/:/metadata \
 		-w /home/test/ \
-		python:3 bash -c "pip install operator-courier && unzip /metadata/$(METADATA_FILE) && operator-courier verify --ui_validate_io ."
+		python:3 bash -c "pip install operator-courier && unzip /metadata/$(METADATA_FILE) -d out && operator-courier --verbose verify --ui_validate_io out/"
 
 # Prepare the repo for a new release.
 release:

--- a/README.md
+++ b/README.md
@@ -26,18 +26,16 @@ for more information.
 1. Build operator container image with `make image/cluster-operator`. Publish or
   copy this container image to an existing k8s cluster to make it available
   for use within the cluster.
-2. Apply the manifests in `deploy/` to install the operator
-   * Apply `namespace.yaml` to create the `storageos-operator` namespace.
-   * Apply `service_account.yaml`, `role.yaml` and `role_binding.yaml` to create
-    a service account and to grant all the permissions.
-   * Apply `crds/*_crd.yaml` to define the custom resources.
-   * Apply `operator.yaml` to install the operator. Change the container image
-     in this file when installing a new operator.
-   * Apply `crds/*_storageoscluster_cr.yaml` to create a `StorageOSCluster`
-     custom resource.
+2. Generate install manifest file with `make generate-install-manifest`. This
+will generate `storageos-operator.yaml`.
+3. Install the operator `kubectl create -f storageos-operator.yaml`
+4. Install a `StorageOSCluster` by creating a custom resource
+`kubectl create -f deploy/crds/*_storageoscluster_cr.yaml`.
 
 **NOTE**: Installing StorageOS on Minikube is not currently supported due to
 missing [kernel prerequisites](https://docs.storageos.com/docs/prerequisites/systemconfiguration).
+There are custom built [Kubernetes in Docker (KinD)](https://github.com/kubernetes-sigs/kind)
+node image compatible with StorageOS available at https://hub.docker.com/r/storageos/kind-node.
 
 For development, run the operator outside of the k8s cluster by running:
 

--- a/scripts/create-manifest.sh
+++ b/scripts/create-manifest.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# This script generates a single manifest file for installing the operator.
+# This file is attached to each release with the appropriate container image for
+# quick installation.
+
+# Set the first argument as the operator container image tag. Default to "test".
+OPERATOR_IMAGE="${1:-test}"
+
+# List of manifests files to combine to form a single operator manifest file.
+declare -a manifestfiles=(
+    "deploy/crds/storageos_v1_storageoscluster_crd.yaml"
+    "deploy/crds/storageos_v1_storageosupgrade_crd.yaml"
+    "deploy/crds/storageos_v1_job_crd.yaml"
+    "deploy/namespace.yaml"
+    "deploy/role.yaml"
+    "deploy/service_account.yaml"
+    "deploy/role_binding.yaml"
+)
+
+# Path of the operator install manifest file.
+INSTALL_MANIFEST="storageos-operator.yaml"
+
+# Delete the existing manifest.
+rm -f $INSTALL_MANIFEST
+
+for i in "${manifestfiles[@]}"
+do
+    echo "---" >> $INSTALL_MANIFEST
+    echo "Copying $i"
+    cat $i >> $INSTALL_MANIFEST
+done
+
+# Write the operator manifest with the proper container image tag.
+echo "---" >> $INSTALL_MANIFEST
+echo "Copying deploy/operator.yaml with image $OPERATOR_IMAGE"
+build/yq w deploy/operator.yaml spec.template.spec.containers[0].image $OPERATOR_IMAGE >> $INSTALL_MANIFEST


### PR DESCRIPTION
This adds `create-manifest.sh` to generate a single manifest file for
installing the operator. This will be used by the CI to generate a quick
install manifest file for every release.

With this, it'll be possible to install the operator by doing:
```
$ kubectl create -f https://github.com/storageos/cluster-operator/releases/download/<version>/storageos-operator.yaml
customresourcedefinition.apiextensions.k8s.io/storageosclusters.storageos.com created
customresourcedefinition.apiextensions.k8s.io/storageosupgrades.storageos.com created
customresourcedefinition.apiextensions.k8s.io/jobs.storageos.com created
namespace/storageos-operator created
clusterrole.rbac.authorization.k8s.io/storageos-operator created
serviceaccount/storageoscluster-operator-sa created
clusterrolebinding.rbac.authorization.k8s.io/storageoscluster-operator-rolebinding created
deployment.apps/storageos-cluster-operator created
```