### PR TITLE
Add storageos scheduler deployment

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1199,6 +1199,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/blang/semver",
+    "github.com/go-logr/logr",
     "github.com/operator-framework/operator-sdk/pkg/test",
     "github.com/operator-framework/operator-sdk/pkg/test/e2eutil",
     "github.com/operator-framework/operator-sdk/version",
@@ -1243,6 +1244,7 @@
     "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",
     "sigs.k8s.io/controller-runtime/pkg/reconcile",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/log",
     "sigs.k8s.io/controller-runtime/pkg/runtime/scheme",
     "sigs.k8s.io/controller-runtime/pkg/runtime/signals",
     "sigs.k8s.io/controller-runtime/pkg/source",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,6 +56,10 @@ required = [
   name = "github.com/storageos/go-api"
   branch = "master"
 
+[[constraint]]
+  name = "github.com/blang/semver"
+  version = "v3.6.1"
+
 [prune]
   go-tests = true
   non-go = true

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Parameter | Description | Default
 `disableTelemetry` | Disable telemetry reports | `false`
 `disableTCMU` | Disable TCMU to allow co-existence with other storage systems but degrades performance | `false`
 `forceTCMU` | Forces TCMU to be enabled or causes StorageOS to abort startup | `false`
+`disableScheduler` | Disable StorageOS scheduler for data locality | `false`
 `nodeSelectorTerms` | Set node selector for storageos pod placement |
 `tolerations` | Set pod tolerations for storageos pod placement |
 `resources` | Set resource requirements for the containers |

--- a/deploy/crds/storageos_v1_storageoscluster_cr.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_cr.yaml
@@ -19,6 +19,7 @@ spec:
   #   csiExternalProvisionerContainer:
   #   csiExternalAttacherContainer:
   #   csiLivenessProbeContainer:
+  #   hyperkubeContainer:
   csi:
     enable: true
   #   endpoint: /var/lib/kubelet/device-plugins/
@@ -76,7 +77,7 @@ spec:
   # disableFencing: false
   # disableTCMU: false
   # forceTCMU: false
-
+  # disableScheduler: false
 
 ---
 apiVersion: v1

--- a/deploy/crds/storageos_v1_storageoscluster_crd.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_crd.yaml
@@ -49,6 +49,8 @@ spec:
               type: boolean
             forceTCMU:
               type: boolean
+            disableScheduler:
+              type: boolean
             images:
               properties:
                 nodeContainer:

--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -192,6 +192,7 @@ spec:
           - statefulsets
           - daemonsets
           - deployments
+          - replicasets
           verbs:
           - '*'
         - apiGroups:
@@ -203,6 +204,7 @@ spec:
           - watch
           - get
           - update
+          - create
         - apiGroups:
           - ""
           resources:
@@ -214,6 +216,7 @@ spec:
           - update
           - patch
           - delete
+          - create
         - apiGroups:
           - ""
           resources:
@@ -224,6 +227,10 @@ spec:
           - services
           - persistentvolumeclaims
           - persistentvolumes
+          - configmaps
+          - replicationcontrollers
+          - pods/binding
+          - endpoints
           verbs:
           - create
           - patch
@@ -269,6 +276,13 @@ spec:
           verbs:
           - create
           - delete
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - list
+          - watch
         - apiGroups:
           - security.openshift.io
           resources:
@@ -407,6 +421,11 @@ spec:
           be desired.
         displayName: Force TCMU
         path: forceTCMU
+      - description: Disable StorageOS scheduler deployment. StorageOS scheduler helps
+          improve the scheduling decision of a pod, considering the location of volumes
+          and their replicas.
+        displayName: Disable Scheduler
+        path: disableScheduler
       - description: When enabled, the Operator will not perform any actions on the
           cluster.
         displayName: Pause Operator

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -192,6 +192,7 @@ spec:
           - statefulsets
           - daemonsets
           - deployments
+          - replicasets
           verbs:
           - '*'
         - apiGroups:
@@ -203,6 +204,7 @@ spec:
           - watch
           - get
           - update
+          - create
         - apiGroups:
           - ""
           resources:
@@ -214,6 +216,7 @@ spec:
           - update
           - patch
           - delete
+          - create
         - apiGroups:
           - ""
           resources:
@@ -224,6 +227,10 @@ spec:
           - services
           - persistentvolumeclaims
           - persistentvolumes
+          - configmaps
+          - replicationcontrollers
+          - pods/binding
+          - endpoints
           verbs:
           - create
           - patch
@@ -269,6 +276,13 @@ spec:
           verbs:
           - create
           - delete
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - list
+          - watch
         - apiGroups:
           - security.openshift.io
           resources:
@@ -407,6 +421,11 @@ spec:
           be desired.
         displayName: Force TCMU
         path: forceTCMU
+      - description: Disable StorageOS scheduler deployment. StorageOS scheduler helps
+          improve the scheduling decision of a pod, considering the location of volumes
+          and their replicas.
+        displayName: Disable Scheduler
+        path: disableScheduler
       - description: When enabled, the Operator will not perform any actions on the
           cluster.
         displayName: Pause Operator

--- a/deploy/olm/storageos/storageoscluster.crd.yaml
+++ b/deploy/olm/storageos/storageoscluster.crd.yaml
@@ -49,6 +49,8 @@ spec:
               type: boolean
             forceTCMU:
               type: boolean
+            disableScheduler:
+              type: boolean
             images:
               properties:
                 nodeContainer:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -17,6 +17,7 @@ rules:
   - statefulsets
   - daemonsets
   - deployments
+  - replicasets
   verbs:
   - "*"
 - apiGroups:
@@ -28,6 +29,7 @@ rules:
   - watch
   - get
   - update
+  - create
 - apiGroups:
   - ""
   resources:
@@ -39,6 +41,7 @@ rules:
   - update
   - patch
   - delete
+  - create
 - apiGroups:
   - ""
   resources:
@@ -49,6 +52,10 @@ rules:
   - services
   - persistentvolumeclaims
   - persistentvolumes
+  - configmaps
+  - replicationcontrollers
+  - pods/binding
+  - endpoints
   verbs:
   - create
   - patch
@@ -94,6 +101,13 @@ rules:
   verbs:
   - create
   - delete
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
 # OpenShift specific rule.
 - apiGroups:
   - security.openshift.io

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -653,6 +653,11 @@ data:
                 drawbacks, this may not always be desired.
               displayName: Force TCMU
               path: forceTCMU
+            - description: Disable StorageOS scheduler deployment. StorageOS scheduler
+                helps improve the scheduling decision of a pod, considering the location
+                of volumes and their replicas.
+              displayName: Disable Scheduler
+              path: disableScheduler
             - description: When enabled, the Operator will not perform any actions on
                 the cluster.
               displayName: Pause Operator

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -58,6 +58,8 @@ data:
                     type: boolean
                   forceTCMU:
                     type: boolean
+                  disableScheduler:
+                    type: boolean
                   images:
                     properties:
                       nodeContainer:
@@ -419,6 +421,7 @@ data:
                 - statefulsets
                 - daemonsets
                 - deployments
+                - replicasets
                 verbs:
                 - "*"
               - apiGroups:
@@ -430,6 +433,7 @@ data:
                 - watch
                 - get
                 - update
+                - create
               - apiGroups:
                 - ""
                 resources:
@@ -441,6 +445,7 @@ data:
                 - update
                 - patch
                 - delete
+                - create
               - apiGroups:
                 - ""
                 resources:
@@ -451,6 +456,10 @@ data:
                 - services
                 - persistentvolumeclaims
                 - persistentvolumes
+                - configmaps
+                - replicationcontrollers
+                - pods/binding
+                - endpoints
                 verbs:
                 - create
                 - patch
@@ -496,6 +505,13 @@ data:
                 verbs:
                 - create
                 - delete
+              - apiGroups:
+                - policy
+                resources:
+                - poddisruptionbudgets
+                verbs:
+                - list
+                - watch
               - apiGroups:
                 - security.openshift.io
                 resources:

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -39,6 +39,8 @@ const (
 	CSIv0ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v0.4.2"
 	CSIv0ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v0.4.2"
 
+	DefaultHyperkubeContainerRegistry = "gcr.io/google_containers/hyperkube"
+
 	DefaultPluginRegistrationPath = "/var/lib/kubelet/plugins_registry"
 	OldPluginRegistrationPath     = "/var/lib/kubelet/plugins"
 
@@ -185,6 +187,9 @@ type StorageOSClusterSpec struct {
 	// distribution information will also be included in the product telemetry
 	// (if enabled), to help focus development efforts.
 	K8sDistro string `json:"k8sDistro"`
+
+	// Disable StorageOS scheduler extender.
+	DisableScheduler bool `json:"disableScheduler"`
 }
 
 // StorageOSClusterStatus defines the observed state of StorageOSCluster
@@ -305,6 +310,17 @@ func (s StorageOSClusterSpec) GetCSILivenessProbeImage() string {
 		return s.Images.CSILivenessProbeContainer
 	}
 	return CSIv1LivenessProbeContainerImage
+}
+
+// GetHyperkubeImage returns hyperkube container image for a given k8s version.
+// If an image is set explicitly in the cluster configuration, that image is
+// returned.
+func (s StorageOSClusterSpec) GetHyperkubeImage(k8sVersion string) string {
+	if s.Images.HyperkubeContainer != "" {
+		return s.Images.HyperkubeContainer
+	}
+	// Add version prefix "v" in the tag.
+	return fmt.Sprintf("%s:v%s", DefaultHyperkubeContainerRegistry, k8sVersion)
 }
 
 // GetServiceName returns the service name.
@@ -460,6 +476,7 @@ type ContainerImages struct {
 	CSIExternalProvisionerContainer    string `json:"csiExternalProvisionerContainer"`
 	CSIExternalAttacherContainer       string `json:"csiExternalAttacherContainer"`
 	CSILivenessProbeContainer          string `json:"csiLivenessProbeContainer"`
+	HyperkubeContainer                 string `json:"hyperkubeContainer"`
 }
 
 // StorageOSClusterCSI contains CSI configurations.

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -191,6 +191,10 @@ func (r *ReconcileStorageOSCluster) reconcile(m *storageosv1.StorageOSCluster) e
 	m.Spec.Images.NodeContainer = m.Spec.GetNodeContainerImage()
 	m.Spec.Images.InitContainer = m.Spec.GetInitContainerImage()
 
+	if !m.Spec.DisableScheduler {
+		m.Spec.Images.HyperkubeContainer = m.Spec.GetHyperkubeImage(r.k8sVersion)
+	}
+
 	if m.Spec.CSI.Enable {
 		m.Spec.Images.CSINodeDriverRegistrarContainer = m.Spec.GetCSINodeDriverRegistrarImage(storageos.CSIV1Supported(r.k8sVersion))
 		if storageos.CSIV1Supported((r.k8sVersion)) {

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -40,7 +40,7 @@ func Add(mgr manager.Manager) error {
 
 	log.WithValues("k8s", version).Info("Adding cluster controller")
 
-	return add(mgr, newReconciler(mgr, strings.TrimLeft(version, "v")))
+	return add(mgr, newReconciler(mgr, version))
 }
 
 // newReconciler returns a new reconcile.Reconciler

--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -248,49 +248,15 @@ func (s Deployment) csiHelperVolumes() []corev1.Volume {
 	}
 }
 
-// getCSIHelperStatefulSet returns the CSI helper StatefulSet resource.
-func (s Deployment) getCSIHelperStatefulSet(name string) *appsv1.StatefulSet {
-	return &appsv1.StatefulSet{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "StatefulSet",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: s.stos.Spec.GetResourceNS(),
-			Labels: map[string]string{
-				"app": "storageos",
-			},
-		},
-	}
-}
-
-// getCSIHelperDeployment returns the CSI helper Deployment resource.
-func (s Deployment) getCSIHelperDeployment(name string) *appsv1.Deployment {
-	return &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: s.stos.Spec.GetResourceNS(),
-			Labels: map[string]string{
-				"app": "storageos",
-			},
-		},
-	}
-}
-
 // deleteCSIHelper deletes the CSI helper based on the cluster configuration.
 func (s Deployment) deleteCSIHelper() error {
 	// The names of CSI helpers are fixed. Using the appropriate names for the
 	// different kinds.
 	switch s.stos.Spec.GetCSIDeploymentStrategy() {
 	case deploymentKind:
-		return s.deleteObject(s.getCSIHelperDeployment(csiHelperName))
+		return s.deleteObject(s.getDeploymentByName(csiHelperName))
 	default:
-		return s.deleteObject(s.getCSIHelperStatefulSet(statefulsetName))
+		return s.deleteObject(s.getStatefulSetByName(statefulsetName))
 	}
 }
 

--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -118,28 +118,6 @@ func (s Deployment) addCommonPodProperties(podSpec *corev1.PodSpec) error {
 	return nil
 }
 
-// addPodTolerationForRecovery adds pod tolerations for cases when a node isn't
-// functional. Usually k8s toleration seconds is five minutes. This sets the
-// toleration seconds to 30 seconds.
-func addPodTolerationForRecovery(podSpec *corev1.PodSpec) {
-	tolerationSeconds := int64(30)
-	recoveryTolerations := []corev1.Toleration{
-		{
-			Effect:            corev1.TaintEffectNoExecute,
-			Key:               nodeNotReadyTolKey,
-			Operator:          corev1.TolerationOpExists,
-			TolerationSeconds: &tolerationSeconds,
-		},
-		{
-			Effect:            corev1.TaintEffectNoExecute,
-			Key:               nodeUnreachableTolKey,
-			Operator:          corev1.TolerationOpExists,
-			TolerationSeconds: &tolerationSeconds,
-		},
-	}
-	podSpec.Tolerations = append(podSpec.Tolerations, recoveryTolerations...)
-}
-
 // csiHelperContainers returns a list of containers that should be part of the
 // CSI helper pods.
 func (s Deployment) csiHelperContainers() []corev1.Container {

--- a/pkg/storageos/delete.go
+++ b/pkg/storageos/delete.go
@@ -80,6 +80,12 @@ func (s *Deployment) Delete() error {
 		}
 	}
 
+	if !s.stos.Spec.DisableScheduler {
+		if err := s.deleteSchedulerExtender(); err != nil {
+			return err
+		}
+	}
+
 	// Delete cluster role for openshift security context constraints.
 	if strings.Contains(s.stos.Spec.K8sDistro, k8sDistroOpenShift) {
 		if err := s.deleteClusterRoleBinding(OpenShiftSCCClusterBindingName); err != nil {

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -82,6 +82,9 @@ func (s Deployment) schedulerDeployment(replicas int32) *appsv1.Deployment {
 		},
 	}
 
+	// Add pod toleration for quick recovery on node failure.
+	addPodTolerationForRecovery(&dep.Spec.Template.Spec)
+
 	return dep
 }
 

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -1,0 +1,280 @@
+package storageos
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	policyConfigMapName          = "storageos-scheduler-policy"
+	policyConfigKey              = "policy.cfg"
+	schedulerConfigConfigMapName = "storageos-scheduler-config"
+	schedulerConfigKey           = "config.yaml"
+
+	// schedulerReplicas is the number of instances of kube-scheduler.
+	schedulerReplicas = 1
+)
+
+func (s *Deployment) createSchedulerExtender() error {
+	// Create configmap with scheduler configuration and policy.
+	if err := s.createSchedulerPolicy(); err != nil {
+		return err
+	}
+	if err := s.createSchedulerConfiguration(); err != nil {
+		return err
+	}
+
+	// Create RBAC related resources.
+	if err := s.createClusterRoleForScheduler(); err != nil {
+		return err
+	}
+	if err := s.createServiceAccountForScheduler(); err != nil {
+		return err
+	}
+	if err := s.createClusterRoleBindingForScheduler(); err != nil {
+		return err
+	}
+
+	// Replicas of kube-scheduler deployment.
+	replicas := int32(schedulerReplicas)
+
+	// Create the deployment.
+	schedulerDeployment := s.schedulerDeployment(replicas)
+	return s.createOrUpdateObject(schedulerDeployment)
+}
+
+// schedulerDeployment returns a scheduler extender Deployment object. This
+// contains the deployment configuration of the external kube-scheduler.
+func (s Deployment) schedulerDeployment(replicas int32) *appsv1.Deployment {
+	podLabels := podLabelsForScheduler(s.stos.Name)
+	dep := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      schedulerExtenderName,
+			Namespace: s.stos.Spec.GetResourceNS(),
+			Labels: map[string]string{
+				"app": "storageos",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: podLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: SchedulerSA,
+					Containers:         s.schedulerContainers(),
+					Volumes:            s.schedulerVolumes(),
+				},
+			},
+		},
+	}
+
+	return dep
+}
+
+// schedulerContainers returns a list of containers that should be part of the
+// scheduler extender deployment.
+func (s Deployment) schedulerContainers() []corev1.Container {
+	return []corev1.Container{
+		{
+			Image:           s.stos.Spec.GetHyperkubeImage(s.k8sVersion),
+			Name:            "storageos-scheduler",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Args: []string{
+				"kube-scheduler",
+				"--config=/storageos-scheduler/config.yaml",
+				"-v=4",
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "storageos-scheduler-config",
+					MountPath: "/storageos-scheduler",
+				},
+			},
+		},
+	}
+}
+
+// schedulerVolumes returns a list of volumes that should be part of the
+// scheduler extender deployment.
+func (s Deployment) schedulerVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: schedulerConfigConfigMapName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: schedulerConfigConfigMapName},
+				},
+			},
+		},
+	}
+}
+
+// deleteSchedulerExtender deletes all the scheduler related resources.
+func (s Deployment) deleteSchedulerExtender() error {
+	if err := s.deleteObject(s.getDeploymentByName(schedulerExtenderName)); err != nil {
+		return err
+	}
+	if err := s.deleteObject(s.getConfigMap(policyConfigMapName)); err != nil {
+		return err
+	}
+	if err := s.deleteObject(s.getConfigMap(schedulerConfigConfigMapName)); err != nil {
+		return err
+	}
+	if err := s.deleteClusterRoleBinding(SchedulerClusterBindingName); err != nil {
+		return err
+	}
+	if err := s.deleteServiceAccount(SchedulerSA); err != nil {
+		return err
+	}
+	if err := s.deleteClusterRole(SchedulerClusterRoleName); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getConfigMap returns an empty ConfigMap object. This can be used while
+// creating a configmap resource.
+func (s Deployment) getConfigMap(name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: s.stos.Spec.GetResourceNS(),
+		},
+	}
+}
+
+// schedulerPolicyTemplate contains fields for rendering the scheduler policy.
+type schedulerPolicyTemplate struct {
+	FilterVerb     string
+	PrioritizeVerb string
+	EnableHTTPS    bool
+	URLPrefix      string
+}
+
+// createSchedulerPolicy creates a configmap with kube-scheduler policy.
+func (s Deployment) createSchedulerPolicy() error {
+	policyConfigMap := s.getConfigMap(policyConfigMapName)
+	policyConfigurationTemplate := `
+    {
+      "kind" : "Policy",
+      "apiVersion" : "v1",
+      "predicates" : [
+        {"name" : "PodFitsHostPorts"},
+        {"name" : "PodFitsResources"},
+        {"name" : "NoDiskConflict"},
+        {"name" : "MatchNodeSelector"},
+        {"name" : "HostName"}
+      ],
+      "extenders" : [{
+        "urlPrefix": "{{.URLPrefix}}",
+        "filterVerb": "{{.FilterVerb}}",
+        "prioritizeVerb": "{{.PrioritizeVerb}}",
+        "weight": 1,
+        "enableHttps": {{.EnableHTTPS}},
+        "nodeCacheCapable": false
+      }]
+    }
+`
+	// Service address format: <service-name>.<namespace>.svc.cluster.local.
+	serviceEndpoint := fmt.Sprintf("%s.%s.svc.cluster.local", s.stos.Spec.GetServiceName(), s.stos.Spec.GetResourceNS())
+	policyData := schedulerPolicyTemplate{
+		FilterVerb:     "filter",
+		PrioritizeVerb: "prioritize",
+		EnableHTTPS:    false,
+		URLPrefix:      fmt.Sprintf("http://%s:5705/v1/scheduler", serviceEndpoint),
+	}
+
+	// Render the policy configuration.
+	var policyConfig bytes.Buffer
+	tmpl, err := template.New("policyConfig").Parse(policyConfigurationTemplate)
+	if err != nil {
+		return err
+	}
+	if err := tmpl.Execute(&policyConfig, policyData); err != nil {
+		return err
+	}
+
+	// Add the policy configuration in the configmap.
+	policyConfigMap.Data = map[string]string{
+		"policy.cfg": policyConfig.String(),
+	}
+	return s.createOrUpdateObject(policyConfigMap)
+}
+
+// schedulerConfigTemplate contains fields for rendering the scheduler
+// configuration.
+type schedulerConfigTemplate struct {
+	SchedulerName  string
+	PolicyName     string
+	Namespace      string
+	LeaderElection bool
+}
+
+// createSchedulerConfiguration creates a configmap with kube-scheduler
+// configuration.
+func (s Deployment) createSchedulerConfiguration() error {
+	configConfigMap := s.getConfigMap(schedulerConfigConfigMapName)
+	configTemplate := `
+    apiVersion: "kubescheduler.config.k8s.io/v1alpha1"
+    kind: KubeSchedulerConfiguration
+    schedulerName: {{.SchedulerName}}
+    algorithmSource:
+      policy:
+        configMap:
+          namespace: {{.Namespace}}
+          name: {{.PolicyName}}
+    leaderElection:
+      leaderElect: {{.LeaderElection}}
+      lockObjectName: {{.SchedulerName}}
+      lockObjectNamespace: {{.Namespace}}
+`
+	schedConfigData := schedulerConfigTemplate{
+		SchedulerName:  schedulerExtenderName,
+		PolicyName:     policyConfigMapName,
+		Namespace:      s.stos.Spec.GetResourceNS(),
+		LeaderElection: true,
+	}
+
+	// Render the scheduler configuration.
+	var schedConfig bytes.Buffer
+	tmpl, err := template.New("schedConfig").Parse(configTemplate)
+	if err != nil {
+		return err
+	}
+	if err := tmpl.Execute(&schedConfig, schedConfigData); err != nil {
+		return err
+	}
+
+	// Add the configuration in the configmap.
+	configConfigMap.Data = map[string]string{
+		"config.yaml": schedConfig.String(),
+	}
+	return s.createOrUpdateObject(configConfigMap)
+}
+
+// podLabelsForScheduler returns labels for the scheduler pod.
+func podLabelsForScheduler(name string) map[string]string {
+	return map[string]string{
+		"app":          appName,
+		"storageos_cr": name,
+		"kind":         deploymentKind,
+	}
+}

--- a/pkg/util/k8sutil/k8sutil_test.go
+++ b/pkg/util/k8sutil/k8sutil_test.go
@@ -1,0 +1,55 @@
+package k8sutil
+
+import (
+	"testing"
+)
+
+func TestGetBaseK8SVersion(t *testing.T) {
+
+	testcases := []struct {
+		name        string
+		version     string
+		wantVersion string
+	}{
+		{
+			name:        "simple base version",
+			version:     "v1.14.1",
+			wantVersion: "1.14.1",
+		},
+		{
+			name:        "version with dash",
+			version:     "v1.14.1-gke-qnxo4",
+			wantVersion: "1.14.1",
+		},
+		{
+			name:        "version with plus",
+			version:     "v1.14.1+nxiel",
+			wantVersion: "1.14.1",
+		},
+		{
+			name:        "version with no prefix",
+			version:     "1.14.1-aks-foo",
+			wantVersion: "1.14.1",
+		},
+		{
+			// https://github.com/blang/semver/issues/55 patch value 0 case.
+			name:        "version with patch 0",
+			version:     "v1.11.0+d4cacc0",
+			wantVersion: "1.11.0",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			k := K8SOps{}
+			version, err := k.getBaseK8SVersion(tc.version)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if version != tc.wantVersion {
+				t.Errorf("unexpected k8s version:\n\t(WNT) %q\n\t(GOT) %q", tc.wantVersion, version)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds deployment of an external scheduler using kube-scheduler as a
Deployment. This is automatically deployed by default. For a workload to
use storageos scheduler, the pod spec must have `schedulerName` set to
`storageos-scheduler`.

Adds a new StorageOSCluster spec property `disableScheduler` to disable
the scheduler. Also adds `image.hyperkubeContainer` to set the hyperkube
container image to use. By default, `gcr.io/google_containers/hyperkube`
is the container image used for hyperkube. The image tag depends on
the version of kubernetes cluster running.