### PR TITLE
Add pod scheduler mutating admission controller

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -28,6 +28,11 @@ LABEL name="StorageOS Cluster Operator" \
     summary="Highly-available persistent block storage for containerized applications." \
     description="StorageOS transforms commodity server or cloud based disk capacity into enterprise-class storage to run persistent workloads such as databases in containers. Provides high availability, low latency persistent block storage. No other hardware or software is required."
 
+# Create a working directory that's writable by non-root users. This is needed
+# for writing the certificate generation.
+WORKDIR /home/operator
+RUN chmod -R g+rwX /home/operator
+
 # Docker is required by the upgrader to pre-load images.  Only `docker pull` is
 # used.  `podman` would be preferred but it's not available in the package repo,
 # and there isn't a binary release that we can easily download into the image.
@@ -42,3 +47,6 @@ COPY --from=build /go/src/github.com/storageos/cluster-operator/LICENSE /license
 COPY --from=build /go/src/github.com/storageos/cluster-operator/build/_output/bin/cluster-operator /usr/local/bin/cluster-operator
 COPY --from=build /go/src/github.com/storageos/cluster-operator/build/_output/bin/upgrader /usr/local/bin/upgrader
 COPY --from=build /go/src/github.com/storageos/cluster-operator/cmd/image-puller/docker-puller.sh /usr/local/bin/docker-puller.sh
+
+# Set a non-root default user.
+USER 1001

--- a/build/rhel-build-service/Dockerfile
+++ b/build/rhel-build-service/Dockerfile
@@ -29,6 +29,11 @@ LABEL name="StorageOS Cluster Operator" \
     summary="Highly-available persistent block storage for containerized applications." \
     description="StorageOS transforms commodity server or cloud based disk capacity into enterprise-class storage to run persistent workloads such as databases in containers. Provides high availability, low latency persistent block storage. No other hardware or software is required."
 
+# Create a working directory that's writable by non-root users. This is needed
+# for writing the certificate generation.
+WORKDIR /home/operator
+RUN chmod -R g+rwX /home/operator
+
 # Docker is required by the upgrader to pre-load images.  Only `docker pull` is
 # used.  `podman` would be preferred but it's not available in the package repo,
 # and there isn't a binary release that we can easily download into the image.
@@ -43,3 +48,6 @@ COPY --from=build /go/src/github.com/storageos/cluster-operator/LICENSE /license
 COPY --from=build /go/src/github.com/storageos/cluster-operator/build/_output/bin/cluster-operator /usr/local/bin/cluster-operator
 COPY --from=build /go/src/github.com/storageos/cluster-operator/build/_output/bin/upgrader /usr/local/bin/upgrader
 COPY --from=build /go/src/github.com/storageos/cluster-operator/cmd/image-puller/docker-puller.sh /usr/local/bin/docker-puller.sh
+
+# Set a non-root default user.
+USER 1001

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -4,18 +4,48 @@ import (
 	"flag"
 	"os"
 	"runtime"
+	"strconv"
 
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
+	"github.com/storageos/cluster-operator/internal/pkg/admission"
+	"github.com/storageos/cluster-operator/internal/pkg/admission/scheduler"
 	"github.com/storageos/cluster-operator/pkg/apis"
 	"github.com/storageos/cluster-operator/pkg/controller"
+	"github.com/storageos/cluster-operator/pkg/storageos"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	webhookAdmission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 var log = logf.Log.WithName("storageos.setup")
+
+const (
+	// Env vars.
+	enableSchedulerEnvVar = "ENABLE_SCHEDULER"
+	podNamespaceEnvVar    = "POD_NAMESPACE"
+
+	// operatorNameLabel is the "name" label in the operator's deployment
+	// config. This is needed for proper operator pod selection by webhook
+	// service.
+	// NOTE: If the operator's deployment changes the name label, this must be
+	// updated.
+	operatorNameLabel = "storageos-cluster-operator"
+
+	// podSchedulerWebhookName is a fully qualified name of the pod scheduler
+	// admission webhook.
+	podSchedulerWebhookName = "podscheduler.storageos.com"
+	// podSchedulerResourceName is the name of webhook server, service,
+	// mutatingwebhookconfig and other related resources.
+	podSchedulerResourceName = "storageos-scheduler-webhook"
+	// podSchedulerWebhookPort is the port at which the pod scheduler webhook
+	// server runs.
+	podSchedulerWebhookPort = 5720
+)
 
 func main() {
 
@@ -56,6 +86,54 @@ func main() {
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
 		fatal(err)
+	}
+
+	// Check if storageos scheduler should be enabled.
+	enableScheduler := false
+	enableSchedulerEnvVarVal := os.Getenv(enableSchedulerEnvVar)
+	if len(enableSchedulerEnvVarVal) > 0 {
+		var parseError error
+		enableScheduler, parseError = strconv.ParseBool(enableSchedulerEnvVarVal)
+		if parseError != nil {
+			log.Error(parseError, "unable to parse ENABLE_SCHEDULER val")
+			fatal(parseError)
+		}
+	}
+
+	if enableScheduler {
+		// Configure a pod scheduler webhook handler with StorageOS provisioner
+		// and scheduler.
+		webhookHandler := &scheduler.PodSchedulerSetter{
+			Provisioners:  []string{storageos.CSIProvisionerName, storageos.IntreeProvisionerName},
+			SchedulerName: storageos.SchedulerExtenderName,
+		}
+
+		// Enable webhook config installer.
+		disableWebhookConfigInstaller := false
+
+		// Create a mutating webhook for mutating pods that have volumes managed
+		// by StorageOS and set them to use storageos pod scheduler.
+		mutatingWebhook := &admission.MutatingWebhook{
+			Name:        podSchedulerWebhookName,
+			Namespace:   os.Getenv(podNamespaceEnvVar),
+			ServerName:  podSchedulerResourceName,
+			ServiceName: podSchedulerResourceName,
+			ServiceSelector: map[string]string{
+				"name": operatorNameLabel,
+			},
+			Port: podSchedulerWebhookPort,
+			Operations: []admissionregistrationv1beta1.OperationType{
+				admissionregistrationv1beta1.Create,
+			},
+			Manager:                mgr,
+			ObjectType:             &corev1.Pod{},
+			Handlers:               []webhookAdmission.Handler{webhookHandler},
+			DisableConfigInstaller: &disableWebhookConfigInstaller,
+		}
+
+		if err := mutatingWebhook.SetupWebhook(); err != nil {
+			fatal(err)
+		}
 	}
 
 	log.Info("Starting the StorageOS Operator")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -45,6 +45,9 @@ const (
 	// podSchedulerWebhookPort is the port at which the pod scheduler webhook
 	// server runs.
 	podSchedulerWebhookPort = 5720
+	// podSchedulerAnnotationKey is the pod annotation key that can be set to
+	// skip pod scheduler name mutation.
+	podSchedulerAnnotationKey = "storageos.com/scheduler"
 )
 
 func main() {
@@ -104,8 +107,9 @@ func main() {
 		// Configure a pod scheduler webhook handler with StorageOS provisioner
 		// and scheduler.
 		webhookHandler := &scheduler.PodSchedulerSetter{
-			Provisioners:  []string{storageos.CSIProvisionerName, storageos.IntreeProvisionerName},
-			SchedulerName: storageos.SchedulerExtenderName,
+			Provisioners:           []string{storageos.CSIProvisionerName, storageos.IntreeProvisionerName},
+			SchedulerName:          storageos.SchedulerExtenderName,
+			SchedulerAnnotationKey: podSchedulerAnnotationKey,
 		}
 
 		// Enable webhook config installer.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -26,8 +26,8 @@ var log = logf.Log.WithName("storageos.setup")
 
 const (
 	// Env vars.
-	enableSchedulerEnvVar = "ENABLE_SCHEDULER"
-	podNamespaceEnvVar    = "POD_NAMESPACE"
+	disableSchedulerWebhookEnvVar = "DISABLE_SCHEDULER_WEBHOOK"
+	podNamespaceEnvVar            = "POD_NAMESPACE"
 
 	// operatorNameLabel is the "name" label in the operator's deployment
 	// config. This is needed for proper operator pod selection by webhook
@@ -91,19 +91,19 @@ func main() {
 		fatal(err)
 	}
 
-	// Check if storageos scheduler should be enabled.
-	enableScheduler := false
-	enableSchedulerEnvVarVal := os.Getenv(enableSchedulerEnvVar)
-	if len(enableSchedulerEnvVarVal) > 0 {
+	// Check if storageos pod scheduler webhook should be disabled.
+	disableSchedulerWebhook := false
+	disableSchedulerEnvVarVal := os.Getenv(disableSchedulerWebhookEnvVar)
+	if len(disableSchedulerEnvVarVal) > 0 {
 		var parseError error
-		enableScheduler, parseError = strconv.ParseBool(enableSchedulerEnvVarVal)
+		disableSchedulerWebhook, parseError = strconv.ParseBool(disableSchedulerEnvVarVal)
 		if parseError != nil {
 			log.Error(parseError, "unable to parse ENABLE_SCHEDULER val")
 			fatal(parseError)
 		}
 	}
 
-	if enableScheduler {
+	if !disableSchedulerWebhook {
 		// Configure a pod scheduler webhook handler with StorageOS provisioner
 		// and scheduler.
 		webhookHandler := &scheduler.PodSchedulerSetter{

--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -320,6 +320,12 @@ spec:
           - use
           resourceNames:
           - privileged
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - '*'
       deployments:
       - name: storageos-operator
         spec:
@@ -346,9 +352,17 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: OPERATOR_NAME
                   value: cluster-operator
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ENABLE_SCHEDULER
+                  value: "true"
                 ports:
                 - containerPort: 8080
                   name: metrics
+                - containerPort: 5720
+                  name: podschedwebhook
   customresourcedefinitions:
     owned:
     - name: storageosclusters.storageos.com

--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -356,8 +356,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                - name: ENABLE_SCHEDULER
-                  value: "true"
+                - name: DISABLE_SCHEDULER_WEBHOOK
+                  value: "false"
                 ports:
                 - containerPort: 8080
                   name: metrics

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -320,6 +320,12 @@ spec:
           - use
           resourceNames:
           - privileged
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - '*'
       deployments:
       - name: storageos-operator
         spec:
@@ -346,9 +352,17 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: OPERATOR_NAME
                   value: cluster-operator
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ENABLE_SCHEDULER
+                  value: "true"
                 ports:
                 - containerPort: 8080
                   name: metrics
+                - containerPort: 5720
+                  name: podschedwebhook
   customresourcedefinitions:
     owned:
     - name: storageosclusters.storageos.com

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -356,8 +356,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                - name: ENABLE_SCHEDULER
-                  value: "true"
+                - name: DISABLE_SCHEDULER_WEBHOOK
+                  value: "false"
                 ports:
                 - containerPort: 8080
                   name: metrics

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -40,8 +40,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "cluster-operator"
-            - name: ENABLE_SCHEDULER
-              value: "true"
+            - name: DISABLE_SCHEDULER_WEBHOOK
+              value: "false"
       tolerations:
       - key: "key"
         operator: "Equal"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,6 +20,8 @@ spec:
           ports:
           - containerPort: 60000
             name: metrics
+          - containerPort: 5720
+            name: podschedwebhook
           command:
           - cluster-operator
           imagePullPolicy: IfNotPresent
@@ -32,8 +34,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "cluster-operator"
+            - name: ENABLE_SCHEDULER
+              value: "true"
       tolerations:
       - key: "key"
         operator: "Equal"

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -127,3 +127,9 @@ rules:
   - update
   - get
   - use
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - '*'

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -966,8 +966,8 @@ data:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.namespace
-                      - name: ENABLE_SCHEDULER
-                        value: "true"
+                      - name: DISABLE_SCHEDULER_WEBHOOK
+                        value: "false"
                       ports:
                       - containerPort: 8080
                         name: metrics

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -930,6 +930,12 @@ data:
                 - use
                 resourceNames:
                 - privileged
+              - apiGroups:
+                - admissionregistration.k8s.io
+                resources:
+                - mutatingwebhookconfigurations
+                verbs:
+                - '*'
             deployments:
             - name: storageos-operator
               spec:
@@ -956,9 +962,17 @@ data:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
                       - name: OPERATOR_NAME
                         value: "cluster-operator"
+                      - name: POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: ENABLE_SCHEDULER
+                        value: "true"
                       ports:
                       - containerPort: 8080
                         name: metrics
+                      - containerPort: 5720
+                        name: podschedwebhook
                     - name: scorecard-proxy
                       image: quay.io/operator-framework/scorecard-proxy:v0.10.0
                       imagePullPolicy: IfNotPresent

--- a/docs/pod-scheduler-mutating-admission-controller.md
+++ b/docs/pod-scheduler-mutating-admission-controller.md
@@ -1,0 +1,74 @@
+# Pod Scheduler Mutating Admission Controller
+
+Cluster operator supports running a mutating admission controller to
+automatically set the `schedulerName` attribute of a pod to StorageOS scheduler.
+
+## Webhook Server
+
+The admission controller webhook server runs within the operator, managed by the
+controller manager. The webhook server must support TLS. A self-signed TLS
+certificate is generated within the operator and used when running the webhook
+server. During the webhook server bootstrap process, the operator also creates a
+`MutatingWebhookConfiguration` and a `Service` resources. A client cert for the
+generated cert is set in the `MutatingWebhookConfiguration`. This client cert is
+used by k8s when it communicates with the webhook server. The `Service` is used
+by the k8s to communicate with the webhook server. The `Service` is initialized
+with label selectors to select the operator pod with the port that serves the
+webhook server.
+
+The `MutatingWebhookConfiguration` is not bound to any namespace.
+```
+$ kubectl get mutatingwebhookconfigurations
+NAME                    CREATED AT
+storageos-scheduler-webhook   2019-10-22T08:03:04Z
+```
+
+The `Service` is created in the namespace where the operator is deployed.
+```
+$ kubectl -n storageos-operator get service
+NAME                    TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
+storageos-scheduler-webhook   ClusterIP   10.108.236.78   <none>        443/TCP   3m51s
+```
+
+If the operator pod restarts for some reason, the previous TLS certificate is
+lost because it was stored within the pod. The operator generates and signs a
+new cert and updates the `MutatingWebhookConfiguration` with a new client cert.
+This may change in the future, the certificate may be generated once and stored
+in a k8s `Secret` and shared among multiple instances of the operator, making
+the cert persistent. If the certificate expires, the operator handles renewal of
+the certificate automatically.
+
+If the webhook server is not available due to some reason, the failure policy of
+`MutatingWebhookConfiguration` is set to ignore the webhook.
+
+## Mutation Conditions
+
+The webhook server handler conditionally mutates the pods. The conditions for
+mutating are:
+
+- The pod has at least one volume that is managed by StorageOS.
+- The StorageOS cluster has the scheduler enabled.
+
+Both the above conditions must be true for the mutation to applied.
+
+## Deployment
+
+The admission controller is enabled in the default installation of the operator.
+In order to disable the admission controller, the `Deployment` config of the
+operator can be modified to set the environment variable `ENABLE_SCHEDULER` to
+`"false"`.
+
+## Skipping Mutation
+
+If a pod uses StorageOS volume but wants to skip the mutation, this can be
+achieved by adding an annotation to the pod:
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+    ...
+    annotations:
+        storageos.com/scheduler: "false"
+    ...
+```
+The value must be a string.

--- a/docs/pod-scheduler-mutating-admission-controller.md
+++ b/docs/pod-scheduler-mutating-admission-controller.md
@@ -49,7 +49,7 @@ mutating are:
 - The pod has at least one volume that is managed by StorageOS.
 - The StorageOS cluster has the scheduler enabled.
 
-Both the above conditions must be true for the mutation to applied.
+Both the above conditions must be true for the mutation to be applied.
 
 ## Deployment
 

--- a/internal/pkg/admission/doc.go
+++ b/internal/pkg/admission/doc.go
@@ -1,0 +1,2 @@
+// Package admission provides helpers for admission webhook builder and server.
+package admission

--- a/internal/pkg/admission/scheduler/doc.go
+++ b/internal/pkg/admission/scheduler/doc.go
@@ -1,0 +1,6 @@
+// Package scheduler contains mutating admission controller webhook handlers for
+// pod scheduler. The handler mutates a given pod if the pod has any volume
+// that's managed by the given volume provisioners in
+// PodSchedulerSetter.Provisioners and the associated scheduler is enabled.
+// The scheduler name is set in PodSchedulerSetter.SchedulerName.
+package scheduler

--- a/internal/pkg/admission/scheduler/handler.go
+++ b/internal/pkg/admission/scheduler/handler.go
@@ -1,0 +1,92 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+// PodSchedulerSetter is responsible for mutating and setting pod scheduler
+// name.
+type PodSchedulerSetter struct {
+	client  client.Client
+	decoder types.Decoder
+	// Provisioners is a list of storage provisioners to check a pod volume
+	// against.
+	Provisioners []string
+	// SchedulerName is the name of the scheduler to mutate pods with.
+	SchedulerName string
+}
+
+// Check if the Handler interface is implemented.
+var _ admission.Handler = &PodSchedulerSetter{}
+
+// Handle handles an admission request and mutates a pod object in the request.
+func (p *PodSchedulerSetter) Handle(ctx context.Context, req types.Request) types.Response {
+	// Decode the pod in request to a pod variable.
+	pod := &corev1.Pod{}
+	if err := p.decoder.Decode(req, pod); err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+	// Create a copy of the pod to mutate.
+	copy := pod.DeepCopy()
+	if err := p.mutatePodsFn(ctx, copy); err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponse(pod, copy)
+}
+
+// mutatePodFn mutates a given pod with a configured scheduler name if the pod
+// is associated with volumes managed by the configured provisioners.
+func (p *PodSchedulerSetter) mutatePodsFn(ctx context.Context, pod *corev1.Pod) error {
+	managedVols := []corev1.Volume{}
+
+	// Find all the managed volumes.
+	for _, vol := range pod.Spec.Volumes {
+		ok, err := p.IsManagedVolume(vol, pod.Namespace)
+		if err != nil {
+			return fmt.Errorf("failed to determine if the volume is managed: %v", err)
+		}
+		if ok {
+			managedVols = append(managedVols, vol)
+		}
+	}
+
+	// Set scheduler name only if there are managed volumes.
+	if len(managedVols) > 0 {
+		// Check if StorageOS scheduler is enabled before setting the scheduler.
+		cluster, err := p.getCurrentStorageOSCluster()
+		if err != nil {
+			return err
+		}
+		if !cluster.Spec.DisableScheduler {
+			pod.Spec.SchedulerName = p.SchedulerName
+		}
+	}
+
+	return nil
+}
+
+// Check if the Client interface is implemented.
+var _ inject.Client = &PodSchedulerSetter{}
+
+// InjectClient injects a client into object.
+func (p *PodSchedulerSetter) InjectClient(c client.Client) error {
+	p.client = c
+	return nil
+}
+
+// Check if the Decoder interface is implemented.
+var _ inject.Decoder = &PodSchedulerSetter{}
+
+// InjectDecoder injects a decoder into the object.
+func (p *PodSchedulerSetter) InjectDecoder(d types.Decoder) error {
+	p.decoder = d
+	return nil
+}

--- a/internal/pkg/admission/scheduler/handler_test.go
+++ b/internal/pkg/admission/scheduler/handler_test.go
@@ -1,0 +1,192 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	storageosapis "github.com/storageos/cluster-operator/pkg/apis"
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestMutatePodFn(t *testing.T) {
+	storageosSchedulerName := "storageos-scheduler"
+	storageosCSIProvisioner := "storageos"
+	storageosNativeProvisioner := "kubernetes.io/storageos"
+
+	// Create a new scheme and add all the types from different clientsets.
+	scheme := runtime.NewScheme()
+	kscheme.AddToScheme(scheme)
+	apiextensionsv1beta1.AddToScheme(scheme)
+	storageosapis.AddToScheme(scheme)
+
+	// StorageOS StorageClass.
+	stosSC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fast",
+		},
+		Provisioner: storageosCSIProvisioner,
+	}
+
+	// StorageOS StorageClass with different provisioner.
+	stosNativeSC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fast2",
+		},
+		Provisioner: storageosNativeProvisioner,
+	}
+
+	// Non-StorageOS StorageClass.
+	fooSC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "slow",
+		},
+		Provisioner: "foo-provisioner",
+	}
+
+	// PVC that uses StorageOS StorageClass.
+	stosPVC := createPVC("pv1", "default", stosSC.Name)
+
+	// PVC that uses StorageOS native StorageClass.
+	stosNativePVC := createPVC("pv2", "default", stosNativeSC.Name)
+
+	// PVC that uses non-StorageOS StorageClass.
+	fooPVC := createPVC("pv3", "default", fooSC.Name)
+
+	testcases := []struct {
+		name              string
+		volumeClaimNames  []string
+		schedulerDisabled bool
+		wantSchedulerName string
+	}{
+		{
+			name:              "pod with storageos volume, scheduler enabled",
+			volumeClaimNames:  []string{stosPVC.Name},
+			schedulerDisabled: false,
+			wantSchedulerName: storageosSchedulerName,
+		},
+		{
+			name:              "pod with storageos volume, scheduler disabled",
+			volumeClaimNames:  []string{stosPVC.Name},
+			schedulerDisabled: true,
+		},
+		{
+			name:              "pod without storageos volume, scheduler enabled",
+			volumeClaimNames:  []string{fooPVC.Name},
+			schedulerDisabled: false,
+		},
+		{
+			name:              "pod without storageos volume, scheduler disabled",
+			volumeClaimNames:  []string{fooPVC.Name},
+			schedulerDisabled: true,
+		},
+		{
+			// Using the PVC that uses the native provisioner StorageClass.
+			name:              "pod with non-storageos and storageos volumes, scheduler enabled",
+			volumeClaimNames:  []string{stosNativePVC.Name, fooPVC.Name},
+			schedulerDisabled: false,
+			wantSchedulerName: storageosSchedulerName,
+		},
+		{
+			name:              "pod with non-storageos and storageos volumes, scheduler disabled",
+			volumeClaimNames:  []string{stosPVC.Name, fooPVC.Name},
+			schedulerDisabled: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// StorageOS Cluster with scheduler configured.
+			stosCluster := &storageosv1.StorageOSCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stos",
+					Namespace: "default",
+				},
+				Spec: storageosv1.StorageOSClusterSpec{
+					DisableScheduler: tc.schedulerDisabled,
+				},
+			}
+
+			// Pod that uses PVCs.
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{},
+					Containers: []corev1.Container{
+						{
+							Name:  "some-app",
+							Image: "some-image",
+						},
+					},
+				},
+			}
+
+			// Append the volumes in the pod spec.
+			for i, claimName := range tc.volumeClaimNames {
+				pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+					Name: fmt.Sprintf("vol%d", i),
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: claimName,
+						},
+					},
+				})
+			}
+
+			// Create all the above resources and get a k8s client.
+			client := fake.NewFakeClientWithScheme(scheme, stosCluster, stosSC, stosNativeSC, fooSC, stosPVC, stosNativePVC, fooPVC, pod)
+
+			// Create a PodSchedulerSetter instance with the fake client.
+			podSchedulerSetter := PodSchedulerSetter{
+				client: client,
+				Provisioners: []string{
+					storageosCSIProvisioner,
+					storageosNativeProvisioner,
+				},
+				SchedulerName: storageosSchedulerName,
+			}
+
+			// Pass the created pod to the mutatePodFn and check if the schedulerName in
+			// podSpec changed.
+			if err := podSchedulerSetter.mutatePodsFn(context.Background(), pod); err != nil {
+				t.Fatalf("failed to mutate pod: %v", err)
+			}
+
+			if pod.Spec.SchedulerName != tc.wantSchedulerName {
+				t.Errorf("unexpected pod scheduler name:\n\t(WNT) %s\n\t(GOT) %s", tc.wantSchedulerName, pod.Spec.SchedulerName)
+			}
+		})
+	}
+}
+
+// createPVC creates and returns a PVC object.
+func createPVC(name, namespace, storageClassName string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			StorageClassName: &storageClassName,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+}

--- a/internal/pkg/admission/scheduler/helper.go
+++ b/internal/pkg/admission/scheduler/helper.go
@@ -1,0 +1,92 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ErrNoCluster is the error when there's no running StorageOS cluster found.
+var ErrNoCluster = errors.New("no storageos cluster found")
+
+// IsManagedVolume inspects a given volume to find if it's managed by the given
+// provisioners.
+func (p *PodSchedulerSetter) IsManagedVolume(volume corev1.Volume, namespace string) (bool, error) {
+	// Ensure that the volume has a claim.
+	if volume.PersistentVolumeClaim == nil {
+		return false, nil
+	}
+
+	// Get the PersistentVolumeClaim object.
+	pvc := &corev1.PersistentVolumeClaim{}
+	pvcNSName := types.NamespacedName{
+		Name:      volume.PersistentVolumeClaim.ClaimName,
+		Namespace: namespace,
+	}
+	if err := p.client.Get(context.Background(), pvcNSName, pvc); err != nil {
+		return false, fmt.Errorf("failed to get PVC: %v", err)
+	}
+
+	// Get the StorageClass of the PVC.
+	scName := pvc.Spec.StorageClassName
+	if scName == nil {
+		return false, fmt.Errorf("could not get StorageClass name associated with PVC %q", pvc.Name)
+	}
+	sc := &storagev1.StorageClass{}
+	scNSName := types.NamespacedName{
+		Name: *scName,
+	}
+	if err := p.client.Get(context.Background(), scNSName, sc); err != nil {
+		return false, fmt.Errorf("failed to get StorageClass: %v", err)
+	}
+
+	// Check if the StorageClass provisioner matches with any of the provided
+	// provisioners.
+	for _, provisioner := range p.Provisioners {
+		if sc.Provisioner == provisioner {
+			// This is a managed volume.
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// getCurrentStorageOSCluster returns the currently running StorageOS cluster.
+// TODO: Move this to a separate package as a helper function.
+func (p *PodSchedulerSetter) getCurrentStorageOSCluster() (*storageosv1.StorageOSCluster, error) {
+	var currentCluster *storageosv1.StorageOSCluster
+
+	// Get a list of all the StorageOS clusters.
+	clusterList := &storageosv1.StorageOSClusterList{}
+	if err := p.client.List(context.Background(), &client.ListOptions{}, clusterList); err != nil {
+		return nil, fmt.Errorf("failed to list storageos clusters: %v", err)
+	}
+
+	// If there's only one cluster, return it as the current cluster.
+	if len(clusterList.Items) == 1 {
+		currentCluster = &clusterList.Items[0]
+	}
+
+	// If there are multiple clusters, consider the status of the cluster.
+	for _, cluster := range clusterList.Items {
+		// Only one cluster can be in running phase at a time.
+		if cluster.Status.Phase == storageosv1.ClusterPhaseRunning {
+			currentCluster = &cluster
+			break
+		}
+	}
+
+	// If no current cluster found, fail.
+	if currentCluster != nil {
+		return currentCluster, nil
+	}
+
+	return currentCluster, ErrNoCluster
+}

--- a/internal/pkg/admission/webhook.go
+++ b/internal/pkg/admission/webhook.go
@@ -1,0 +1,82 @@
+package admission
+
+import (
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+// MutatingWebhook is a mutating admission webhook.
+type MutatingWebhook struct {
+	// Name of the mutating webhook.
+	Name string
+	// Namespace where the mutating webhook is deployed.
+	Namespace string
+	// ServerName is the name of the admission webhook server.
+	ServerName string
+	// ServiceName is the Service for the webhook endpoints.
+	ServiceName string
+	// ServiceSelector is the label selector used by Service to select the pods.
+	ServiceSelector map[string]string
+	// Port is the port at which the webhook server runs.
+	Port int32
+	// Operations are the admission operation events to listen for.
+	Operations []admissionregistrationv1beta1.OperationType
+	// Manager is a controller manager.
+	Manager manager.Manager
+	// ObjectType is the type of the k8s object to mutate.
+	ObjectType runtime.Object
+	// Handlers are the webhook handlers.
+	Handlers []admission.Handler
+	// DisableConfigInstaller can be used to disable automated installation and
+	// update of the mutating webhook configuration.
+	DisableConfigInstaller *bool
+}
+
+// SetupWebhook setsup the webhook by building a mutating webhook, creating a
+// server at a given port, a service, mutating webhook configuration and
+// registering the created webhook with the created server.
+func (w MutatingWebhook) SetupWebhook() error {
+	mutatingWebhook, err := builder.NewWebhookBuilder().
+		Name(w.Name).
+		Mutating().
+		Operations(w.Operations...).
+		WithManager(w.Manager).
+		ForType(w.ObjectType).
+		Handlers(w.Handlers...).
+		Build()
+	if err != nil {
+		return err
+	}
+
+	// Create a new server with the controller manager. Set the webhook
+	// bootstrap to include a Service configuration.
+	// NOTE: If we need to store the certificate outside of the operator, a
+	// secret can be configured in the bootstrap. This way, the cert will be
+	// generated just once and reused or shared by the operator(s).
+	as, err := webhook.NewServer(w.ServerName, w.Manager, webhook.ServerOptions{
+		Port:                          w.Port,
+		DisableWebhookConfigInstaller: w.DisableConfigInstaller,
+		BootstrapOptions: &webhook.BootstrapOptions{
+			Service: &webhook.Service{
+				Name:      w.ServiceName,
+				Namespace: w.Namespace,
+				Selectors: w.ServiceSelector,
+			},
+			MutatingWebhookConfigName: w.ServerName,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Register the webhook with the server.
+	if err := as.Register(mutatingWebhook); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -13,6 +13,15 @@ import (
 )
 
 const (
+	// SchedulerExtenderName is the name of StorageOS scheduler.
+	SchedulerExtenderName = "storageos-scheduler"
+	// IntreeProvisionerName is the name of the k8s native provisioner.
+	IntreeProvisionerName = "kubernetes.io/storageos"
+	// CSIProvisionerName is the name of the CSI provisioner.
+	CSIProvisionerName = "storageos"
+)
+
+const (
 	initSecretName                 = "init-secret"
 	tlsSecretName                  = "tls-secret"
 	csiProvisionerSecretName       = "csi-provisioner-secret"
@@ -24,16 +33,12 @@ const (
 	statefulsetKind = "statefulset"
 	deploymentKind  = "deployment"
 
-	daemonsetName         = "storageos-daemonset"
-	statefulsetName       = "storageos-statefulset"
-	csiHelperName         = "storageos-csi-helper"
-	schedulerExtenderName = "storageos-scheduler"
+	daemonsetName   = "storageos-daemonset"
+	statefulsetName = "storageos-statefulset"
+	csiHelperName   = "storageos-csi-helper"
 
 	tlsSecretType       = "kubernetes.io/tls"
 	storageosSecretType = "kubernetes.io/storageos"
-
-	intreeProvisionerName = "kubernetes.io/storageos"
-	csiProvisionerName    = "storageos"
 
 	defaultFSType                            = "ext4"
 	secretNamespaceKey                       = "adminSecretNamespace"

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -1541,7 +1541,7 @@ func TestDeploySchedulerExtender(t *testing.T) {
 	// Check the attributes of the scheduler deployment.
 	schedDeployment := &appsv1.Deployment{}
 	schedDeploymentNSName := types.NamespacedName{
-		Name:      schedulerExtenderName,
+		Name:      SchedulerExtenderName,
 		Namespace: defaultNS,
 	}
 

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -71,7 +71,7 @@ func (s Deployment) createSchedulerDeployment(replicas int32) error {
 	// Add pod toleration for quick recovery on node failure.
 	addPodTolerationForRecovery(&spec.Template.Spec)
 
-	return s.k8sResourceManager.Deployment(schedulerExtenderName, s.stos.Spec.GetResourceNS(), spec).Create()
+	return s.k8sResourceManager.Deployment(SchedulerExtenderName, s.stos.Spec.GetResourceNS(), spec).Create()
 }
 
 // schedulerContainers returns a list of containers that should be part of the
@@ -115,7 +115,7 @@ func (s Deployment) schedulerVolumes() []corev1.Volume {
 // deleteSchedulerExtender deletes all the scheduler related resources.
 func (s Deployment) deleteSchedulerExtender() error {
 	namespace := s.stos.Spec.GetResourceNS()
-	if err := s.k8sResourceManager.Deployment(schedulerExtenderName, namespace, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.Deployment(SchedulerExtenderName, namespace, nil).Delete(); err != nil {
 		return err
 	}
 	if err := s.k8sResourceManager.ConfigMap(policyConfigMapName, namespace, nil).Delete(); err != nil {
@@ -220,7 +220,7 @@ func (s Deployment) createSchedulerConfiguration() error {
       lockObjectNamespace: {{.Namespace}}
 `
 	schedConfigData := schedulerConfigTemplate{
-		SchedulerName:  schedulerExtenderName,
+		SchedulerName:  SchedulerExtenderName,
 		PolicyName:     policyConfigMapName,
 		Namespace:      s.stos.Spec.GetResourceNS(),
 		LeaderElection: true,

--- a/pkg/storageos/storageclass.go
+++ b/pkg/storageos/storageclass.go
@@ -2,10 +2,10 @@ package storageos
 
 func (s *Deployment) createStorageClass() error {
 	// Provisioner name for in-tree storage plugin.
-	provisioner := intreeProvisionerName
+	provisioner := IntreeProvisionerName
 
 	if s.stos.Spec.CSI.Enable {
-		provisioner = csiProvisionerName
+		provisioner = CSIProvisionerName
 	}
 
 	parameters := map[string]string{

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -204,6 +204,12 @@ operator-sdk-e2e-cleanup() {
 
     # Delete NFSServer statefulset.
     kubectl delete statefulset.apps/example-nfsserver --ignore-not-found=true
+
+    # Delete webhook service.
+    kubectl -n storageos-operator delete service/storageos-scheduler-webhook --ignore-not-found=true
+
+    # Delete webhook config.
+    kubectl delete mutatingwebhookconfigurations storageos-scheduler-webhook --ignore-not-found=true
 }
 
 main() {

--- a/test/e2e/clusterInTreePlugin_test.go
+++ b/test/e2e/clusterInTreePlugin_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	storageos "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 	testutil "github.com/storageos/cluster-operator/test/e2e/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +24,7 @@ func TestClusterInTreePlugin(t *testing.T) {
 		t.Fatalf("could not get namespace: %v", err)
 	}
 
-	clusterSpec := storageos.StorageOSClusterSpec{
+	clusterSpec := storageosv1.StorageOSClusterSpec{
 		SecretRefName:      "storageos-api",
 		SecretRefNamespace: "default",
 		Namespace:          resourceNS,
@@ -65,6 +65,12 @@ func TestClusterInTreePlugin(t *testing.T) {
 	if len(daemonset.Spec.Template.Spec.Containers) != 1 {
 		t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 2)
 	}
+
+	// Test pod scheduler mutating admission contoller.
+	// This test creates a StorageOS consumer pod which will fail for CSI
+	// deployments on openshift 3.11. Therefore, run this test with native
+	// driver only.
+	testutil.PodSchedulerAdmissionControllerTest(t, ctx)
 
 	// Test node label sync.
 	testutil.NodeLabelSyncTest(t, f.KubeClient)

--- a/test/e2e/util/admission_controller.go
+++ b/test/e2e/util/admission_controller.go
@@ -1,0 +1,126 @@
+package util
+
+import (
+	goctx "context"
+	"testing"
+	"time"
+
+	"github.com/blang/semver"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+	storageos "github.com/storageos/cluster-operator/pkg/storageos"
+	"github.com/storageos/cluster-operator/pkg/util/k8sutil"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+// PodSchedulerAdmissionControllerTest checks if the pod scheduler mutating
+// admission controller mutates the scheduler name of a pod by creates a pvc
+// backed by StorageOS and a pod that uses the PVC.
+// NOTE: This test has a minimum k8s version requirement.
+func PodSchedulerAdmissionControllerTest(t *testing.T, ctx *framework.TestCtx) {
+	// Minimum version of k8s required to run this test.
+	minVersion := semver.Version{
+		Major: 1,
+		Minor: 13,
+		Patch: 0,
+	}
+
+	f := framework.Global
+
+	// Check the k8s version before running this test. Admission controller
+	// does not works on openshift 3.11 (k8s 1.11).
+	var log = logf.Log.WithName("test.admissioncontroller")
+	k := k8sutil.NewK8SOps(f.KubeClient, log)
+	version, err := k.GetK8SVersion()
+	if err != nil {
+		t.Errorf("failed to get k8s version: %v", err)
+	}
+
+	currentVersion, err := semver.Parse(version)
+	if err != nil {
+		t.Errorf("failed to parse k8s version: %v", err)
+	}
+
+	if currentVersion.Compare(minVersion) < 0 {
+		// This test is not supported in this version of k8s. Skip the test.
+		return
+	}
+
+	// Provide some time for StorageOS initialization to be complete.
+	time.Sleep(10 * time.Second)
+
+	// Create a StorageOS PVC.
+	scName := storageosv1.DefaultStorageClassName
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &scName,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+	if err := f.Client.Create(goctx.TODO(), pvc, &framework.CleanupOptions{TestContext: ctx, Timeout: CleanupTimeout, RetryInterval: CleanupRetryInterval}); err != nil {
+		t.Fatalf("failed to create pvc using StorageOS: %v", err)
+	}
+
+	// Wait for the volume to be created.
+	time.Sleep(5 * time.Second)
+
+	// Create a Pod with the above PVC.
+	podSpec := corev1.PodSpec{
+		Volumes: []corev1.Volume{
+			{
+				Name: "some-data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "some-pvc",
+					},
+				},
+			},
+		},
+		Containers: []corev1.Container{
+			{
+				Name:  "test-app",
+				Image: "nginx",
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "some-data",
+						MountPath: "/data",
+					},
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "default",
+		},
+		Spec: podSpec,
+	}
+	if err := f.Client.Create(goctx.TODO(), pod, &framework.CleanupOptions{TestContext: ctx, Timeout: CleanupTimeout, RetryInterval: CleanupRetryInterval}); err != nil {
+		t.Fatalf("failed to create pod using StorageOS: %v", err)
+	}
+
+	// Wait for the pod to be created.
+	time.Sleep(15 * time.Second)
+
+	// Get the pod and check the pod scheduler name.
+	if err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "test-app", Namespace: "default"}, pod); err != nil {
+		t.Errorf("failed to get pod using storageos: %v", err)
+	}
+	if pod.Spec.SchedulerName != storageos.SchedulerExtenderName {
+		t.Errorf("unexpected scheduler name:\n\t(WNT) %s\n\t(GOT) %s", storageos.SchedulerExtenderName, pod.Spec.SchedulerName)
+	}
+}


### PR DESCRIPTION
This adds a mutating admission controller for pod scheduler.
When enabled, any pod that uses a volume managed by StorageOS will be mutated to use the StorageOS scheduler.

Adds new packages `pkg/admission` and `pkg/admission/scheduler` under `internal/` for now. They provide helpers and references for adding more admission controllers in the future, if needed.

Adds e2e test to verify that the mutation works.

Refer: docs/pod-scheduler-mutating-admission-controller.md

kubebuilder webhook docs: https://book-v1.book.kubebuilder.io/beyond_basics/what_is_a_webhook.html