### PR TITLE
Add operator-sdk scorecard test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,3 +113,8 @@ release:
 # Create a single manifest for installing the operator.
 generate-install-manifest: install-yq
 	bash scripts/create-manifest.sh $(OPERATOR_IMAGE)
+
+# Runs the operator-sdk scorecard tests. Expects the operator to be installed
+# using OLM first.
+scorecard-test:
+	bash test/scorecard-test.sh

--- a/deploy/crds/storageos_v1_storageoscluster_cr.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_cr.yaml
@@ -80,26 +80,3 @@ spec:
   # forceTCMU: false
   # disableScheduler: false
 
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "storageos-api"
-  namespace: "default"
-  labels:
-    app: "storageos"
-type: "kubernetes.io/storageos"
-data:
-  # echo -n '<secret>' | base64
-  apiUsername: c3RvcmFnZW9z
-  apiPassword: c3RvcmFnZW9z
-  # Add base64 encoded TLS cert and key below if ingress.tls is set to true.
-  # tls.crt:
-  # tls.key:
-  # Add base64 encoded creds below for CSI credentials.
-  # csiProvisionUsername:
-  # csiProvisionPassword:
-  # csiControllerPublishUsername:
-  # csiControllerPublishPassword:
-  # csiNodePublishUsername:
-  # csiNodePublishPassword:

--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -358,6 +358,47 @@ spec:
       description: StorageOS Cluster installs StorageOS in the cluster. It contains
         all the configuration for setting up a StorageOS cluster and also shows the
         status of the running StorageOS cluster.
+      resources:
+      - kind: Namespace
+        version: v1
+      - kind: ServiceAccount
+        version: v1
+      - kind: Role
+        version: rbac.authorization.k8s.io/v1
+      - kind: RoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: ClusterRole
+        version: rbac.authorization.k8s.io/v1
+      - kind: ClusterRoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: Secret
+        version: v1
+      - kind: DaemonSet
+        version: apps/v1
+      - kind: Service
+        version: v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      - kind: Deployment
+        version: apps/v1
+      - kind: StatefulSet
+        version: apps/v1
+      - kind: StorageClass
+        version: storage.k8s.io/v1
+      - kind: StorageOSCluster
+        version: v1
+      - kind: Job
+        version: v1
+      - kind: StorageOSUpgrade
+        version: v1
+      - kind: NFSServer
+        version: v1
+      - kind: Node
+        version: v1
+      - kind: StatefulSet
+        version: v1
+      - kind: DaemonSet
+        version: v1
       specDescriptors:
       - description: Defines the various container images used in the cluster.
         displayName: Images
@@ -482,6 +523,9 @@ spec:
       description: StorageOS Job creates special pods that run on all the node and
         perform an administrative task. This could be used for cluster maintenance
         tasks.
+      resources:
+      - kind: DaemonSet
+        version: apps/v1
       specDescriptors:
       - description: The container image to run as the job.
         displayName: Image
@@ -519,6 +563,15 @@ spec:
       displayName: StorageOS Upgrade
       description: StorageOS Upgrade automatically upgrades an existing StorageOS
         cluster as per the upgrade configuration.
+      resources:
+      - kind: ServiceAccount
+        version: v1
+      - kind: ClusterRole
+        version: rbac.authorization.k8s.io/v1
+      - kind: ClusterRoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: Job
+        version: batch/v1
       specDescriptors:
       - description: The StorageOS Node image to upgrade to. e.g. `registry.connect.redhat.com/storageos/node:latest`
         displayName: New Image
@@ -534,8 +587,45 @@ spec:
       description: StorageOS NFS Server provides support for shared volumes. The StorageOS
         control plane will automatically create and manage NFS Server instances when
         a PersistentVolumeClaim requests a volume with AccessMode=ReadWriteMany.
+      resources:
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: ServiceAccount
+        version: v1
+      - kind: ClusterRoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: StatefulSet
+        version: apps/v1
       specDescriptors:
+      - description: The annotations-related configuration to add/set on each Pod
+          related object.
+        displayName: Pod annotations
+        path: annotations
+      - description: The parameters to configure the NFS export.
+        displayName: NFS export
+        path: export
+      - description: PV mount options. Not validated - mount of the PVs will simply
+          fail if one is invalid.
+        displayName: Mount Options
+        path: mountOptions
       - description: The container image of the NFS server.
         displayName: Image
         path: nfsContainer
+      - description: Reclamation policy for the persistent volume shared to the user's
+          pod.
+        displayName: PVC Reclaimation Policy
+        path: persistentVolumeReclaimPolicy
+      - description: Resources represents the minimum resources required.
+        displayName: Resources
+        path: resources
+      - description: StorageClassName is the name of the StorageClass used by the
+          NFS volume.
+        displayName: StorageClass Name
+        path: storageClassName
+      - description: Tolerations is to set the placement of NFS server pods using
+          pod toleration.
+        displayName: Pod Tolerations.
+        path: tolerations
   replaces: storageosoperator.v1.3.0

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -358,6 +358,47 @@ spec:
       description: StorageOS Cluster installs StorageOS in the cluster. It contains
         all the configuration for setting up a StorageOS cluster and also shows the
         status of the running StorageOS cluster.
+      resources:
+      - kind: Namespace
+        version: v1
+      - kind: ServiceAccount
+        version: v1
+      - kind: Role
+        version: rbac.authorization.k8s.io/v1
+      - kind: RoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: ClusterRole
+        version: rbac.authorization.k8s.io/v1
+      - kind: ClusterRoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: Secret
+        version: v1
+      - kind: DaemonSet
+        version: apps/v1
+      - kind: Service
+        version: v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      - kind: Deployment
+        version: apps/v1
+      - kind: StatefulSet
+        version: apps/v1
+      - kind: StorageClass
+        version: storage.k8s.io/v1
+      - kind: StorageOSCluster
+        version: v1
+      - kind: Job
+        version: v1
+      - kind: StorageOSUpgrade
+        version: v1
+      - kind: NFSServer
+        version: v1
+      - kind: Node
+        version: v1
+      - kind: StatefulSet
+        version: v1
+      - kind: DaemonSet
+        version: v1
       specDescriptors:
       - description: Defines the various container images used in the cluster.
         displayName: Images
@@ -482,6 +523,9 @@ spec:
       description: StorageOS Job creates special pods that run on all the node and
         perform an administrative task. This could be used for cluster maintenance
         tasks.
+      resources:
+      - kind: DaemonSet
+        version: apps/v1
       specDescriptors:
       - description: The container image to run as the job.
         displayName: Image
@@ -519,6 +563,15 @@ spec:
       displayName: StorageOS Upgrade
       description: StorageOS Upgrade automatically upgrades an existing StorageOS
         cluster as per the upgrade configuration.
+      resources:
+      - kind: ServiceAccount
+        version: v1
+      - kind: ClusterRole
+        version: rbac.authorization.k8s.io/v1
+      - kind: ClusterRoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: Job
+        version: batch/v1
       specDescriptors:
       - description: The StorageOS Node image to upgrade to. e.g. `storageos/node:latest`
         displayName: New Image
@@ -534,8 +587,45 @@ spec:
       description: StorageOS NFS Server provides support for shared volumes. The StorageOS
         control plane will automatically create and manage NFS Server instances when
         a PersistentVolumeClaim requests a volume with AccessMode=ReadWriteMany.
+      resources:
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: ServiceAccount
+        version: v1
+      - kind: ClusterRoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: StatefulSet
+        version: apps/v1
       specDescriptors:
+      - description: The annotations-related configuration to add/set on each Pod
+          related object.
+        displayName: Pod annotations
+        path: annotations
+      - description: The parameters to configure the NFS export.
+        displayName: NFS export
+        path: export
+      - description: PV mount options. Not validated - mount of the PVs will simply
+          fail if one is invalid.
+        displayName: Mount Options
+        path: mountOptions
       - description: The container image of the NFS server.
         displayName: Image
         path: nfsContainer
+      - description: Reclamation policy for the persistent volume shared to the user's
+          pod.
+        displayName: PVC Reclaimation Policy
+        path: persistentVolumeReclaimPolicy
+      - description: Resources represents the minimum resources required.
+        displayName: Resources
+        path: resources
+      - description: StorageClassName is the name of the StorageClass used by the
+          NFS volume.
+        displayName: StorageClass Name
+        path: storageClassName
+      - description: Tolerations is to set the placement of NFS server pods using
+          pod toleration.
+        displayName: Pod Tolerations.
+        path: tolerations
   replaces: storageosoperator.v1.3.0

--- a/deploy/secret.yaml
+++ b/deploy/secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "storageos-api"
+  namespace: "default"
+  labels:
+    app: "storageos"
+type: "kubernetes.io/storageos"
+data:
+  # echo -n '<secret>' | base64
+  apiUsername: c3RvcmFnZW9z
+  apiPassword: c3RvcmFnZW9z
+  # Add base64 encoded TLS cert and key below if ingress.tls is set to true.
+  # tls.crt:
+  # tls.key:
+  # Add base64 encoded creds below for CSI credentials.
+  # csiProvisionUsername:
+  # csiProvisionPassword:
+  # csiControllerPublishUsername:
+  # csiControllerPublishPassword:
+  # csiNodePublishUsername:
+  # csiNodePublishPassword:

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -952,6 +952,19 @@ data:
                       ports:
                       - containerPort: 8080
                         name: metrics
+                    - name: scorecard-proxy
+                      image: quay.io/operator-framework/scorecard-proxy:v0.10.0
+                      imagePullPolicy: IfNotPresent
+                      command:
+                      - scorecard-proxy
+                      ports:
+                      - containerPort: 8889
+                        name: proxy
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
         customresourcedefinitions:
           owned:
           - name: storageosclusters.storageos.com

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -974,6 +974,47 @@ data:
             description: StorageOS Cluster installs StorageOS in the cluster. It
               contains all the configuration for setting up a StorageOS cluster and
               also shows the status of the running StorageOS cluster.
+            resources:
+            - kind: Namespace
+              version: v1
+            - kind: ServiceAccount
+              version: v1
+            - kind: Role
+              version: rbac.authorization.k8s.io/v1
+            - kind: RoleBinding
+              version: rbac.authorization.k8s.io/v1
+            - kind: ClusterRole
+              version: rbac.authorization.k8s.io/v1
+            - kind: ClusterRoleBinding
+              version: rbac.authorization.k8s.io/v1
+            - kind: Secret
+              version: v1
+            - kind: DaemonSet
+              version: apps/v1
+            - kind: Service
+              version: v1
+            - kind: Ingress
+              version: extensions/v1beta1
+            - kind: Deployment
+              version: apps/v1
+            - kind: StatefulSet
+              version: apps/v1
+            - kind: StorageClass
+              version: storage.k8s.io/v1
+            - kind: StorageOSCluster
+              version: v1
+            - kind: Job
+              version: v1
+            - kind: StorageOSUpgrade
+              version: v1
+            - kind: NFSServer
+              version: v1
+            - kind: Node
+              version: v1
+            - kind: StatefulSet
+              version: v1
+            - kind: DaemonSet
+              version: v1
             specDescriptors:
             - description: Defines the various container images used in the cluster.
               displayName: Images
@@ -1101,6 +1142,9 @@ data:
             description: StorageOS Job creates special pods that run on all the node
               and perform an administrative task. This could be used for cluster
               maintenance tasks.
+            resources:
+            - kind: DaemonSet
+              version: apps/v1
             specDescriptors:
             - description: The container image to run as the job.
               displayName: Image
@@ -1138,6 +1182,15 @@ data:
             displayName: StorageOS Upgrade
             description: StorageOS Upgrade automatically upgrades an existing
               StorageOS cluster as per the upgrade configuration.
+            resources:
+            - kind: ServiceAccount
+              version: v1
+            - kind: ClusterRole
+              version: rbac.authorization.k8s.io/v1
+            - kind: ClusterRoleBinding
+              version: rbac.authorization.k8s.io/v1
+            - kind: Job
+              version: batch/v1
             specDescriptors:
             - description: The StorageOS Node image to upgrade to.
                 e.g. `storageos/node:latest`
@@ -1155,10 +1208,47 @@ data:
              volumes. The StorageOS control plane will automatically create and
              manage NFS Server instances when a PersistentVolumeClaim requests a
              volume with AccessMode=ReadWriteMany.
+            resources:
+            - kind: Service
+              version: v1
+            - kind: ConfigMap
+              version: v1
+            - kind: ServiceAccount
+              version: v1
+            - kind: ClusterRoleBinding
+              version: rbac.authorization.k8s.io/v1
+            - kind: StatefulSet
+              version: apps/v1
             specDescriptors:
+            - description: The annotations-related configuration to add/set on
+                each Pod related object.
+              displayName: Pod annotations
+              path: annotations
+            - description: The parameters to configure the NFS export.
+              displayName: NFS export
+              path: export
+            - description: PV mount options. Not validated - mount of the PVs
+                will simply fail if one is invalid.
+              displayName: Mount Options
+              path: mountOptions
             - description: The container image of the NFS server.
               displayName: Image
               path: nfsContainer
+            - description: Reclamation policy for the persistent volume shared
+                to the user's pod.
+              displayName: PVC Reclaimation Policy
+              path: persistentVolumeReclaimPolicy
+            - description: Resources represents the minimum resources required.
+              displayName: Resources
+              path: resources
+            - description: StorageClassName is the name of the StorageClass
+                used by the NFS volume.
+              displayName: StorageClass Name
+              path: storageClassName
+            - description: Tolerations is to set the placement of NFS server
+                pods using pod toleration.
+              displayName: Pod Tolerations.
+              path: tolerations
 
   packages: |-
 

--- a/scripts/metadata-checker/metadata-diff-checker.sh
+++ b/scripts/metadata-checker/metadata-diff-checker.sh
@@ -31,7 +31,9 @@ targetfile=deploy/olm/storageos/storageos.clusterserviceversion.yaml
 # Generate a community CSV file.
 yq r deploy/storageos-operators.configmap.yaml \
     data.clusterServiceVersions | yq r - [0] | \
-    yq w -s deploy/olm/community-changes.yaml - > $csvfile
+    yq w -s deploy/olm/community-changes.yaml - | \
+    yq d - 'spec.install.spec.deployments[0].spec.template.spec.containers[1]' \
+    > $csvfile
 check_diff $targetfile $csvfile
 
 # Check rhel CSV file.
@@ -40,7 +42,9 @@ targetfile=deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
 # Generate a rhel CSV file.
 yq r deploy/storageos-operators.configmap.yaml \
     data.clusterServiceVersions | yq r - [0] | \
-    yq w -s deploy/olm/rhel-changes.yaml - > $csvfile
+    yq w -s deploy/olm/rhel-changes.yaml - | \
+    yq d - 'spec.install.spec.deployments[0].spec.template.spec.containers[1]' \
+    > $csvfile
 check_diff $targetfile $csvfile
 
 

--- a/scripts/metadata-checker/update-metadata-files.sh
+++ b/scripts/metadata-checker/update-metadata-files.sh
@@ -6,19 +6,21 @@ set -e
 # files. This script is used to sync the source configmap configurations with
 # the OLM manifest files.
 
-# Extract CSV from configmap, update with community operator changes and write
-# to the final CSV file.
+# Extract CSV from configmap, update with community operator changes, removes
+# OLM scorecard proxy container and write to the final CSV file.
 yq r deploy/storageos-operators.configmap.yaml \
     data.clusterServiceVersions | yq r - [0] | \
-    yq w -s deploy/olm/community-changes.yaml - > \
-    deploy/olm/storageos/storageos.clusterserviceversion.yaml
+    yq w -s deploy/olm/community-changes.yaml - | \
+    yq d - 'spec.install.spec.deployments[0].spec.template.spec.containers[1]' \
+    > deploy/olm/storageos/storageos.clusterserviceversion.yaml
 
-# Extract CSV from configmap, update with rhel operator changes and write to
-# the final CSV file.
+# Extract CSV from configmap, update with rhel operator changes, removes OLM
+# scorecard proxy container and write to the final CSV file.
 yq r deploy/storageos-operators.configmap.yaml \
     data.clusterServiceVersions | yq r - [0] | \
-    yq w -s deploy/olm/rhel-changes.yaml - > \
-    deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+    yq w -s deploy/olm/rhel-changes.yaml - | \
+    yq d - 'spec.install.spec.deployments[0].spec.template.spec.containers[1]' \
+    > deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
 
 
 # Read metadata file configmap and update the CRD files.

--- a/test/.osdk-scorecard.yaml
+++ b/test/.osdk-scorecard.yaml
@@ -1,0 +1,33 @@
+scorecard:
+  plugins:
+    - olm:
+        cr-manifest:
+          - deploy/crds/storageos_v1_storageoscluster_cr.yaml
+        olm-deployed: true
+        csv-path: deploy/olm/storageos/storageos.clusterserviceversion.yaml
+        namespace: olm
+    # - olm:
+    #     cr-manifest:
+    #       - deploy/crds/storageos_v1_job_cr.yaml
+    #     olm-deployed: true
+    #     csv-path: deploy/olm/storageos/storageos.clusterserviceversion.yaml
+    #     namespace: olm
+    # - olm:
+    #     cr-manifest:
+    #       - deploy/crds/storageos_v1_storageosupgrade_cr.yaml
+    #     olm-deployed: true
+    #     csv-path: deploy/olm/storageos/storageos.clusterserviceversion.yaml
+    #     namespace: olm
+    # - olm:
+    #     cr-manifest:
+    #       - deploy/crds/storageos_v1_nfsserver_cr.yaml
+    #     olm-deployed: true
+    #     csv-path: deploy/olm/storageos/storageos.clusterserviceversion.yaml
+    #     namespace: olm
+    - basic:
+        cr-manifest:
+          - deploy/crds/storageos_v1_storageoscluster_cr.yaml
+        olm-deployed: true
+        csv-path: deploy/olm/storageos/storageos.clusterserviceversion.yaml
+        namespace: olm
+

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -201,6 +201,9 @@ operator-sdk-e2e-cleanup() {
         storageos:k8s-driver-registrar storageos:openshift-scc \
         storageos:pod-fencer storageos:scheduler-extender \
         storageos:init storageos:nfs-provisioner --ignore-not-found=true
+
+    # Delete NFSServer statefulset.
+    kubectl delete statefulset.apps/example-nfsserver --ignore-not-found=true
 }
 
 main() {

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -261,6 +261,10 @@ main() {
 
         # Install storageos with CSI helpers as Deployment.
         install_storageos_csi_deployment
+
+        # Run scorecard tests on the olm-deployed operator.
+        make scorecard-test
+
         uninstall_storageos
     else
         # Add taint on the node.

--- a/test/e2e/clusterInTreePlugin_test.go
+++ b/test/e2e/clusterInTreePlugin_test.go
@@ -66,9 +66,6 @@ func TestClusterInTreePlugin(t *testing.T) {
 		t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 2)
 	}
 
-	// Test NFSServer deployment.
-	testutil.NFSServerTest(t, ctx)
-
 	// Test node label sync.
 	testutil.NodeLabelSyncTest(t, f.KubeClient)
 }

--- a/test/e2e/util/nfs_cluster.go
+++ b/test/e2e/util/nfs_cluster.go
@@ -60,9 +60,9 @@ func DeployNFSServer(t *testing.T, ctx *framework.TestCtx, nfsServer *storageos.
 
 	// NOTE: Temporary resource creation check only. Remove once the above check
 	// is added.
-	// Wait for 5 seconds here because there's no wait for the StatefulSet to be
+	// Wait for 10 seconds here because there's no wait for the StatefulSet to be
 	// ready. This will provide time for the PVC to be provisioned.
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 	statefulset := &appsv1.StatefulSet{}
 	namespacedName := types.NamespacedName{
 		Name:      nfsServer.Name,

--- a/test/scorecard-test.sh
+++ b/test/scorecard-test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# This script runs the operator-sdk scorecard tests against an existing operator
+# installed via OLM. OLM and storageos operator can be installed using the
+# helpers in deploy/olm/olm.sh. An example usage of the same is in test/e2e.sh.
+#
+# The scorecard test includes basic and OLM tests that are
+# run against each of the custom resources one at a time. It creates the custom
+# resources, passed as `cr-manifest`, and analyzes the resources.
+# The test "Writing into CRs has an effect" requires a proxy container to be
+# deployed along with the operator. This is added in
+# deploy/storageos-operators.configmap.yaml. The proxy container is removed from
+# CSV in scripts/metadata-checker/update-metadata-files.sh when generating CSVs
+# for a release.
+
+# TODO: test/.osdk-scorecard.yaml contains a scorecard configuration file which
+# will be supported in the upcoming versions of operator-sdk (> v0.10.0). Move
+# .osdk-scorecard.yaml to the root of the project or run:
+# $ operator-sdk scorecard --config test/.osdk-scorecard.yaml
+# to run the same tests using config file. This script will no longer be
+# required once the sdk fully supports scorecard config file.
+
+# NOTE: The scorecard test behavior in operator-sdk 0.8.0 is simpler compared
+# to 0.10.0. When operator-sdk version is updated to 0.10.0 or above, the tests
+# will take extra time, waiting for actual custom resources to be created and
+# analyze the properties of the resources. In order to reduce the test time, the
+# CR controllers can be improved to add status to the created resources as soon
+# as possible and cause some effect when there's a write to the custom resource.
+
+PROJECT_ROOT=$PWD
+CR_DIR="$PROJECT_ROOT/deploy/crds/"
+CSV_PATH="deploy/olm/storageos/storageos.clusterserviceversion.yaml"
+NAMESPACE="olm"
+
+# Iterate through all the CR files and run scorecard test against them.
+for cr_file in $(find "$CR_DIR" -name "*_cr.yaml"); do
+  echo -e "\n\nRunning operator-sdk scorecard with example "$(cat "$cr_file" | yq r - "kind")""
+  ./build/operator-sdk scorecard \
+    --cr-manifest "$cr_file" \
+    --csv-path $CSV_PATH \
+    --olm-deployed \
+    --namespace $NAMESPACE \
+    --verbose
+
+  # If scorecard errors out, print out operator logs
+  if [[ $? != 0 ]]; then
+    echo -e "\nFAIL: Scorecard test errored out."
+    operatorpod=$(kubectl -n $NAMESPACE get pods --template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | grep storageos-operator)
+    kubectl -n $NAMESPACE logs $operatorpod -c storageos-operator
+    exit 1
+  else
+    echo -e "\nPASS: Scorecard test passed"
+  fi
+done


### PR DESCRIPTION
This adds operator-sdk scorecard test, adds the required changes in the operator test deployment for the tests and updates the OLM metadata as suggested by the results of the scorecard tests.

Operator deployment using OLM in CI now adds a proxy container to monitor the requests from operator.

test/scorecard-test.sh contains long description about the scorecard test and future changes.

Scorecard tests can be run against an existing operator installed via OLM with:
```
$ make scorecard-test
bash test/scorecard-test.sh

Running operator-sdk scorecard with example StorageOSCluster
DEBU[0000] Debug logging is set                         
WARN[0000] Could not load config file; using flags      
Running for cr: /tmp/cr.yaml707336597
WARN[0001] Plugin directory not found; skipping plugin tests: <nil> 
OLM Tests:
        Provided APIs have validation: 1/1
        Owned CRDs have resources listed: 1/1
        CRs have at least 1 example: 1/1
        Spec fields with descriptors: 4/4
        Status fields with descriptors: 2/2
Basic Tests:
        Spec Block Exists: 1/1
        Status Block Exists: 1/1
        Writing into CRs has an effect: 0/1

Total Score: 86%
SUGGESTION: The operator should write into objects to update state. No PUT or POST requests from the operator were recorded by the scorecard.

PASS: Scorecard test passed
...
```

Operator Scorecard doc: https://github.com/operator-framework/operator-sdk/blob/master/doc/test-framework/scorecard.md