### PR TITLE
create etcd secret of the same type as source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lint:
 	go vet ./...
 
 unittest:
-	go test -v -race `go list -v ./... | grep -v test/e2e | grep -v test/olm`
+	go test -v -race `go list -v ./... | grep -v test/e2e | grep -v olm`
 
 operator-sdk:
 	# Download sdk only if it's not available.

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -1335,6 +1335,14 @@ func TestDeployTLSEtcdCerts(t *testing.T) {
 		t.Fatalf("expected %q secret to exist, but not found", stosEtcdSecret)
 	}
 
+	// Check the created secret type because the fake k8s client doesn't
+	// validate the type of secret and the data fields.
+	// For example, it allows creating a TLS type secret with opaque type data.
+	// TLS type secret can have only `tls.key` and `tls.crt` data fields.
+	if etcdSecret.Type != stosEtcdSecret.Type {
+		t.Errorf("unexpected secret type:\n\t(WNT) %s\n\t(GOT) %s", etcdSecret.Type, stosEtcdSecret.Type)
+	}
+
 	// Check if the data in the new secret is the same as the source secret.
 	if !reflect.DeepEqual(stosEtcdSecret.Data, etcdSecret.Data) {
 		t.Errorf("unexpected secret data:\n\t(WNT) %v\n\t(GOT) %v", etcdSecret.Data, stosEtcdSecret.Data)

--- a/pkg/storageos/secret.go
+++ b/pkg/storageos/secret.go
@@ -167,8 +167,7 @@ func (s *Deployment) createTLSEtcdSecret() error {
 	if err != nil {
 		return err
 	}
-	data := secret.Data
 
 	// Create new secret with etcd TLS secret data.
-	return s.k8sResourceManager.Secret(TLSEtcdSecretName, s.stos.Spec.GetResourceNS(), corev1.SecretTypeTLS, data).Create()
+	return s.k8sResourceManager.Secret(TLSEtcdSecretName, s.stos.Spec.GetResourceNS(), secret.Type, secret.Data).Create()
 }


### PR DESCRIPTION
This fixes a bug introduced in the refactoring of k8s related code due
to which the etcd secret created for storageos cluster based on a
provided reference secret is of type TLS and not the same type as the
source secret. This results in secret creation failure because TLS
secrets have a strict data field requirement and the source secret
does not have the same data fields.

Adds a test to ensure such issues are caught in the future.