### PR TITLE
Create role for NFSServer management

### DIFF
--- a/pkg/storageos/delete.go
+++ b/pkg/storageos/delete.go
@@ -47,6 +47,14 @@ func (s *Deployment) Delete() error {
 		return err
 	}
 
+	if err := s.k8sResourceManager.RoleBinding(NFSClusterBindingName, namespace, nil, nil).Delete(); err != nil {
+		return err
+	}
+
+	if err := s.k8sResourceManager.Role(NFSClusterRoleName, namespace, nil).Delete(); err != nil {
+		return err
+	}
+
 	if err := s.k8sResourceManager.ServiceAccount(DaemonsetSA, namespace).Delete(); err != nil {
 		return err
 	}

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -100,6 +100,14 @@ func (s *Deployment) Deploy() error {
 		return err
 	}
 
+	if err := s.createClusterRoleForNFS(); err != nil {
+		return err
+	}
+
+	if err := s.createClusterRoleBindingForNFS(); err != nil {
+		return err
+	}
+
 	if err := s.createClusterRoleForInit(); err != nil {
 		return err
 	}

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -193,14 +193,14 @@ operator-sdk-e2e-cleanup() {
         storageos:csi-provisioner storageos:driver-registrar \
         storageos:openshift-scc storageos:pod-fencer \
         storageos:scheduler-extender storageos:init \
-        --ignore-not-found=true
+        storageos:nfs-provisioner --ignore-not-found=true
 
     # Delete all the cluster role bindings.
     kubectl delete clusterrolebinding storageos:csi-attacher \
         storageos:csi-provisioner storageos:driver-registrar \
         storageos:k8s-driver-registrar storageos:openshift-scc \
         storageos:pod-fencer storageos:scheduler-extender \
-        storageos:init --ignore-not-found=true
+        storageos:init storageos:nfs-provisioner --ignore-not-found=true
 }
 
 main() {


### PR DESCRIPTION
This allows the node container to create, update and delete NFSServer resources.  It runs using the `storageos-daemonset-sa` service account.