### PR TITLE
Allow setting cluster-wide NFS container image

### DIFF
--- a/deploy/crds/storageos_v1_storageoscluster_cr.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_cr.yaml
@@ -21,6 +21,7 @@ spec:
   #   csiExternalAttacherContainer:
   #   csiLivenessProbeContainer:
   #   hyperkubeContainer:
+  #   nfsContainer:
   csi:
     enable: true
   #   endpoint: /var/lib/kubelet/device-plugins/

--- a/deploy/crds/storageos_v1_storageoscluster_crd.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_crd.yaml
@@ -137,6 +137,8 @@ spec:
                   type: string
                 initContainer:
                   type: string
+                nfsContainer:
+                  type: string
                 nodeContainer:
                   type: string
               type: object

--- a/deploy/olm/storageos/storageoscluster.crd.yaml
+++ b/deploy/olm/storageos/storageoscluster.crd.yaml
@@ -137,6 +137,8 @@ spec:
                   type: string
                 initContainer:
                   type: string
+                nfsContainer:
+                  type: string
                 nodeContainer:
                   type: string
               type: object

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -146,6 +146,8 @@ data:
                         type: string
                       initContainer:
                         type: string
+                      nfsContainer:
+                        type: string
                       nodeContainer:
                         type: string
                     type: object

--- a/pkg/apis/storageos/v1/nfsserver_types.go
+++ b/pkg/apis/storageos/v1/nfsserver_types.go
@@ -11,9 +11,6 @@ import (
 
 // Constants for NFSServer default values and different phases.
 const (
-	// DefaultNFSContainerImage is the name of the Ganesha container to run.
-	DefaultNFSContainerImage = "storageos/nfs:test"
-
 	DefaultNFSVolumeCapacity = "1Gi"
 
 	PhasePending = "Pending"
@@ -74,11 +71,11 @@ func (s NFSServerSpec) GetStorageClassName(clusterSCName string) string {
 }
 
 // GetContainerImage returns the NFS server container image.
-func (s NFSServerSpec) GetContainerImage() string {
+func (s NFSServerSpec) GetContainerImage(clusterNFSImage string) string {
 	if s.NFSContainer != "" {
 		return s.NFSContainer
 	}
-	return DefaultNFSContainerImage
+	return clusterNFSImage
 }
 
 // GetRequestedCapacity returns the requested capacity for the NFS volume.

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -40,6 +40,7 @@ const (
 	CSIv0DriverRegistrarContainerImage        = "quay.io/k8scsi/driver-registrar:v0.4.2"
 	CSIv0ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v0.4.2"
 	CSIv0ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v0.4.2"
+	DefaultNFSContainerImage                  = "storageos/nfs:test"
 
 	DefaultHyperkubeContainerRegistry = "gcr.io/google_containers/hyperkube"
 
@@ -347,6 +348,15 @@ func (s StorageOSClusterSpec) GetHyperkubeImage(k8sVersion string) string {
 	return fmt.Sprintf("%s:v%s", DefaultHyperkubeContainerRegistry, k8sVersion)
 }
 
+// GetNFSServerImage returns NFS server container image used as the default
+// image in the cluster.
+func (s StorageOSClusterSpec) GetNFSServerImage() string {
+	if s.Images.NFSContainer != "" {
+		return s.Images.NFSContainer
+	}
+	return DefaultNFSContainerImage
+}
+
 // GetServiceName returns the service name.
 func (s StorageOSClusterSpec) GetServiceName() string {
 	if s.Service.Name != "" {
@@ -501,6 +511,7 @@ type ContainerImages struct {
 	CSIExternalAttacherContainer       string `json:"csiExternalAttacherContainer,omitempty"`
 	CSILivenessProbeContainer          string `json:"csiLivenessProbeContainer,omitempty"`
 	HyperkubeContainer                 string `json:"hyperkubeContainer,omitempty"`
+	NFSContainer                       string `json:"nfsContainer,omitempty"`
 }
 
 // StorageOSClusterCSI contains CSI configurations.

--- a/pkg/controller/nfsserver/nfsserver_controller.go
+++ b/pkg/controller/nfsserver/nfsserver_controller.go
@@ -247,6 +247,12 @@ func (r *ReconcileNFSServer) updateSpec(instance *storageosv1.NFSServer, cluster
 		needUpdate = true
 	}
 
+	image := instance.Spec.GetContainerImage(cluster.Spec.GetNFSServerImage())
+	if instance.Spec.NFSContainer != image {
+		instance.Spec.NFSContainer = image
+		needUpdate = true
+	}
+
 	if needUpdate {
 		// Update CR.
 		err := r.client.Update(context.TODO(), instance)

--- a/pkg/controller/nfsserver/nfsserver_controller_test.go
+++ b/pkg/controller/nfsserver/nfsserver_controller_test.go
@@ -1,20 +1,42 @@
 package nfsserver
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
+	storageosapis "github.com/storageos/cluster-operator/pkg/apis"
 	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 	fakeStosClientset "github.com/storageos/cluster-operator/pkg/client/clientset/versioned/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// getTestCluster returns a StorageOSCluster object with the given properties.
 func getTestCluster(
 	name string, namespace string,
 	spec storageosv1.StorageOSClusterSpec,
 	status storageosv1.StorageOSClusterStatus) *storageosv1.StorageOSCluster {
 
 	return &storageosv1.StorageOSCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec:   spec,
+		Status: status,
+	}
+}
+
+// getTestNFSServer returns a NFSServer object with the given properties.
+func getTestNFSServer(
+	name string, namespace string,
+	spec storageosv1.NFSServerSpec,
+	status storageosv1.NFSServerStatus) *storageosv1.NFSServer {
+
+	return &storageosv1.NFSServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -98,6 +120,121 @@ func TestGetCurrentStorageOSCluster(t *testing.T) {
 			} else {
 				if tc.wantClusterName != cc.Name {
 					t.Errorf("unexpected current cluster selection:\n\t(WNT) %s\n\t(GOT) %s", tc.wantClusterName, cc.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateSpec(t *testing.T) {
+	emptyClusterSpec := storageosv1.StorageOSClusterSpec{}
+	emptyClusterStatus := storageosv1.StorageOSClusterStatus{}
+	emptyNFSSpec := storageosv1.NFSServerSpec{}
+	emptyNFSStatus := storageosv1.NFSServerStatus{}
+
+	testcases := []struct {
+		name          string
+		cluster       *storageosv1.StorageOSCluster
+		nfsServer     *storageosv1.NFSServer
+		wantNFSServer *storageosv1.NFSServer
+		wantUpdate    bool
+		wantErr       error
+	}{
+		{
+			name:      "inherit attributes from cluster",
+			cluster:   getTestCluster("cluster1", "default", emptyClusterSpec, emptyClusterStatus),
+			nfsServer: getTestNFSServer("nfs1", "default", emptyNFSSpec, emptyNFSStatus),
+			wantNFSServer: getTestNFSServer("nfs1", "default",
+				storageosv1.NFSServerSpec{
+					StorageClassName: "fast",
+					NFSContainer:     storageosv1.DefaultNFSContainerImage,
+				},
+				emptyNFSStatus,
+			),
+			wantUpdate: true,
+		},
+		{
+			// Check if the overridden cluster level defaults are inherited to
+			// the NFS Server.
+			name: "update the default properties in cluster",
+			cluster: getTestCluster(
+				"cluster1", "default",
+				storageosv1.StorageOSClusterSpec{
+					StorageClassName: "testsc",
+					Images: storageosv1.ContainerImages{
+						NFSContainer: "test-image",
+					},
+				}, emptyClusterStatus),
+			nfsServer: getTestNFSServer("nfs1", "default", emptyNFSSpec, emptyNFSStatus),
+			wantNFSServer: getTestNFSServer("nfs1", "default", storageosv1.NFSServerSpec{
+				StorageClassName: "testsc",
+				NFSContainer:     "test-image",
+			}, emptyNFSStatus),
+			wantUpdate: true,
+		},
+		{
+			// Check that there's no update when the NFS Server CR is already
+			// up-to-date.
+			name:    "no new attributes to update",
+			cluster: getTestCluster("cluster1", "default", emptyClusterSpec, emptyClusterStatus),
+			nfsServer: getTestNFSServer(
+				"nfs1", "default",
+				storageosv1.NFSServerSpec{
+					StorageClassName: "fast",
+					NFSContainer:     storageosv1.DefaultNFSContainerImage,
+				}, emptyNFSStatus),
+			wantUpdate: false,
+		},
+		{
+			// When the attributes are defined in NFS Server CR, no CR update
+			// should happen.
+			name:    "override default attributes",
+			cluster: getTestCluster("cluster1", "default", emptyClusterSpec, emptyClusterStatus),
+			nfsServer: getTestNFSServer("nfs1", "default", storageosv1.NFSServerSpec{
+				StorageClassName: "testsc",
+				NFSContainer:     "test-image",
+			}, emptyNFSStatus),
+			wantUpdate: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a new scheme and add StorageOS APIs to it. Pass this to the
+			// k8s client so that it can create StorageOS resources.
+			testScheme := runtime.NewScheme()
+			storageosapis.AddToScheme(testScheme)
+
+			client := fake.NewFakeClientWithScheme(testScheme, tc.cluster, tc.nfsServer)
+
+			reconciler := ReconcileNFSServer{
+				client: client,
+			}
+
+			// Update NFSServer instance with the StorageOS Cluster and check the
+			// results.
+			result, err := reconciler.updateSpec(tc.nfsServer, tc.cluster)
+			if err != nil {
+				t.Fatalf("error while updating spec: %v", err)
+			}
+
+			if result != tc.wantUpdate {
+				t.Errorf("unexpected update spec result:\n\t(WNT) %t\n\t(GOT) %t", tc.wantUpdate, result)
+			}
+
+			// If there was an update, get the NFS Server and check if it's as
+			// expected.
+			if tc.wantUpdate {
+				namespacedNameNFS := types.NamespacedName{Name: tc.nfsServer.Name, Namespace: tc.nfsServer.Namespace}
+				nfsServer := &storageosv1.NFSServer{}
+
+				if err := client.Get(context.TODO(), namespacedNameNFS, nfsServer); err != nil {
+					t.Fatalf("failed to get NFS Server: %v", err)
+				}
+
+				if !reflect.DeepEqual(nfsServer, tc.wantNFSServer) {
+					t.Errorf("unexpected NFS Server:\n\t(WNT) %v\n\t(GOT) %v", tc.wantNFSServer, nfsServer)
 				}
 			}
 		})

--- a/pkg/nfs/statefulset.go
+++ b/pkg/nfs/statefulset.go
@@ -54,7 +54,7 @@ func (d *Deployment) createStatefulSet(size *resource.Quantity, nfsPort int, htt
 }
 
 func (d *Deployment) createVolumeClaimTemplateSpecs(size *resource.Quantity) []corev1.PersistentVolumeClaim {
-	scName := d.nfsServer.Spec.StorageClassName
+	scName := d.nfsServer.Spec.GetStorageClassName(d.cluster.Spec.GetStorageClassName())
 
 	claim := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -91,7 +91,7 @@ func (d *Deployment) createPodTemplateSpec(nfsPort int, httpPort int) corev1.Pod
 				{
 					ImagePullPolicy: "IfNotPresent",
 					Name:            "nfsd",
-					Image:           d.nfsServer.Spec.GetContainerImage(),
+					Image:           d.nfsServer.Spec.GetContainerImage(d.cluster.Spec.GetNFSServerImage()),
 					Env: []corev1.EnvVar{
 						{
 							Name:  "GANESHA_CONFIGFILE",


### PR DESCRIPTION
This adds NFSContainer in StorageOSCluster.Spec.Images to allow setting the
default NFS container image for a StorageOS cluster. This can be
overridden by specifying a container image in the NFSServer CR.

Also, adds tests for updateSpec() in the NFS controller to test the
inheritance and override of container image and storageclass from
StorageOSCluster into NFS Server.