### PR TITLE
Use logger from controller-runtime package

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"log"
+	"os"
 	"runtime"
 
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
@@ -11,17 +11,23 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
-func printVersion() {
-	log.Printf("Go Version: %s", runtime.Version())
-	log.Printf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
-	log.Printf("operator-sdk Version: %v", sdkVersion.Version)
-}
+var log = logf.Log.WithName("setup")
 
 func main() {
-	printVersion()
+
+	logf.SetLogger(logf.ZapLogger(true))
+
+	log.WithValues(
+		"goversion", runtime.Version(),
+		"os", runtime.GOOS,
+		"arch", runtime.GOARCH,
+		"operator-sdk", sdkVersion.Version,
+	).Info("Initializing")
+
 	flag.Parse()
 
 	// TODO: Expose metrics port after SDK uses controller-runtime's dynamic client
@@ -30,30 +36,35 @@ func main() {
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Fatal(err)
+		fatal(err)
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
 	// Use "" namespace to watch all the namespaces.
 	mgr, err := manager.New(cfg, manager.Options{Namespace: ""})
 	if err != nil {
-		log.Fatal(err)
+		fatal(err)
 	}
 
-	log.Print("Registering Components.")
+	log.Info("Registering Components")
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatal(err)
+		fatal(err)
 	}
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
-		log.Fatal(err)
+		fatal(err)
 	}
 
-	log.Print("Starting the Cmd.")
+	log.Info("Starting the Cmd")
 
 	// Start the Cmd
-	log.Fatal(mgr.Start(signals.SetupSignalHandler()))
+	fatal(mgr.Start(signals.SetupSignalHandler()))
+}
+
+func fatal(err error) {
+	log.Error(err, "Fatal error")
+	os.Exit(1)
 }

--- a/cmd/upgrader/main.go
+++ b/cmd/upgrader/main.go
@@ -1,37 +1,47 @@
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/storageos/cluster-operator/pkg/util/k8sutil"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
+var log = logf.Log.WithName("upgrader")
+
 func main() {
+
+	var log = logf.Log.WithName("upgrader")
+
 	cfg, err := restclient.InClusterConfig()
 	if err != nil {
-		log.Fatal(err)
+		fatal(err)
 	}
 
 	client := kubernetes.NewForConfigOrDie(cfg)
-	kops := k8sutil.NewK8SOps(client)
+	kops := k8sutil.NewK8SOps(client, log)
 
 	newImage := os.Getenv("NEW_IMAGE")
 
 	// Scale down the applications.
 	if err = kops.ScaleDownApps(); err != nil {
-		log.Fatal(err)
+		fatal(err)
 	}
 
 	// Update the storageos nodes.
 	if err = kops.UpgradeDaemonSet(newImage); err != nil {
-		log.Fatal(err)
+		fatal(err)
 	}
 
 	// Scale up the applications.
 	if err = kops.ScaleUpApps(); err != nil {
-		log.Fatal(err)
+		fatal(err)
 	}
+}
+
+func fatal(err error) {
+	log.Error(err, "Fatal error")
+	os.Exit(1)
 }

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -19,17 +19,17 @@ import (
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = ctrl.Log.WithName("job")
+var log = logf.Log.WithName("job")
 
 // Add creates a new Job Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -23,6 +23,8 @@ import (
 	storageosapi "github.com/storageos/go-api"
 	storageostypes "github.com/storageos/go-api/types"
 )
+
+var log = ctrl.Log.WithName("node")
 
 // Node controller errors.
 var (
@@ -69,7 +71,9 @@ type ReconcileNode struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	// log.Printf("Reconciling Node %s/%s\n", request.Namespace, request.Name)
+
+	log := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	// log.Info("Reconciling Node")
 
 	reconcilePeriod := 5 * time.Second
 	reconcileResult := reconcile.Result{RequeueAfter: reconcilePeriod}
@@ -96,7 +100,7 @@ func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, 
 			return reconcile.Result{}, nil
 		}
 		// Requeue the request in order to retry getting the cluster.
-		log.Println("failed to find current cluster:", err)
+		log.Error(err, "failed to find current cluster")
 		return reconcileResult, err
 	}
 
@@ -109,14 +113,14 @@ func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, 
 		r.stosClient.clusterUID != cluster.GetUID() {
 
 		if err := r.setClientForCluster(cluster); err != nil {
-			log.Println("failed to configure api client:", err)
+			log.Error(err, "failed to configure api client")
 			return reconcileResult, err
 		}
 	}
 
 	// Sync labels to StorageOS node object.
 	if err = r.syncLabels(instance.Name, instance.Labels); err != nil {
-		log.Println("failed to sync labels:", err)
+		log.Error(err, "failed to sync labels, api may not be ready")
 		// Error syncing labels - requeue the request.
 		return reconcileResult, err
 	}

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -11,12 +11,12 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
@@ -24,7 +24,7 @@ import (
 	storageostypes "github.com/storageos/go-api/types"
 )
 
-var log = ctrl.Log.WithName("node")
+var log = logf.Log.WithName("node")
 
 // Node controller errors.
 var (

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -16,16 +16,16 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = ctrl.Log.WithName("cluster")
+var log = logf.Log.WithName("cluster")
 
 // Add creates a new StorageOSCluster Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/storageosupgrade/storageosupgrade_controller.go
+++ b/pkg/controller/storageosupgrade/storageosupgrade_controller.go
@@ -15,19 +15,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	storageosapi "github.com/storageos/go-api"
 )
 
-var log = ctrl.Log.WithName("upgrade")
+var log = logf.Log.WithName("upgrade")
 
 var (
 	// operatorImage is the image name of controller-operator. This is needed

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -11,7 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 const (
@@ -73,7 +73,7 @@ const (
 	k8sDistroOpenShift = "openshift"
 )
 
-var log = ctrl.Log.WithName("cluster")
+var log = logf.Log.WithName("cluster")
 
 // Deploy deploys storageos by creating all the resources needed to run storageos.
 func (s *Deployment) Deploy() error {

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -3,7 +3,6 @@ package storageos
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/blang/semver"
@@ -12,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const (
@@ -72,6 +72,8 @@ const (
 	// k8s distribution vendor specific keywords.
 	k8sDistroOpenShift = "openshift"
 )
+
+var log = ctrl.Log.WithName("cluster")
 
 // Deploy deploys storageos by creating all the resources needed to run storageos.
 func (s *Deployment) Deploy() error {
@@ -239,13 +241,13 @@ func CSIV1Supported(version string) bool {
 func versionSupported(haveVersion, wantVersion string) bool {
 	supportedVersion, err := semver.Parse(wantVersion)
 	if err != nil {
-		log.Printf("failed to parse version: %v", err)
+		log.Error(err, "failed to parse version", "want", wantVersion)
 		return false
 	}
 
 	currentVersion, err := semver.Parse(haveVersion)
 	if err != nil {
-		log.Printf("failed to parse version: %v", err)
+		log.Error(err, "failed to parse version", "have", haveVersion)
 		return false
 	}
 

--- a/pkg/storageos/update_status.go
+++ b/pkg/storageos/update_status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"reflect"
 	"strings"
@@ -13,7 +12,7 @@ import (
 	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 	storageosapi "github.com/storageos/go-api"
 	"github.com/storageos/go-api/types"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func (s *Deployment) updateStorageOSStatus(status *storageosv1.StorageOSClusterStatus) error {
@@ -46,6 +45,7 @@ func (s *Deployment) updateStorageOSStatus(status *storageosv1.StorageOSClusterS
 // getStorageOSStatus queries health of all the nodes in the join token and
 // returns the cluster status.
 func (s *Deployment) getStorageOSStatus() (*storageosv1.StorageOSClusterStatus, error) {
+
 	var totalNodes, readyNodes int
 
 	// Create an empty array because it's used to create cluster status. An
@@ -72,7 +72,7 @@ func (s *Deployment) getStorageOSStatus() (*storageosv1.StorageOSClusterStatus, 
 				memberStatus.Unready = append(memberStatus.Unready, node)
 			}
 		} else {
-			log.Printf("failed to get health of node %s: %v", node, err)
+			log.WithValues("node", node).Info("api not ready, retrying")
 		}
 	}
 

--- a/pkg/util/task/task.go
+++ b/pkg/util/task/task.go
@@ -2,8 +2,9 @@ package task
 
 import (
 	"errors"
-	"log"
 	"time"
+
+	"github.com/go-logr/logr"
 )
 
 // ErrTimedOut is returned when an operation times out
@@ -12,7 +13,7 @@ var ErrTimedOut = errors.New("timed out performing task")
 // DoRetryWithTimeout performs given task with given timeout and timeBeforeRetry.
 // The function t returns a result out, a boolean to retry, and an error
 // containing the reason for failure.
-func DoRetryWithTimeout(t func() (interface{}, bool, error), timeout, timeBeforeRetry time.Duration) (interface{}, error) {
+func DoRetryWithTimeout(t func() (interface{}, bool, error), timeout, timeBeforeRetry time.Duration, log logr.Logger) (interface{}, error) {
 	done := make(chan bool, 1)
 	quit := make(chan bool, 1)
 	var out interface{}
@@ -35,7 +36,7 @@ func DoRetryWithTimeout(t func() (interface{}, bool, error), timeout, timeBefore
 					return
 				}
 
-				log.Printf("%v Next retry in: %v", err, timeBeforeRetry)
+				log.Error(err, "task failed", "retrying in", timeBeforeRetry.String())
 				time.Sleep(timeBeforeRetry)
 			}
 


### PR DESCRIPTION
The recommended logger for Operators is in the controller-runtime package, but we could never get it to work.  Turns out we needed to use `logf.SetLogger()`, but this wasn't clear from the examples.

This PR enables it and converts the `log.Printf()` messages to use it.  I'll do separate PRs to update the other controllers and add a bit more verbosity where needed.  This was kept minimal to hopefully avoid conflicts with the other PRs in progress.

Sample new messages:
```
simon@wkstn05:~/go/src/github.com/storageos/cluster-operator$ ko logs pod/storageos-cluster-operator-66c5c7c6f5-l986r
2019-06-24T11:00:46.931Z	INFO	setup	Initializing	{"goversion": "go1.12.5", "os": "linux", "arch": "amd64", "operator-sdk": "v0.8.0"}
2019-06-24T11:00:47.005Z	INFO	setup	Registering Components
2019-06-24T11:00:47.007Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "job-controller", "source": "kind source: /, Kind="}
2019-06-24T11:00:47.007Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "job-controller", "source": "kind source: /, Kind="}
2019-06-24T11:00:47.008Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "node-controller", "source": "kind source: /, Kind="}
2019-06-24T11:00:47.011Z	INFO	cluster	Adding cluster controller	{"k8s": "v1.16.0-alpha.0.615+6d9f4659d8712a-dirty"}
2019-06-24T11:00:47.012Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "storageoscluster-controller", "source": "kind source: /, Kind="}
2019-06-24T11:00:47.012Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "storageosupgrade-controller", "source": "kind source: /, Kind="}
2019-06-24T11:00:47.012Z	INFO	setup	Starting the Cmd
2019-06-24T11:00:47.113Z	INFO	kubebuilder.controller	Starting Controller	{"controller": "job-controller"}
2019-06-24T11:00:47.113Z	INFO	kubebuilder.controller	Starting Controller	{"controller": "storageoscluster-controller"}
2019-06-24T11:00:47.113Z	INFO	kubebuilder.controller	Starting Controller	{"controller": "storageosupgrade-controller"}
2019-06-24T11:00:47.113Z	INFO	kubebuilder.controller	Starting Controller	{"controller": "node-controller"}
2019-06-24T11:00:47.213Z	INFO	kubebuilder.controller	Starting workers	{"controller": "job-controller", "worker count": 1}
2019-06-24T11:00:47.213Z	INFO	kubebuilder.controller	Starting workers	{"controller": "storageosupgrade-controller", "worker count": 1}
2019-06-24T11:00:47.213Z	INFO	kubebuilder.controller	Starting workers	{"controller": "node-controller", "worker count": 1}
2019-06-24T11:00:47.213Z	INFO	kubebuilder.controller	Starting workers	{"controller": "storageoscluster-controller", "worker count": 1}
2019-06-24T11:00:47.214Z	DEBUG	kubebuilder.controller	Successfully Reconciled	{"controller": "node-controller", "request": "/wkstn05"}
2019-06-24T11:00:59.978Z	INFO	cluster	Reconciling Cluster	{"Request.Namespace": "default", "Request.Name": "example-storageoscluster"}
2019/06/24 11:01:00 failed to get health of node 10.1.5.56: Get http://10.1.5.56:5705/v1/health: dial tcp 10.1.5.56:5705: connect: connection refused
2019-06-24T11:01:00.446Z	DEBUG	kubebuilder.manager.events	Warning	{"object": {"kind":"StorageOSCluster","namespace":"default","name":"example-storageoscluster","uid":"e0c6f046-0789-4705-92b1-fa0ce5e1d7bb","apiVersion":"storageos.com/v1","resourceVersion":"143708"}, "reason": "ChangedStatus", "message": "0/1 StorageOS nodes are functional"}
2019-06-24T11:01:00.452Z	INFO	cluster	Reconciling Cluster	{"Request.Namespace": "default", "Request.Name": "example-storageoscluster"}
2019/06/24 11:01:00 failed to get health of node 10.1.5.56: Get http://10.1.5.56:5705/v1/health: dial tcp 10.1.5.56:5705: connect: connection refused
2019-06-24T11:01:00.824Z	INFO	cluster	Reconciling Cluster	{"Request.Namespace": "default", "Request.Name": "example-storageoscluster"}
2019/06/24 11:01:01 failed to get health of node 10.1.5.56: Get http://10.1.5.56:5705/v1/health: dial tcp 10.1.5.56:5705: connect: connection refused
2019-06-24T11:01:12.357Z	DEBUG	kubebuilder.controller	Successfully Reconciled	{"controller": "node-controller", "request": "/wkstn05"}
2019-06-24T11:01:12.386Z	DEBUG	kubebuilder.controller	Successfully Reconciled	{"controller": "node-controller", "request": "/wkstn05"}
2019-06-24T11:01:15.452Z	INFO	cluster	Reconciling Cluster	{"Request.Namespace": "default", "Request.Name": "example-storageoscluster"}
2019-06-24T11:01:15.725Z	DEBUG	kubebuilder.manager.events	Normal	{"object": {"kind":"StorageOSCluster","namespace":"default","name":"example-storageoscluster","uid":"e0c6f046-0789-4705-92b1-fa0ce5e1d7bb","apiVersion":"storageos.com/v1","resourceVersion":"143750"}, "reason": "ChangedStatus", "message": "1/1 StorageOS nodes are functional. Cluster healthy"}
2019-06-24T11:01:15.736Z	INFO	cluster	Reconciling Cluster	{"Request.Namespace": "default", "Request.Name": "example-storageoscluster"}
2019-06-24T11:01:30.736Z	INFO	cluster	Reconciling Cluster	{"Request.Namespace": "default", "Request.Name": "example-storageoscluster"}
```