### PR TITLE
Scheduler must handle PVC with SC set as annotation

### DIFF
--- a/internal/pkg/admission/scheduler/handler_test.go
+++ b/internal/pkg/admission/scheduler/handler_test.go
@@ -231,7 +231,7 @@ func createPVC(name, namespace, storageClassName string, betaAnnotation bool) *c
 	}
 
 	if betaAnnotation {
-		pvc.ObjectMeta.Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+		pvc.ObjectMeta.Annotations[pvcStorageClassKey] = storageClassName
 	} else {
 		pvc.Spec.StorageClassName = &storageClassName
 	}

--- a/internal/pkg/admission/scheduler/helper.go
+++ b/internal/pkg/admission/scheduler/helper.go
@@ -15,6 +15,11 @@ import (
 // ErrNoCluster is the error when there's no running StorageOS cluster found.
 var ErrNoCluster = errors.New("no storageos cluster found")
 
+// pvcStorageClassKey is the annotation used to refer to the StorageClass when
+// the PVC storageClassName wasn't used.  This is now deprecated but should
+// still be checked as k8s still supports it.
+var pvcStorageClassKey = "volume.beta.kubernetes.io/storage-class"
+
 // IsManagedVolume inspects a given volume to find if it's managed by the given
 // provisioners.
 func (p *PodSchedulerSetter) IsManagedVolume(volume corev1.Volume, namespace string) (bool, error) {
@@ -33,14 +38,20 @@ func (p *PodSchedulerSetter) IsManagedVolume(volume corev1.Volume, namespace str
 		return false, fmt.Errorf("failed to get PVC: %v", err)
 	}
 
-	// Get the StorageClass of the PVC.
-	scName := pvc.Spec.StorageClassName
-	if scName == nil {
+	// Get the StorageClass of the PVC.  The beta annotation should still be
+	// supported since even latest versions of Kubernetes still allow it.
+	var scName string
+	if pvc.Spec.StorageClassName != nil && len(*pvc.Spec.StorageClassName) > 0 {
+		scName = *pvc.Spec.StorageClassName
+	} else {
+		scName = pvc.Annotations[pvcStorageClassKey]
+	}
+	if scName == "" {
 		return false, fmt.Errorf("could not get StorageClass name associated with PVC %q", pvc.Name)
 	}
 	sc := &storagev1.StorageClass{}
 	scNSName := types.NamespacedName{
-		Name: *scName,
+		Name: scName,
 	}
 	if err := p.client.Get(context.Background(), scNSName, sc); err != nil {
 		return false, fmt.Errorf("failed to get StorageClass: %v", err)

--- a/internal/pkg/admission/scheduler/helper.go
+++ b/internal/pkg/admission/scheduler/helper.go
@@ -18,7 +18,7 @@ var ErrNoCluster = errors.New("no storageos cluster found")
 // pvcStorageClassKey is the annotation used to refer to the StorageClass when
 // the PVC storageClassName wasn't used.  This is now deprecated but should
 // still be checked as k8s still supports it.
-var pvcStorageClassKey = "volume.beta.kubernetes.io/storage-class"
+const pvcStorageClassKey = "volume.beta.kubernetes.io/storage-class"
 
 // IsManagedVolume inspects a given volume to find if it's managed by the given
 // provisioners.

--- a/internal/pkg/admission/scheduler/helper_test.go
+++ b/internal/pkg/admission/scheduler/helper_test.go
@@ -1,0 +1,139 @@
+package scheduler
+
+import (
+	"testing"
+
+	storageosapis "github.com/storageos/cluster-operator/pkg/apis"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPodSchedulerSetter_IsManagedVolume(t *testing.T) {
+
+	// Test values only.
+	storageosSchedulerName := "storageos-scheduler"
+	storageosCSIProvisioner := "storageos"
+	storageosNativeProvisioner := "kubernetes.io/storageos"
+	schedulerAnnotationKey := "storageos.com/scheduler"
+
+	// Create a new scheme and add all the types from different clientsets.
+	scheme := runtime.NewScheme()
+	kscheme.AddToScheme(scheme)
+	apiextensionsv1beta1.AddToScheme(scheme)
+	storageosapis.AddToScheme(scheme)
+
+	// StorageOS StorageClass.
+	stosSC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fast",
+		},
+		Provisioner: storageosCSIProvisioner,
+	}
+
+	// StorageOS StorageClass with different provisioner.
+	stosNativeSC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fast2",
+		},
+		Provisioner: storageosNativeProvisioner,
+	}
+
+	// Non-StorageOS StorageClass.
+	fooSC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "slow",
+		},
+		Provisioner: "foo-provisioner",
+	}
+
+	testNamespace := "default"
+
+	tests := []struct {
+		name    string
+		pvc     *corev1.PersistentVolumeClaim
+		volume  *corev1.Volume
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:   "storageos volume",
+			pvc:    createPVC("pv1", testNamespace, stosSC.Name, false),
+			volume: createVolume("pv1"),
+			want:   true,
+		},
+		{
+			name:   "storageos volume, beta annotation",
+			pvc:    createPVC("pv1", testNamespace, stosSC.Name, true),
+			volume: createVolume("pv1"),
+			want:   true,
+		},
+		{
+			name:   "storageos native driver volume",
+			pvc:    createPVC("pv1", testNamespace, stosNativeSC.Name, false),
+			volume: createVolume("pv1"),
+			want:   true,
+		},
+		{
+			name:   "storageos native driver volume, beta annotation",
+			pvc:    createPVC("pv1", testNamespace, stosNativeSC.Name, true),
+			volume: createVolume("pv1"),
+			want:   true,
+		},
+		{
+			name:   "non-storageos volume",
+			pvc:    createPVC("pv1", testNamespace, fooSC.Name, false),
+			volume: createVolume("pv1"),
+			want:   false,
+		},
+		{
+			name:   "non-storageos volume, beta annotation",
+			pvc:    createPVC("pv1", testNamespace, fooSC.Name, true),
+			volume: createVolume("pv1"),
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Create all the above resources and get a k8s client.
+			client := fake.NewFakeClientWithScheme(scheme, stosSC, stosNativeSC, fooSC, tt.pvc)
+
+			// Create a PodSchedulerSetter instance with the fake client.
+			podSchedulerSetter := PodSchedulerSetter{
+				client: client,
+				Provisioners: []string{
+					storageosCSIProvisioner,
+					storageosNativeProvisioner,
+				},
+				SchedulerName:          storageosSchedulerName,
+				SchedulerAnnotationKey: schedulerAnnotationKey,
+			}
+
+			got, err := podSchedulerSetter.IsManagedVolume(*tt.volume, testNamespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PodSchedulerSetter.IsManagedVolume() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("PodSchedulerSetter.IsManagedVolume() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// createVolume creates and returns a Volume object.
+func createVolume(pvcName string) *corev1.Volume {
+	return &corev1.Volume{
+		Name: pvcName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: pvcName,
+			},
+		},
+	}
+}


### PR DESCRIPTION
In `1.5.0`, PVCs that were created using the beta annotation for specifying the StorageClass weren't being matched, causing processing of the volume to fail:

```
Internal error occurred: admission webhook "podscheduler.storageos.com" denied the request: failed to determine if the volume is managed: could not get StorageClass name associated with PVC "fast0001"
```

