### PR TITLE
Update controller-runtime to v0.1.12

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1134,7 +1134,7 @@
   revision = "0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803"
 
 [[projects]]
-  digest = "1:06035489efbd51ccface65fc878ceeb849aba05b2f9443c8993f363fc96e80ac"
+  digest = "1:21c23272171c749230b32cf3d797db213414dc4bed6abcd457946230d002418f"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -1149,6 +1149,7 @@
     "pkg/handler",
     "pkg/internal/controller",
     "pkg/internal/controller/metrics",
+    "pkg/internal/objectutil",
     "pkg/internal/recorder",
     "pkg/leaderelection",
     "pkg/manager",
@@ -1169,8 +1170,8 @@
     "pkg/webhook/types",
   ]
   pruneopts = "NT"
-  revision = "12d98582e72927b6cd0123e2b4e819f9341ce62c"
-  version = "v0.1.10"
+  revision = "f1eaba5087d69cebb154c6a48193e6667f5b512c"
+  version = "v0.1.12"
 
 [[projects]]
   digest = "1:00eecd8f1e0541da85a37549f6514c4b3517e2e000b74a0dc9f47cee07d7e1b5"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,7 +44,7 @@ required = [
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"
-  version = "v0.1.10"
+  version = "v0.1.12"
 
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/builder/build.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/builder/build.go
@@ -183,6 +183,10 @@ func (blder *Builder) doConfig() error {
 	if blder.config != nil {
 		return nil
 	}
+	if blder.mgr != nil {
+		blder.config = blder.mgr.GetConfig()
+		return nil
+	}
 	var err error
 	blder.config, err = getConfig()
 	return err

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -31,6 +32,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/internal/objectutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -110,7 +112,30 @@ func (c *fakeClient) List(ctx context.Context, opts *client.ListOptions, list ru
 	}
 	decoder := scheme.Codecs.UniversalDecoder()
 	_, _, err = decoder.Decode(j, nil, list)
-	return err
+	if err != nil {
+		return err
+	}
+
+	if opts.LabelSelector != nil {
+		return filterListItems(list, opts.LabelSelector)
+	}
+	return nil
+}
+
+func filterListItems(list runtime.Object, labSel labels.Selector) error {
+	objs, err := meta.ExtractList(list)
+	if err != nil {
+		return err
+	}
+	filteredObjs, err := objectutil.FilterWithLabels(objs, labSel)
+	if err != nil {
+		return err
+	}
+	err = meta.SetList(list, filteredObjs)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *fakeClient) Create(ctx context.Context, obj runtime.Object) error {

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/typed_client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/typed_client.go
@@ -104,7 +104,6 @@ func (c *typedClient) List(ctx context.Context, opts *ListOptions, obj runtime.O
 	return r.Get().
 		NamespaceIfScoped(namespace, r.isNamespaced()).
 		Resource(r.resource()).
-		Body(obj).
 		VersionedParams(opts.AsListOptions(), c.paramCodec).
 		Context(ctx).
 		Do().

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/filter.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/filter.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectutil
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// FilterWithLabels returns a copy of the items in objs matching labelSel
+func FilterWithLabels(objs []runtime.Object, labelSel labels.Selector) ([]runtime.Object, error) {
+	outItems := make([]runtime.Object, 0, len(objs))
+	for _, obj := range objs {
+		meta, err := apimeta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		if labelSel != nil {
+			lbls := labels.Set(meta.GetLabels())
+			if !labelSel.Matches(lbls) {
+				continue
+			}
+		}
+		outItems = append(outItems, obj.DeepCopyObject())
+	}
+	return outItems, nil
+}


### PR DESCRIPTION
operator-sdk v0.10.0 projects use controller-runtime v0.1.12 by default.
This has fixes for k8s label selector in fake client for List functions.

Project scaffold reference: https://github.com/operator-framework/operator-sdk/blob/v0.10.0/internal/pkg/scaffold/gopkgtoml.go#L81

operator-sdk issue ref: https://github.com/operator-framework/operator-sdk/issues/1606