### PR TITLE
nfs: use k8s rest config from controller manager

### DIFF
--- a/pkg/nfs/delete_test.go
+++ b/pkg/nfs/delete_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -66,6 +67,7 @@ func TestDelete(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewFakeClient(existingPVC)
+			kConfig := &rest.Config{}
 
 			// NFSServer config.
 			nfsServer := &storageosv1.NFSServer{
@@ -86,7 +88,7 @@ func TestDelete(t *testing.T) {
 			}
 
 			// NFSServer deployment.
-			deployment := NewDeployment(client, stosCluster, nfsServer, nil, nil, nil)
+			deployment := NewDeployment(client, kConfig, stosCluster, nfsServer, nil, nil, nil)
 
 			// Deploy NFS Server.
 			if err := deployment.Deploy(); err != nil {

--- a/pkg/nfs/deploy.go
+++ b/pkg/nfs/deploy.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/rest"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -165,14 +164,8 @@ func (d *Deployment) createServiceMonitor() error {
 		return err
 	}
 
-	// Get a k8s client config
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		return err
-	}
-
 	// Create the ServiceMonitor resource for the metrics service.
-	_, err = metrics.CreateServiceMonitors(cfg, d.nfsServer.Namespace, []*corev1.Service{metricsService})
+	_, err = metrics.CreateServiceMonitors(d.kConfig, d.nfsServer.Namespace, []*corev1.Service{metricsService})
 	if err != nil {
 		return err
 	}

--- a/pkg/nfs/deploy_test.go
+++ b/pkg/nfs/deploy_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -41,6 +42,7 @@ func TestDeploy(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewFakeClient()
+			kConfig := &rest.Config{}
 
 			// NFSServer config.
 			nfsServer := &storageosv1.NFSServer{
@@ -61,7 +63,7 @@ func TestDeploy(t *testing.T) {
 			}
 
 			// NFSServer deployment.
-			deployment := NewDeployment(client, stosCluster, nfsServer, nil, nil, nil)
+			deployment := NewDeployment(client, kConfig, stosCluster, nfsServer, nil, nil, nil)
 
 			// Deploy NFS Server.
 			if err := deployment.Deploy(); err != nil {

--- a/pkg/nfs/deployment.go
+++ b/pkg/nfs/deployment.go
@@ -4,6 +4,7 @@ import (
 	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 	"github.com/storageos/cluster-operator/pkg/util/k8s"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -11,6 +12,7 @@ import (
 // Deployment manages the NFS server deployment.
 type Deployment struct {
 	client             client.Client
+	kConfig            *rest.Config
 	nfsServer          *storageosv1.NFSServer
 	recorder           record.EventRecorder
 	scheme             *runtime.Scheme
@@ -21,6 +23,7 @@ type Deployment struct {
 // NewDeployment returns an initialized Deployment.
 func NewDeployment(
 	client client.Client,
+	kConfig *rest.Config,
 	stosCluster *storageosv1.StorageOSCluster,
 	nfsServer *storageosv1.NFSServer,
 	labels map[string]string,
@@ -29,6 +32,7 @@ func NewDeployment(
 
 	return &Deployment{
 		client:             client,
+		kConfig:            kConfig,
 		nfsServer:          nfsServer,
 		recorder:           recorder,
 		scheme:             scheme,


### PR DESCRIPTION
Using `rest.InClusterConfig()` to get kubeconfig results in reading the
config file in the container every time the reconciliation loop runs.
File reads can be avoided by passing the k8s rest client config from
the controller manager to NFS reconciler. NFS reconciler uses the rest
client config in NFS Server deployment to create a k8s discovery client
to check if `ServiceMonitor` custom resource is defined in the cluster.