### PR TITLE
Bump kind k8s version to 1.15.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 env:
   global:
     - CHANGE_MINIKUBE_NONE_USER=true
-    - K8S_VERSION="v1.10.0"
+    - K8S_VERSION="v1.15.3"
     - MINIKUBE_VERSION="v0.28.2"
     - IMAGE_NAME=storageos/cluster-operator
     - IMAGE_TAG=test


### PR DESCRIPTION
storageos/kind-node:v1.15.3 adds the nfs-common package needed for NFS testing.  Not required for the operator.  Built from https://github.com/storageos/kind/tree/kind-23-08-19