### PR TITLE
Fix metadata zip generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@ MACHINE = $(shell uname -m)
 BUILD_IMAGE = golang:1.12.5
 BASE_IMAGE = storageos/base-image:0.1.0
 
+# OLM release versions(StorageOS operator) are required to creating redhat
+# operator metadata zip. The zip must have the previous version and the new
+# version CSVs. For operator to upgrade, CSV of the previous release, that's
+# referred in the replaces field of CSV, must also be included in the zip.
+OLM_PREVIOUS_VERSION = 1.1.0
+OLM_CURRENT_VERSION = 1.2.0
+
 # When this file name is modified, the new name must be added in .travis.yml
 # file as well for publishing the file at release.
 METADATA_FILE = storageos-olm-metadata.zip
@@ -80,7 +87,8 @@ metadata-zip:
 		deploy/olm/storageos/storageoscluster.crd.yaml \
 		deploy/olm/storageos/storageosjob.crd.yaml \
 		deploy/olm/storageos/storageosupgrade.crd.yaml \
-		deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+		deploy/olm/csv-rhel/storageos.v$(OLM_PREVIOUS_VERSION).clusterserviceversion.yaml \
+		deploy/olm/csv-rhel/storageos.v$(OLM_CURRENT_VERSION).clusterserviceversion.yaml
 
 metadata-update:
 	# Update all the metadata files in-place.

--- a/scripts/release-helpers/release-gen.sh
+++ b/scripts/release-helpers/release-gen.sh
@@ -155,4 +155,12 @@ echo "Creating versioned CSV files..."
 cp deploy/olm/storageos/storageos.clusterserviceversion.yaml deploy/olm/storageos/storageos.v$NEW_VERSION.clusterserviceversion.yaml
 cp deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml deploy/olm/csv-rhel/storageos.v$NEW_VERSION.clusterserviceversion.yaml
 
+# Update OLM versions in the makefile. This is required for proper OLM metadata
+# zip generation.
+# Swap the previous version with current version and use the new version as
+# current version.
+REPLACE=$(awk '/CURRENT_VERSION =/{print $3}' Makefile)
+sed -i -e "s/OLM_PREVIOUS_VERSION\ =.*/OLM_PREVIOUS_VERSION\ = $REPLACE/g" Makefile
+sed -i -e "s/OLM_CURRENT_VERSION\ =.*/OLM_CURRENT_VERSION\ = $NEW_VERSION/g" Makefile
+
 echo "Ready for new release."


### PR DESCRIPTION
Operator metadata zip that consists of CSVs with replaces field must
also include the version of CSV that's being replaced.
This change packages the versioned CSV files in the zip.

A reference to default old and current versions of OLM releases are
added in the Makefile, which is updated by the release-gen.sh script
when preparing for a new release.