### PR TITLE
Add missing CR attributes

### DIFF
--- a/test/e2e/clusterCSIDeployment_test.go
+++ b/test/e2e/clusterCSIDeployment_test.go
@@ -56,7 +56,7 @@ func TestClusterCSIDeployment(t *testing.T) {
 
 	f := framework.Global
 
-	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-storageos", Namespace: namespace}, testStorageOS)
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: testutil.TestClusterCRName, Namespace: namespace}, testStorageOS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,6 +85,9 @@ func TestClusterCSIDeployment(t *testing.T) {
 			t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 2)
 		}
 	}
+
+	// Test StorageOSCluster CR attributes.
+	testutil.StorageOSClusterCRAttributesTest(t, testutil.TestClusterCRName, namespace)
 
 	// Test NFSServer deployment.
 	testutil.NFSServerTest(t, ctx)


### PR DESCRIPTION
The StorageOSCluster and NFSServer CRs were not being updated with
default and inferred values. This change adds a check in the reconcile
loop to update the spec if the spec properties need to be updated.

This also fixes the empty StorageClass in the NFSServer CR.

In StorageOSCluster reconcile loop, an spec update requires updating
the current cluster with new properties to reflect any new data in the
cluster deployment.

StorageOSCluster:
```
Spec:
  Csi:
    Deployment Strategy:  statefulset
    Enable:               true
  Disable TCMU:           true
  Images:
    Csi Cluster Driver Registrar Container:  quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
    Csi External Attacher Container:         quay.io/k8scsi/csi-attacher:v1.0.1
    Csi External Provisioner Container:      storageos/csi-provisioner:v1.0.1
    Csi Liveness Probe Container:            quay.io/k8scsi/livenessprobe:v1.0.1
    Csi Node Driver Registrar Container:     quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
    Hyperkube Container:                     gcr.io/google_containers/hyperkube:v1.15.3
    Init Container:                          storageos/init:1.0.0
    Node Container:                          storageos/node:develop
  Ingress:
  Join:  172.17.0.2
  Kv Backend:
  Namespace:  storageos
  Resources:
  Secret Ref Name:       storageos-api
  Secret Ref Namespace:  default
  Service:
    External Port:  5705
    Internal Port:  5705
    Name:           storageos
    Type:           ClusterIP
Status:
  Members:
...
```


NFSServer:
```
$ kubectl get nfsserver
NAME                STATUS    CAPACITY   TARGET         ACCESS MODES   STORAGECLASS   AGE
example-nfsserver   Running   1Gi        10.96.94.147   RW             fast           40m
```

Also, adds e2e tests to avoid dropping the CR properties unintentionally in the future.

Fixes #169 