### PR TITLE
NFS: Remove duplicate watcher

### DIFF
--- a/pkg/controller/nfsserver/nfsserver_controller.go
+++ b/pkg/controller/nfsserver/nfsserver_controller.go
@@ -57,12 +57,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for changes to primary resource NFSServer
-	err = c.Watch(&source.Kind{Type: &storageosv1.NFSServer{}}, &handler.EnqueueRequestForObject{})
-	if err != nil {
-		return err
-	}
-
 	// Watch for changes to primary resource NFSServer.
 	err = c.Watch(&source.Kind{Type: &storageosv1.NFSServer{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -122,12 +122,12 @@ func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, 
 	// Sync labels to StorageOS node object.
 	if err = r.syncLabels(instance.Name, instance.Labels); err != nil {
 		if storageoserror.ErrorKind(err) == storageoserror.APIUncontactable {
-			log.V(4).Info("Waiting for StorageOS API to become ready")
+			log.Info("Waiting for StorageOS API to become ready")
 			return reconcileResult, nil
 		}
 
 		// Error syncing labels - requeue the request.
-		log.V(4).Info("Failed to sync node labels", "error", err)
+		log.Info("Failed to sync node labels", "error", err)
 		return reconcileResult, nil
 	}
 


### PR DESCRIPTION
Also change the verbosity level of the node controller logs to avoid silent connection failures when querying StorageOS API endpoint.