### PR TITLE
Add permissions and env vars for init container

### DIFF
--- a/pkg/storageos/delete.go
+++ b/pkg/storageos/delete.go
@@ -31,6 +31,14 @@ func (s *Deployment) Delete() error {
 		return err
 	}
 
+	if err := s.k8sResourceManager.ClusterRoleBinding(InitClusterBindingName, nil, nil).Delete(); err != nil {
+		return err
+	}
+
+	if err := s.k8sResourceManager.ClusterRole(InitClusterRoleName, nil).Delete(); err != nil {
+		return err
+	}
+
 	if err := s.k8sResourceManager.RoleBinding(KeyManagementBindingName, namespace, nil, nil).Delete(); err != nil {
 		return err
 	}

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -100,6 +100,14 @@ func (s *Deployment) Deploy() error {
 		return err
 	}
 
+	if err := s.createClusterRoleForInit(); err != nil {
+		return err
+	}
+
+	if err := s.createClusterRoleBindingForInit(); err != nil {
+		return err
+	}
+
 	if err := s.createInitSecret(); err != nil {
 		return err
 	}

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -879,11 +879,11 @@ func TestDeployNodeAffinity(t *testing.T) {
 		csiDeploymentStrategy string
 	}{
 		{
-			name: "csi helper StatefulSet",
+			name:                  "csi helper StatefulSet",
 			csiDeploymentStrategy: "statefulset",
 		},
 		{
-			name: "csi helper Deployment",
+			name:                  "csi helper Deployment",
 			csiDeploymentStrategy: "deployment",
 		},
 	}

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -201,14 +201,15 @@ operator-sdk-e2e-cleanup() {
     kubectl delete clusterrole storageos:csi-attacher \
         storageos:csi-provisioner storageos:driver-registrar \
         storageos:openshift-scc storageos:pod-fencer \
-        storageos:scheduler-extender --ignore-not-found=true
+        storageos:scheduler-extender storageos:init \
+        --ignore-not-found=true
 
     # Delete all the cluster role bindings.
     kubectl delete clusterrolebinding storageos:csi-attacher \
         storageos:csi-provisioner storageos:driver-registrar \
         storageos:k8s-driver-registrar storageos:openshift-scc \
         storageos:pod-fencer storageos:scheduler-extender \
-        --ignore-not-found=true
+        storageos:init --ignore-not-found=true
 }
 
 main() {


### PR DESCRIPTION
Adds permissions and env vars required by the init container to query
the current node image.
Also sets the default update strategy of the DaemonSet to OnDelete by
default.