### PR TITLE
Log cleanup

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
-var log = logf.Log.WithName("setup")
+var log = logf.Log.WithName("storageos.setup")
 
 func main() {
 
@@ -58,7 +58,7 @@ func main() {
 		fatal(err)
 	}
 
-	log.Info("Starting the Cmd")
+	log.Info("Starting the StorageOS Operator")
 
 	// Start the Cmd
 	fatal(mgr.Start(signals.SetupSignalHandler()))

--- a/cmd/upgrader/main.go
+++ b/cmd/upgrader/main.go
@@ -9,11 +9,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.Log.WithName("upgrader")
+var log = logf.Log.WithName("storageos.upgrader")
 
 func main() {
-
-	var log = logf.Log.WithName("upgrader")
 
 	cfg, err := restclient.InClusterConfig()
 	if err != nil {

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("job")
+var log = logf.Log.WithName("storageos.job")
 
 // Add creates a new Job Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -133,7 +133,7 @@ func (r *ReconcileJob) Reconcile(request reconcile.Request) (reconcile.Result, e
 	found := &appsv1.DaemonSet{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: daemonset.Name, Namespace: daemonset.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
-		log.Info("creating a new DaemonSet")
+		log.Info("Creating a new DaemonSet")
 		err = r.client.Create(context.TODO(), daemonset)
 		if err != nil {
 			return reconcileResult, err
@@ -175,7 +175,7 @@ func checkPods(client kubernetes.Interface, cr *storageosv1.Job, recorder record
 
 	pods, err := client.CoreV1().Pods(cr.GetNamespace()).List(podListOpts)
 	if err != nil {
-		log.Error(err, "failed to get podList")
+		log.Error(err, "Failed to get pods")
 		return false, err
 	}
 
@@ -184,7 +184,7 @@ func checkPods(client kubernetes.Interface, cr *storageosv1.Job, recorder record
 
 	// Skip if there are no daemonset-job pods.
 	if totalPods == 0 {
-		log.Info("no DaemonSets found")
+		log.Info("No DaemonSets found")
 		return false, nil
 	}
 
@@ -194,7 +194,7 @@ func checkPods(client kubernetes.Interface, cr *storageosv1.Job, recorder record
 		req := client.CoreV1().Pods(p.GetNamespace()).GetLogs(p.GetName(), opts)
 		logText, err := getPlainLogs(req)
 		if err != nil {
-			log.Error(err, "failed to get logs from pod", "pod", p.GetName())
+			log.Info("Failed to get logs from pod", "pod", p.GetName(), "error", err)
 			// Continue checking other pods.
 			continue
 		}

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -25,7 +25,7 @@ import (
 	storageostypes "github.com/storageos/go-api/types"
 )
 
-var log = logf.Log.WithName("node")
+var log = logf.Log.WithName("storageos.node")
 
 // Node controller errors.
 var (
@@ -101,7 +101,7 @@ func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, 
 			return reconcile.Result{}, nil
 		}
 		// Requeue the request in order to retry getting the cluster.
-		log.Error(err, "failed to find current cluster")
+		log.Error(err, "Failed to find current cluster")
 		return reconcileResult, err
 	}
 
@@ -114,7 +114,7 @@ func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, 
 		r.stosClient.clusterUID != cluster.GetUID() {
 
 		if err := r.setClientForCluster(cluster); err != nil {
-			log.Error(err, "failed to configure api client")
+			log.Error(err, "Failed to configure api client")
 			return reconcileResult, err
 		}
 	}
@@ -122,12 +122,12 @@ func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, 
 	// Sync labels to StorageOS node object.
 	if err = r.syncLabels(instance.Name, instance.Labels); err != nil {
 		if storageoserror.ErrorKind(err) == storageoserror.APIUncontactable {
-			log.Info("Waiting for StorageOS API to become ready")
+			log.V(4).Info("Waiting for StorageOS API to become ready")
 			return reconcileResult, nil
 		}
 
 		// Error syncing labels - requeue the request.
-		log.Error(err, "failed to sync node labels")
+		log.Error(err, "Failed to sync node labels")
 		return reconcileResult, err
 	}
 

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -127,8 +127,8 @@ func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, 
 		}
 
 		// Error syncing labels - requeue the request.
-		log.Error(err, "Failed to sync node labels")
-		return reconcileResult, err
+		log.V(4).Info("Failed to sync node labels", "error", err)
+		return reconcileResult, nil
 	}
 
 	return reconcileResult, nil

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("cluster")
+var log = logf.Log.WithName("storageos.cluster")
 
 // Add creates a new StorageOSCluster Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/storageosupgrade/storageosupgrade_controller.go
+++ b/pkg/controller/storageosupgrade/storageosupgrade_controller.go
@@ -27,7 +27,7 @@ import (
 	storageosapi "github.com/storageos/go-api"
 )
 
-var log = logf.Log.WithName("upgrade")
+var log = logf.Log.WithName("storageos.upgrade")
 
 var (
 	// operatorImage is the image name of controller-operator. This is needed
@@ -281,7 +281,7 @@ func (r *ReconcileStorageOSUpgrade) Reconcile(request reconcile.Request) (reconc
 	}
 	err = r.client.Get(context.TODO(), nsdName, r.imagePuller)
 	if err != nil {
-		log.Error(err, "error fetching image puller status")
+		log.Info("Failed to fetch image puller status", "error", err)
 	}
 	// Re-queue if the image pull didn't complete.
 	if !r.imagePuller.Status.Completed {

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -73,7 +73,7 @@ const (
 	k8sDistroOpenShift = "openshift"
 )
 
-var log = logf.Log.WithName("cluster")
+var log = logf.Log.WithName("storageos.cluster")
 
 // Deploy deploys storageos by creating all the resources needed to run storageos.
 func (s *Deployment) Deploy() error {
@@ -241,13 +241,13 @@ func CSIV1Supported(version string) bool {
 func versionSupported(haveVersion, wantVersion string) bool {
 	supportedVersion, err := semver.Parse(wantVersion)
 	if err != nil {
-		log.Error(err, "failed to parse version", "want", wantVersion)
+		log.Error(err, "Failed to parse version", "want", wantVersion)
 		return false
 	}
 
 	currentVersion, err := semver.Parse(haveVersion)
 	if err != nil {
-		log.Error(err, "failed to parse version", "have", haveVersion)
+		log.Error(err, "Failed to parse version", "have", haveVersion)
 		return false
 	}
 

--- a/pkg/storageos/update_status.go
+++ b/pkg/storageos/update_status.go
@@ -71,8 +71,6 @@ func (s *Deployment) getStorageOSStatus() (*storageosv1.StorageOSClusterStatus, 
 			} else {
 				memberStatus.Unready = append(memberStatus.Unready, node)
 			}
-		} else {
-			log.WithValues("node", node).Info("api not ready, retrying")
 		}
 	}
 

--- a/pkg/util/task/task.go
+++ b/pkg/util/task/task.go
@@ -36,7 +36,7 @@ func DoRetryWithTimeout(t func() (interface{}, bool, error), timeout, timeBefore
 					return
 				}
 
-				log.Error(err, "task failed", "retrying in", timeBeforeRetry.String())
+				log.Info("Task failed", "retrying in", timeBeforeRetry.String(), "error", err)
 				time.Sleep(timeBeforeRetry)
 			}
 


### PR DESCRIPTION
The default settings for the new logger will print a stack trace on errors.  While this can be useful, we were logging some expected conditions at error level (e.g. api errors while waiting for the cluster to become ready).  Where it's not a real error, logs have been moved to debug or info level.

Also capitalized log messages to be consistent with messages from the rest of the framework.

