### PR TITLE
Bump to ubi8 base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_ENV = GOOS=linux CGO_ENABLED=0
 SDK_VERSION = v0.10.0
 MACHINE = $(shell uname -m)
 BUILD_IMAGE = golang:1.12.9
-BASE_IMAGE = storageos/base-image:0.1.0
+BASE_IMAGE = storageos/base-image:0.2.0
 
 # When this file name is modified, the new name must be added in .travis.yml
 # file as well for publishing the file at release.

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_IMAGE=golang:1.12.9
-ARG BASE_IMAGE=storageos/base-image:0.1.0
+ARG BASE_IMAGE=storageos/base-image:0.2.0
 ARG OPERATOR_IMAGE=storageos/cluster-operator:test
 
 FROM ${BUILD_IMAGE} AS build

--- a/build/rhel-build-service/Dockerfile
+++ b/build/rhel-build-service/Dockerfile
@@ -1,5 +1,5 @@
 # ARG BUILD_IMAGE=golang:1.12.9
-# ARG BASE_IMAGE=storageos/base-image:0.1.0
+# ARG BASE_IMAGE=storageos/base-image:0.2.0
 # ARG OPERATOR_IMAGE=storageos/cluster-operator:test
 
 FROM golang:1.12.9 AS build
@@ -14,7 +14,7 @@ RUN make generate
 RUN make build/cluster-operator OPERATOR_IMAGE=registry.connect.redhat.com/storageos/cluster-operator:1.1.0
 RUN make build/upgrader
 
-FROM storageos/base-image:0.1.0
+FROM storageos/base-image:0.2.0
 LABEL name="StorageOS Cluster Operator" \
     maintainer="support@storageos.com" \
     vendor="StorageOS" \


### PR DESCRIPTION
Upgrades base image from RHEL7 -> RHEL8.

e2e tests passing, will get further testing pre-release.