### PR TITLE
Generate additional openAPI go code for custom types

### DIFF
--- a/deploy/crds/storageos_v1_storageoscluster_crd.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_crd.yaml
@@ -177,8 +177,8 @@ spec:
                   type: string
               type: object
             namespace:
-              description: ResourceNS is the kubernetes Namespace where storageos
-                resources are provisioned.
+              description: Namespace is the kubernetes Namespace where storageos resources
+                are provisioned.
               type: string
             nodeSelectorTerms:
               description: NodeSelectorTerms is to set the placement of storageos

--- a/deploy/olm/storageos/storageoscluster.crd.yaml
+++ b/deploy/olm/storageos/storageoscluster.crd.yaml
@@ -177,8 +177,8 @@ spec:
                   type: string
               type: object
             namespace:
-              description: ResourceNS is the kubernetes Namespace where storageos
-                resources are provisioned.
+              description: Namespace is the kubernetes Namespace where storageos resources
+                are provisioned.
               type: string
             nodeSelectorTerms:
               description: NodeSelectorTerms is to set the placement of storageos

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -186,8 +186,8 @@ data:
                         type: string
                     type: object
                   namespace:
-                    description: ResourceNS is the kubernetes Namespace where storageos
-                      resources are provisioned.
+                    description: Namespace is the kubernetes Namespace where storageos resources
+                      are provisioned.
                     type: string
                   nodeSelectorTerms:
                     description: NodeSelectorTerms is to set the placement of storageos

--- a/pkg/apis/storageos/v1/job_types.go
+++ b/pkg/apis/storageos/v1/job_types.go
@@ -9,6 +9,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // JobSpec defines the desired state of Job
+// +k8s:openapi-gen=true
 type JobSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
@@ -50,6 +51,7 @@ func (s JobSpec) GetLabelSelector() string {
 }
 
 // JobStatus defines the observed state of Job
+// +k8s:openapi-gen=true
 type JobStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -69,6 +69,7 @@ func getDefaultCSIKubeletRegistrationPath(pluginRegistrationPath string) string 
 }
 
 // StorageOSClusterSpec defines the desired state of StorageOSCluster
+// +k8s:openapi-gen=true
 type StorageOSClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
@@ -79,9 +80,9 @@ type StorageOSClusterSpec struct {
 	// CSI defines the configurations for CSI.
 	CSI StorageOSClusterCSI `json:"csi,omitempty"`
 
-	// ResourceNS is the kubernetes Namespace where storageos resources are
+	// Namespace is the kubernetes Namespace where storageos resources are
 	// provisioned.
-	ResourceNS string `json:"namespace,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
 
 	// Service is the Service configuration for the cluster nodes.
 	Service StorageOSClusterService `json:"service,omitempty"`
@@ -193,6 +194,7 @@ type StorageOSClusterSpec struct {
 }
 
 // StorageOSClusterStatus defines the observed state of StorageOSCluster
+// +k8s:openapi-gen=true
 type StorageOSClusterStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
@@ -246,8 +248,8 @@ type MembersStatus struct {
 
 // GetResourceNS returns the namespace where all the resources should be provisioned.
 func (s StorageOSClusterSpec) GetResourceNS() string {
-	if s.ResourceNS != "" {
-		return s.ResourceNS
+	if s.Namespace != "" {
+		return s.Namespace
 	}
 	return DefaultNamespace
 }

--- a/pkg/apis/storageos/v1/storageosupgrade_types.go
+++ b/pkg/apis/storageos/v1/storageosupgrade_types.go
@@ -8,6 +8,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // StorageOSUpgradeSpec defines the desired state of StorageOSUpgrade
+// +k8s:openapi-gen=true
 type StorageOSUpgradeSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
@@ -17,6 +18,7 @@ type StorageOSUpgradeSpec struct {
 }
 
 // StorageOSUpgradeStatus defines the observed state of StorageOSUpgrade
+// +k8s:openapi-gen=true
 type StorageOSUpgradeStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file

--- a/pkg/apis/storageos/v1/zz_generated.openapi.go
+++ b/pkg/apis/storageos/v1/zz_generated.openapi.go
@@ -13,9 +13,15 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.Job":              schema_pkg_apis_storageos_v1_Job(ref),
-		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSCluster": schema_pkg_apis_storageos_v1_StorageOSCluster(ref),
-		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSUpgrade": schema_pkg_apis_storageos_v1_StorageOSUpgrade(ref),
+		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.Job":                    schema_pkg_apis_storageos_v1_Job(ref),
+		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.JobSpec":                schema_pkg_apis_storageos_v1_JobSpec(ref),
+		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.JobStatus":              schema_pkg_apis_storageos_v1_JobStatus(ref),
+		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSCluster":       schema_pkg_apis_storageos_v1_StorageOSCluster(ref),
+		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSClusterSpec":   schema_pkg_apis_storageos_v1_StorageOSClusterSpec(ref),
+		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSClusterStatus": schema_pkg_apis_storageos_v1_StorageOSClusterStatus(ref),
+		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSUpgrade":       schema_pkg_apis_storageos_v1_StorageOSUpgrade(ref),
+		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSUpgradeSpec":   schema_pkg_apis_storageos_v1_StorageOSUpgradeSpec(ref),
+		"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSUpgradeStatus": schema_pkg_apis_storageos_v1_StorageOSUpgradeStatus(ref),
 	}
 }
 
@@ -62,6 +68,116 @@ func schema_pkg_apis_storageos_v1_Job(ref common.ReferenceCallback) common.OpenA
 	}
 }
 
+func schema_pkg_apis_storageos_v1_JobSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobSpec defines the desired state of Job",
+				Properties: map[string]spec.Schema{
+					"image": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Image is the container image to run as the job.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"args": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Args is an array of strings passed as an argument to the job container.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"mountPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MountPath is the path in the job container where a volume is mounted.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"hostPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "HostPath is the path in the host that's mounted into a job container.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"completionWord": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CompletionWord is the word that's looked for in the pod logs to find out if a DaemonSet Pod has completed its task.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"labelSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LabelSelector is the label selector for the job Pods.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"nodeSelectorTerms": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeSelectorTerms is the set of placement of the job pods using node affinity requiredDuringSchedulingIgnoredDuringExecution.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.NodeSelectorTerm"),
+									},
+								},
+							},
+						},
+					},
+					"tolerations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Tolerations is to set the placement of storageos pods using pod toleration.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.Toleration"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"image", "args", "mountPath", "hostPath", "completionWord"},
+			},
+		},
+		Dependencies: []string{
+			"k8s.io/api/core/v1.NodeSelectorTerm", "k8s.io/api/core/v1.Toleration"},
+	}
+}
+
+func schema_pkg_apis_storageos_v1_JobStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobStatus defines the observed state of Job",
+				Properties: map[string]spec.Schema{
+					"completed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Completed indicates the complete status of job.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
 func schema_pkg_apis_storageos_v1_StorageOSCluster(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -105,6 +221,244 @@ func schema_pkg_apis_storageos_v1_StorageOSCluster(ref common.ReferenceCallback)
 	}
 }
 
+func schema_pkg_apis_storageos_v1_StorageOSClusterSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StorageOSClusterSpec defines the desired state of StorageOSCluster",
+				Properties: map[string]spec.Schema{
+					"join": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Join is the join token used for service discovery.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"csi": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CSI defines the configurations for CSI.",
+							Ref:         ref("github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSClusterCSI"),
+						},
+					},
+					"namespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace is the kubernetes Namespace where storageos resources are provisioned.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"service": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Service is the Service configuration for the cluster nodes.",
+							Ref:         ref("github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSClusterService"),
+						},
+					},
+					"secretRefName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SecretRefName is the name of the secret object that contains all the sensitive cluster configurations.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"secretRefNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SecretRefNamespace is the namespace of the secret reference.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"sharedDir": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SharedDir is the shared directory to be used when the kubelet is running in a container. Typically: \"/var/lib/kubelet/plugins/kubernetes.io~storageos\". If not set, defaults will be used.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"ingress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Ingress defines the ingress configurations used in the cluster.",
+							Ref:         ref("github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSClusterIngress"),
+						},
+					},
+					"images": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Images defines the various container images used in the cluster.",
+							Ref:         ref("github.com/storageos/cluster-operator/pkg/apis/storageos/v1.ContainerImages"),
+						},
+					},
+					"kvBackend": {
+						SchemaProps: spec.SchemaProps{
+							Description: "KVBackend defines the key-value store backend used in the cluster.",
+							Ref:         ref("github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSClusterKVBackend"),
+						},
+					},
+					"pause": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Pause is to pause the operator for the cluster.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"debug": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Debug is to set debug mode of the cluster.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"nodeSelectorTerms": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeSelectorTerms is to set the placement of storageos pods using node affinity requiredDuringSchedulingIgnoredDuringExecution.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.NodeSelectorTerm"),
+									},
+								},
+							},
+						},
+					},
+					"tolerations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Tolerations is to set the placement of storageos pods using pod toleration.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.Toleration"),
+									},
+								},
+							},
+						},
+					},
+					"resources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Resources is to set the resource requirements of the storageos containers.",
+							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
+					"disableFencing": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Disable Pod Fencing.  With StatefulSets, Pods are only re-scheduled if the Pod has been marked as killed.  In practice this means that failover of a StatefulSet pod is a manual operation.\n\nBy enabling Pod Fencing and setting the `storageos.com/fenced=true` label on a Pod, StorageOS will enable automated Pod failover (by killing the application Pod on the failed node) if the following conditions exist:\n\n- Pod fencing has not been explicitly disabled. - StorageOS has determined that the node the Pod is running on is\n  offline.  StorageOS uses Gossip and TCP checks and will retry for 30\n  seconds.  At this point all volumes on the failed node are marked\n  offline (irrespective of whether fencing is enabled) and volume\n  failover starts.\n- The Pod has the label `storageos.com/fenced=true` set. - The Pod has at least one StorageOS volume attached. - Each StorageOS volume has at least 1 healthy replica.\n\nWhen Pod Fencing is disabled, StorageOS will not perform any interaction with Kubernetes when it detects that a node has gone offline. Additionally, the Kubernetes permissions required for Fencing will not be added to the StorageOS role.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"disableTelemetry": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Disable Telemetry.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"disableTCMU": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Disable TCMU can be set to true to disable the TCMU storage driver.  This is required when there are multiple storage systems running on the same node and you wish to avoid conflicts.  Only one TCMU-based storage system can run on a node at a time.\n\nDisabling TCMU will degrade performance.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"forceTCMU": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Force TCMU can be set to true to ensure that TCMU is enabled or cause StorageOS to abort startup.\n\nAt startup, StorageOS will automatically fallback to non-TCMU mode if another TCMU-based storage system is running on the node.  Since non-TCMU will degrade performance, this may not always be desired.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"tlsEtcdSecretRefName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TLSEtcdSecretRefName is the name of the secret object that contains the etcd TLS certs. This secret is shared with etcd, therefore it's not part of the main storageos secret.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"tlsEtcdSecretRefNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TLSEtcdSecretRefNamespace is the namespace of the etcd TLS secret object.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"k8sDistro": {
+						SchemaProps: spec.SchemaProps{
+							Description: "K8sDistro is the name of the Kubernetes distribution where the operator is being deployed.  It should be in the format: `name[-1.0]`, where the version is optional and should only be appended if known.  Suitable names include: `openshift`, `rancher`, `aks`, `gke`, `eks`, or the deployment method if using upstream directly, e.g `minishift` or `kubeadm`.\n\nSetting k8sDistro is optional, and will be used to simplify cluster configuration by setting appropriate defaults for the distribution.  The distribution information will also be included in the product telemetry (if enabled), to help focus development efforts.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"disableScheduler": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Disable StorageOS scheduler extender.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"secretRefName", "secretRefNamespace"},
+			},
+		},
+		Dependencies: []string{
+			"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.ContainerImages", "github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSClusterCSI", "github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSClusterIngress", "github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSClusterKVBackend", "github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSClusterService", "k8s.io/api/core/v1.NodeSelectorTerm", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration"},
+	}
+}
+
+func schema_pkg_apis_storageos_v1_StorageOSClusterStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StorageOSClusterStatus defines the observed state of StorageOSCluster",
+				Properties: map[string]spec.Schema{
+					"phase": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"nodeHealthStatus": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/storageos/cluster-operator/pkg/apis/storageos/v1.NodeHealth"),
+									},
+								},
+							},
+						},
+					},
+					"nodes": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"ready": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"members": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/storageos/cluster-operator/pkg/apis/storageos/v1.MembersStatus"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.MembersStatus", "github.com/storageos/cluster-operator/pkg/apis/storageos/v1.NodeHealth"},
+	}
+}
+
 func schema_pkg_apis_storageos_v1_StorageOSUpgrade(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -145,5 +499,46 @@ func schema_pkg_apis_storageos_v1_StorageOSUpgrade(ref common.ReferenceCallback)
 		},
 		Dependencies: []string{
 			"github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSUpgradeSpec", "github.com/storageos/cluster-operator/pkg/apis/storageos/v1.StorageOSUpgradeStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+	}
+}
+
+func schema_pkg_apis_storageos_v1_StorageOSUpgradeSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StorageOSUpgradeSpec defines the desired state of StorageOSUpgrade",
+				Properties: map[string]spec.Schema{
+					"newImage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NewImage is the new StorageOS node container image.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"newImage"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_pkg_apis_storageos_v1_StorageOSUpgradeStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StorageOSUpgradeStatus defines the observed state of StorageOSUpgrade",
+				Properties: map[string]spec.Schema{
+					"completed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Completed is the status of upgrade process.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
 	}
 }

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -188,7 +188,7 @@ func (r *ReconcileStorageOSCluster) reconcile(m *storageosv1.StorageOSCluster) e
 
 	// Update the spec values. This ensures that the default values are applied
 	// when fields are not set in the spec.
-	m.Spec.ResourceNS = m.Spec.GetResourceNS()
+	m.Spec.Namespace = m.Spec.GetResourceNS()
 	m.Spec.Images.NodeContainer = m.Spec.GetNodeContainerImage()
 	m.Spec.Images.InitContainer = m.Spec.GetInitContainerImage()
 

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -1616,7 +1616,7 @@ func TestDeployPodPriorityClass(t *testing.T) {
 						Enable:             true,
 						DeploymentStrategy: tc.csiDeploymentStrategy,
 					},
-					ResourceNS: tc.resourceNS,
+					Namespace: tc.resourceNS,
 				},
 			}
 

--- a/test/e2e/clusterCSIDeployment_test.go
+++ b/test/e2e/clusterCSIDeployment_test.go
@@ -30,7 +30,7 @@ func TestClusterCSIDeployment(t *testing.T) {
 	clusterSpec := storageos.StorageOSClusterSpec{
 		SecretRefName:      "storageos-api",
 		SecretRefNamespace: "default",
-		ResourceNS:         resourceNS,
+		Namespace:          resourceNS,
 		CSI: storageos.StorageOSClusterCSI{
 			Enable:             true,
 			DeploymentStrategy: "deployment",

--- a/test/e2e/clusterCSI_test.go
+++ b/test/e2e/clusterCSI_test.go
@@ -29,7 +29,7 @@ func TestClusterCSI(t *testing.T) {
 	clusterSpec := storageos.StorageOSClusterSpec{
 		SecretRefName:      "storageos-api",
 		SecretRefNamespace: "default",
-		ResourceNS:         resourceNS,
+		Namespace:          resourceNS,
 		CSI: storageos.StorageOSClusterCSI{
 			Enable: true,
 		},

--- a/test/e2e/clusterInTreePlugin_test.go
+++ b/test/e2e/clusterInTreePlugin_test.go
@@ -27,7 +27,7 @@ func TestClusterInTreePlugin(t *testing.T) {
 	clusterSpec := storageos.StorageOSClusterSpec{
 		SecretRefName:      "storageos-api",
 		SecretRefNamespace: "default",
-		ResourceNS:         resourceNS,
+		Namespace:          resourceNS,
 		Tolerations: []corev1.Toleration{
 			{
 				Key:      "key",


### PR DESCRIPTION
This adds k8s:openapi-gen tag to the go type definitions of the custom
resources and generates openAPI go code.

Also changes the storageosclusterspec attribute name ResoureNS to
Namespace to be valid with the openAPI generator requirements. The json
attribute for the property remains same `namespace`.