### PR TITLE
storageos: Add scheduler perm for events patch

### DIFF
--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -205,6 +205,7 @@ spec:
           - get
           - update
           - create
+          - patch
         - apiGroups:
           - ""
           resources:

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -205,6 +205,7 @@ spec:
           - get
           - update
           - create
+          - patch
         - apiGroups:
           - ""
           resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -30,6 +30,7 @@ rules:
   - get
   - update
   - create
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -434,6 +434,7 @@ data:
                 - get
                 - update
                 - create
+                - patch
               - apiGroups:
                 - ""
                 resources:

--- a/pkg/storageos/rbac.go
+++ b/pkg/storageos/rbac.go
@@ -299,7 +299,7 @@ func (s *Deployment) createClusterRoleForScheduler() error {
 				"endpoints",
 				"events",
 			},
-			Verbs: []string{"get", "list", "watch", "create", "update"},
+			Verbs: []string{"get", "list", "watch", "create", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"apps"},

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -200,13 +200,15 @@ operator-sdk-e2e-cleanup() {
     # Delete all the cluster roles.
     kubectl delete clusterrole storageos:csi-attacher \
         storageos:csi-provisioner storageos:driver-registrar \
-        storageos:openshift-scc storageos:pod-fencer --ignore-not-found=true
+        storageos:openshift-scc storageos:pod-fencer \
+        storageos:scheduler-extender --ignore-not-found=true
 
     # Delete all the cluster role bindings.
     kubectl delete clusterrolebinding storageos:csi-attacher \
         storageos:csi-provisioner storageos:driver-registrar \
         storageos:k8s-driver-registrar storageos:openshift-scc \
-        storageos:pod-fencer --ignore-not-found=true
+        storageos:pod-fencer storageos:scheduler-extender \
+        --ignore-not-found=true
 }
 
 main() {


### PR DESCRIPTION
Scheduler shows the following error because it can't patch events:
`forbidden: User
"system:serviceaccount:storageos:storageos-scheduler-sa" cannot
patch resource "events" in API group "" in the namespace... `.
This change add patch permission.