### PR TITLE
Enable CRD subresource status

### DIFF
--- a/deploy/crds/storageos_v1_job_crd.yaml
+++ b/deploy/crds/storageos_v1_job_crd.yaml
@@ -10,6 +10,8 @@ spec:
     plural: jobs
     singular: job
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/crds/storageos_v1_nfsserver_crd.yaml
+++ b/deploy/crds/storageos_v1_nfsserver_crd.yaml
@@ -36,6 +36,8 @@ spec:
     - nfsserver
     singular: nfsserver
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/crds/storageos_v1_storageoscluster_crd.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_crd.yaml
@@ -24,6 +24,8 @@ spec:
     - stos
     singular: storageoscluster
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/crds/storageos_v1_storageosupgrade_crd.yaml
+++ b/deploy/crds/storageos_v1_storageosupgrade_crd.yaml
@@ -10,6 +10,8 @@ spec:
     plural: storageosupgrades
     singular: storageosupgrade
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -201,9 +201,13 @@ spec:
           - storageos.com
           resources:
           - storageosclusters
+          - storageosclusters/status
           - storageosupgrades
+          - storageosupgrades/status
           - jobs
+          - jobs/status
           - nfsservers
+          - nfsservers/status
           verbs:
           - '*'
         - apiGroups:

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -201,9 +201,13 @@ spec:
           - storageos.com
           resources:
           - storageosclusters
+          - storageosclusters/status
           - storageosupgrades
+          - storageosupgrades/status
           - jobs
+          - jobs/status
           - nfsservers
+          - nfsservers/status
           verbs:
           - '*'
         - apiGroups:

--- a/deploy/olm/storageos/storageoscluster.crd.yaml
+++ b/deploy/olm/storageos/storageoscluster.crd.yaml
@@ -24,6 +24,8 @@ spec:
     - stos
     singular: storageoscluster
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/olm/storageos/storageosjob.crd.yaml
+++ b/deploy/olm/storageos/storageosjob.crd.yaml
@@ -10,6 +10,8 @@ spec:
     plural: jobs
     singular: job
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/olm/storageos/storageosnfsserver.crd.yaml
+++ b/deploy/olm/storageos/storageosnfsserver.crd.yaml
@@ -36,6 +36,8 @@ spec:
     - nfsserver
     singular: nfsserver
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/olm/storageos/storageosupgrade.crd.yaml
+++ b/deploy/olm/storageos/storageosupgrade.crd.yaml
@@ -10,6 +10,8 @@ spec:
     plural: storageosupgrades
     singular: storageosupgrade
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -8,9 +8,13 @@ rules:
   - storageos.com
   resources:
   - storageosclusters
+  - storageosclusters/status
   - storageosupgrades
+  - storageosupgrades/status
   - jobs
+  - jobs/status
   - nfsservers
+  - nfsservers/status
   verbs:
   - '*'
 - apiGroups:

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -33,6 +33,8 @@ data:
           - stos
           singular: storageoscluster
         scope: Namespaced
+        subresources:
+          status: {}
         validation:
           openAPIV3Schema:
             properties:
@@ -320,6 +322,8 @@ data:
           plural: jobs
           singular: job
         scope: Namespaced
+        subresources:
+          status: {}
         validation:
           openAPIV3Schema:
             properties:
@@ -403,6 +407,8 @@ data:
           plural: storageosupgrades
           singular: storageosupgrade
         scope: Namespaced
+        subresources:
+          status: {}
         validation:
           openAPIV3Schema:
             properties:
@@ -475,6 +481,8 @@ data:
           - nfsserver
           singular: nfsserver
         scope: Namespaced
+        subresources:
+          status: {}
         validation:
           openAPIV3Schema:
             properties:
@@ -796,9 +804,13 @@ data:
                 - storageos.com
                 resources:
                 - storageosclusters
+                - storageosclusters/status
                 - storageosupgrades
+                - storageosupgrades/status
                 - jobs
+                - jobs/status
                 - nfsservers
+                - nfsservers/status
                 verbs:
                 - "*"
               - apiGroups:

--- a/pkg/apis/storageos/v1/job_types.go
+++ b/pkg/apis/storageos/v1/job_types.go
@@ -66,6 +66,7 @@ type JobStatus struct {
 // Job is the Schema for the jobs API
 // +k8s:openapi-gen=true
 // +kubebuilder:singular=job
+// +kubebuilder:subresource:status
 type Job struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/storageos/v1/nfsserver_types.go
+++ b/pkg/apis/storageos/v1/nfsserver_types.go
@@ -140,6 +140,7 @@ type NFSServerStatus struct {
 // +kubebuilder:printcolumn:name="storageclass",type="string",JSONPath=".spec.storageClassName",description="StorageClass used for creating the NFS volume."
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=nfsservers,shortName=nfsserver
+// +kubebuilder:subresource:status
 type NFSServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -222,6 +222,7 @@ type StorageOSClusterStatus struct {
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=storageosclusters,shortName=stos
 // +kubebuilder:singular=storageoscluster
+// +kubebuilder:subresource:status
 type StorageOSCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/storageos/v1/storageosupgrade_types.go
+++ b/pkg/apis/storageos/v1/storageosupgrade_types.go
@@ -33,6 +33,7 @@ type StorageOSUpgradeStatus struct {
 // StorageOSUpgrade is the Schema for the storageosupgrades API
 // +k8s:openapi-gen=true
 // +kubebuilder:singular=storageosupgrade
+// +kubebuilder:subresource:status
 type StorageOSUpgrade struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -156,9 +156,9 @@ func (r *ReconcileJob) Reconcile(request reconcile.Request) (reconcile.Result, e
 		return reconcileResult, err
 	}
 
-	// Update the Completed status of the Job.
+	// Update the Completed status of the Job (status subresource).
 	instance.Status.Completed = completed
-	if err := r.client.Update(context.Background(), instance); err != nil {
+	if err := r.client.Status().Update(context.Background(), instance); err != nil {
 		return reconcileResult, err
 	}
 

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -157,7 +157,7 @@ func (r *ReconcileStorageOSCluster) Reconcile(request reconcile.Request) (reconc
 	}
 
 	if err := r.reconcile(instance); err != nil {
-		log.V(4).Info("Reconcile failed", "error", err)
+		log.Info("Reconcile failed", "error", err)
 		return reconcileResult, nil
 	}
 
@@ -178,9 +178,9 @@ func (r *ReconcileStorageOSCluster) reconcile(m *storageosv1.StorageOSCluster) e
 	if m.Spec.Join != join {
 		m.Spec.Join = join
 		// Update Nodes as well, because updating StorageOS with null Nodes
-		// results in invalid config.
+		// results in invalid config (status subresource).
 		m.Status.Nodes = strings.Split(join, ",")
-		if err := r.client.Update(context.Background(), m); err != nil {
+		if err := r.client.Status().Update(context.Background(), m); err != nil {
 			return err
 		}
 		// Update current cluster.

--- a/pkg/nfs/status.go
+++ b/pkg/nfs/status.go
@@ -24,8 +24,10 @@ func (s *Deployment) updateStatus(status *storageosv1.NFSServerStatus) error {
 			}
 		}
 	}
+
+	// Update subresource status.
 	s.nfsServer.Status = *status
-	return s.client.Update(context.Background(), s.nfsServer)
+	return s.client.Status().Update(context.Background(), s.nfsServer)
 }
 
 // getStatus determines the status of the NFS Server deployment.

--- a/pkg/storageos/update_status.go
+++ b/pkg/storageos/update_status.go
@@ -38,8 +38,9 @@ func (s *Deployment) updateStorageOSStatus(status *storageosv1.StorageOSClusterS
 		}
 	}
 
+	// Update subresource status.
 	s.stos.Status = *status
-	return s.client.Update(context.Background(), s.stos)
+	return s.client.Status().Update(context.Background(), s.stos)
 }
 
 // getStorageOSStatus queries health of all the nodes in the join token and


### PR DESCRIPTION
This enables CRD subresource status to store and update custom resource
status. Updates the k8s client.Update() calls to use a status writer
when updating resource status only.
Adds permissions required to update subresource status.

CRD files updated using `make generate`.
OLM files updated using `make metadata-update`.

Ref: https://book-v1.book.kubebuilder.io/basics/status_subresource.html