### PR TITLE
create-pr: Update for operatorhub changes

### DIFF
--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -8,6 +8,7 @@ set -e
 # GITHUB_USER: github username
 # GITHUB_EMAIL: github user email
 # GITHUB_TOKEN: github user API token with repo access permission only
+# SIGN_OFF_NAME: git commit sign-off name
 # VERSION: release version
 # TARGET_REPO: upstream community operator repo
 # COMMUNITY_REPO_PATH: community operator repo path
@@ -16,7 +17,6 @@ set -e
 
 
 declare -a metadatafiles=(
-  "${OLM_ROOT}/storageos.package.yaml" 
   "${OLM_ROOT}/storageoscluster.crd.yaml"
   "${OLM_ROOT}/storageosjob.crd.yaml"
   "${OLM_ROOT}/storageosupgrade.crd.yaml"
@@ -32,33 +32,40 @@ echo "machine github.com
 
 # Configure git.
 git config --global user.email "$GITHUB_EMAIL"
-git config --global user.name "$GITHUB_USER"
+git config --global user.name "$SIGN_OFF_NAME"
 
 # Clone community hub repo.
 git clone $TARGET_REPO $COMMUNITY_REPO_PATH
 
-# Copy OLM package changes.
+echo "Creating new release dir in community repo for $VERSION"
+mkdir $COMMUNITY_REPO_PATH/$COMMUNITY_PKG_PATH/$VERSION
+
+# Copy OLM manifest files.
 for i in "${metadatafiles[@]}"
 do
   echo "Copying $i"
   # Copy the metada files to target package in community repo.
   # Example: cp deploy/olm/storageos/storageos.package.yaml /go/src/github.com/operator-framework/community-operators/upstream-community-operators/storageos/
-  cp $i $COMMUNITY_REPO_PATH/$COMMUNITY_PKG_PATH
+  cp $i $COMMUNITY_REPO_PATH/$COMMUNITY_PKG_PATH/$VERSION
 done
+
+# Copy OLM package file.
+cp $OLM_ROOT/storageos.package.yaml $COMMUNITY_REPO_PATH/$COMMUNITY_PKG_PATH
 
 # Create branch, commit and create a PR.
 MESSAGE="Update StorageOS Operator to version ${VERSION}"
 PR_TEMPLATE="### Update to existing Operators
 
 * [x] Is your new CSV pointing to the previous version with the replaces property?
-* [x] Is your new CSV referenced in the appropriate channel defined in the package.yaml ?
-* [x] Have you tested an update to your Operator when deployed via OLM?"
+* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the package.yaml ?
+* [x] Have you tested an update to your Operator when deployed via OLM?
+* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?"
 
 pushd $COMMUNITY_REPO_PATH
 hub remote add fork https://github.com/$GITHUB_USER/community-operators
 git checkout -b $VERSION
 git add *
-git commit -m "$MESSAGE"
+git commit -m "$MESSAGE" -s
 git push fork $VERSION
 # Create PR message by combining commit message and PR template.
 PR_MESSAGE="${MESSAGE}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,6 +21,7 @@ if [ "$1" = "tagged" ]; then
         -e GITHUB_USER=$GH_USER \
         -e GITHUB_EMAIL=$GH_EMAIL \
         -e GITHUB_TOKEN=$API_TOKEN \
+        -e SIGN_OFF_NAME=$SIGN_OFF_NAME \
         -e VERSION=$TRAVIS_TAG \
         -e TARGET_REPO="https://github.com/operator-framework/community-operators/" \
         -e COMMUNITY_REPO_PATH="/go/src/github.com/operator-framework/community-operators/" \


### PR DESCRIPTION
operatorhub repo changed the directory structure of the OLM files. This
change adapts to the new dir structure.
It also signs the commit and appends the PR template with new additions.

Updated TravisCI settings with `SIGN_OFF_NAME` env var.