### PR TITLE
Add leader-for-life leader election

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"runtime"
 	"strconv"
 
+	"github.com/operator-framework/operator-sdk/pkg/leader"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/storageos/cluster-operator/internal/pkg/admission"
 	"github.com/storageos/cluster-operator/internal/pkg/admission/scheduler"
@@ -68,6 +70,13 @@ func main() {
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
+	if err != nil {
+		fatal(err)
+	}
+
+	ctx := context.TODO()
+	// Become the leader before proceeding.
+	err = leader.Become(ctx, "storageos-operator-lock")
 	if err != nil {
 		fatal(err)
 	}

--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -359,6 +359,10 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: OPERATOR_NAME
                   value: cluster-operator
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 - name: POD_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -359,6 +359,10 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: OPERATOR_NAME
                   value: cluster-operator
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 - name: POD_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -969,6 +969,10 @@ data:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
                       - name: OPERATOR_NAME
                         value: "cluster-operator"
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
                       - name: POD_NAMESPACE
                         valueFrom:
                           fieldRef:


### PR DESCRIPTION
New Operator-SDK projects enable leader-for-life leader election by
default. This can help in running multiple instances of the operator
with only one pod running the controllers until the leader pod is deleted.
This model doesn't affect the admission controller webhook in the
current setup as only the leader pod will be running the webhook and
the other pods will be in a waiting state. When a leader pod is
deleted, the new leader generates new cert for the admission controller
and updates the client cert.

Reference docs:
- [Leader election - Operator SDK User Guide](https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md#leader-election)
- [Leader for Life Proposal for Operator SDK](https://github.com/operator-framework/operator-sdk/blob/master/doc/proposals/leader-for-life.md#leader-for-life-proposal-for-operator-sdk)

Logs of a pod that becomes leader when the current leader pod is deleted:
```

2019-11-14T09:00:37.791Z	INFO	storageos.setup	Initializing	{"goversion": "go1.12.9", "os": "linux", "arch": "amd64", "operator-sdk": "v0.10.0"}
2019-11-14T09:00:37.792Z	INFO	leader	Trying to become the leader.
2019-11-14T09:00:37.792Z	DEBUG	k8sutil	Found namespace	{"Namespace": "storageos-operator"}
2019-11-14T09:00:37.836Z	DEBUG	k8sutil	Found podname	{"Pod.Name": "storageos-cluster-operator-697dd4797c-fwfjm"}
2019-11-14T09:00:37.845Z	DEBUG	k8sutil	Found Pod	{"Pod.Namespace": "storageos-operator", "Pod.Name": "storageos-cluster-operator-697dd4797c-fwfjm"}
2019-11-14T09:00:37.847Z	INFO	leader	Found existing lock	{"LockOwner": "storageos-cluster-operator-697dd4797c-zvbmn"}
2019-11-14T09:00:37.852Z	INFO	leader	Not the leader. Waiting.
2019-11-14T09:00:38.977Z	INFO	leader	Not the leader. Waiting.
...
<--Leader pod deleted-->
...
2019-11-14T09:04:03.443Z	INFO	leader	Not the leader. Waiting.
2019-11-14T09:04:20.952Z	INFO	leader	Became the leader.
2019-11-14T09:04:21.014Z	INFO	storageos.setup	Registering Components
...
2019-11-14T09:04:21.236Z	INFO	kubebuilder.controller	Starting workers	{"controller": "nfsserver-controller", "worker count": 1}
2019-11-14T09:04:21.453Z	INFO	kubebuilder.admission.cert.writer	cert directory doesn't exist, creating	{"directory": "k8s-webhook-server/cert"}
2019-11-14T09:04:21.455Z	DEBUG	kubebuilder.admission.cert.writer.atomic-writer	performed write of new data to ts data directory	{"task": "processing webhook", "ts directory": "k8s-webhook-server/cert/..2019_11_14_09_04_21.229763209"}
2019-11-14T09:04:21.595Z	INFO	kubebuilder.webhook	starting the webhook server.
...
```
This is applicable only when more than one replica of operator is deployed.