### PR TITLE
Add prometheus metrics for operator

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -445,6 +445,7 @@
     "internal/util/projutil",
     "internal/util/yamlutil",
     "pkg/k8sutil",
+    "pkg/kube-metrics",
     "pkg/metrics",
     "pkg/test",
     "pkg/test/e2eutil",
@@ -1148,6 +1149,18 @@
   revision = "0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803"
 
 [[projects]]
+  digest = "1:1d309e59a3f963aac5bc26b0e9ead40f74e568f7e3ebbb46b3b10054fe03dc43"
+  name = "k8s.io/kube-state-metrics"
+  packages = [
+    "pkg/collector",
+    "pkg/metric",
+    "pkg/metrics_store",
+  ]
+  pruneopts = "NT"
+  revision = "de19ed4f12d471fccc79f9a9fee73f7c107ecd33"
+  version = "v1.6.0"
+
+[[projects]]
   digest = "1:21c23272171c749230b32cf3d797db213414dc4bed6abcd457946230d002418f"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
@@ -1223,6 +1236,8 @@
     "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1",
     "github.com/go-logr/logr",
     "github.com/go-openapi/spec",
+    "github.com/operator-framework/operator-sdk/pkg/k8sutil",
+    "github.com/operator-framework/operator-sdk/pkg/kube-metrics",
     "github.com/operator-framework/operator-sdk/pkg/metrics",
     "github.com/operator-framework/operator-sdk/pkg/test",
     "github.com/operator-framework/operator-sdk/pkg/test/e2eutil",

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -3,11 +3,15 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"runtime"
 	"strconv"
 
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
+	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/storageos/cluster-operator/internal/pkg/admission"
 	"github.com/storageos/cluster-operator/internal/pkg/admission/scheduler"
@@ -16,7 +20,9 @@ import (
 	"github.com/storageos/cluster-operator/pkg/storageos"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -52,6 +58,12 @@ const (
 	podSchedulerAnnotationKey = "storageos.com/scheduler"
 )
 
+var (
+	metricsHost               = "0.0.0.0"
+	metricsPort         int32 = 8383
+	operatorMetricsPort int32 = 8686
+)
+
 func main() {
 
 	logf.SetLogger(logf.ZapLogger(true))
@@ -83,7 +95,10 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	// Use "" namespace to watch all the namespaces.
-	mgr, err := manager.New(cfg, manager.Options{Namespace: ""})
+	mgr, err := manager.New(cfg, manager.Options{
+		Namespace:          "",
+		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+	})
 	if err != nil {
 		fatal(err)
 	}
@@ -149,6 +164,45 @@ func main() {
 		}
 	}
 
+	if err := serveCRMetrics(cfg); err != nil {
+		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
+	}
+
+	// Add to the below struct any other metrics ports to expose.
+	servicePorts := []corev1.ServicePort{
+		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: corev1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
+		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: corev1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
+	}
+
+	// CreateServiceMonitors will automatically create the prometheus-operator
+	// ServiceMonitor resources necessary to configure Prometheus to scrape
+	// metrics from this operator.
+	services := []*corev1.Service{}
+
+	// Create Service object to expose the metrics port(s).
+	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
+	if err != nil {
+		log.Info("Could not create metrics Service", "error", err.Error())
+	} else {
+		services = append(services, service)
+	}
+
+	operatorNs, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		fatal(err)
+	}
+
+	_, err = metrics.CreateServiceMonitors(cfg, operatorNs, services)
+	if err != nil {
+		log.Info("Could not create ServiceMonitor object", "error", err.Error())
+		// If this operator is deployed to a cluster without the
+		// prometheus-operator running, it will return
+		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
+		if err == metrics.ErrServiceMonitorNotPresent {
+			log.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
+		}
+	}
+
 	log.Info("Starting the StorageOS Operator")
 
 	// Start the Cmd
@@ -158,4 +212,28 @@ func main() {
 func fatal(err error) {
 	log.Error(err, "Fatal error")
 	os.Exit(1)
+}
+
+// serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
+// It serves those metrics on "http://metricsHost:operatorMetricsPort".
+func serveCRMetrics(cfg *rest.Config) error {
+	// Below function returns filtered operator/CustomResource specific GVKs.
+	// For more control override the below GVK list with your own custom logic.
+	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
+	if err != nil {
+		return err
+	}
+	// Get the namespace the operator is currently deployed in.
+	operatorNs, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return err
+	}
+	// To generate metrics in other namespaces, add the values below.
+	ns := []string{operatorNs}
+	// Generate and serve custom resource specific metrics.
+	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   name: storageosoperator.v1.5.0
   namespace: placeholder
   annotations:
-    capabilities: Full Lifecycle
+    capabilities: Deep Insights
     categories: Storage
     description: Cloud-native, persistent storage for containers.
     containerImage: registry.connect.redhat.com/storageos/cluster-operator:1.5.0
@@ -333,6 +333,14 @@ spec:
           - servicemonitors
           verbs:
           - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          resourceNames:
+          - storageos-cluster-operator
+          verbs:
+          - update
       deployments:
       - name: storageos-operator
         spec:
@@ -358,7 +366,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: OPERATOR_NAME
-                  value: cluster-operator
+                  value: storageos-cluster-operator
                 - name: POD_NAME
                   valueFrom:
                     fieldRef:
@@ -370,8 +378,10 @@ spec:
                 - name: DISABLE_SCHEDULER_WEBHOOK
                   value: "false"
                 ports:
-                - containerPort: 8080
+                - containerPort: 8383
                   name: metrics
+                - containerPort: 8686
+                  name: operatormetrics
                 - containerPort: 5720
                   name: podschedwebhook
   customresourcedefinitions:

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   name: storageosoperator.v1.5.0
   namespace: placeholder
   annotations:
-    capabilities: Full Lifecycle
+    capabilities: Deep Insights
     categories: Storage
     description: Cloud-native, persistent storage for containers.
     containerImage: storageos/cluster-operator:1.5.0
@@ -333,6 +333,14 @@ spec:
           - servicemonitors
           verbs:
           - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          resourceNames:
+          - storageos-cluster-operator
+          verbs:
+          - update
       deployments:
       - name: storageos-operator
         spec:
@@ -358,7 +366,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: OPERATOR_NAME
-                  value: cluster-operator
+                  value: storageos-cluster-operator
                 - name: POD_NAME
                   valueFrom:
                     fieldRef:
@@ -370,8 +378,10 @@ spec:
                 - name: DISABLE_SCHEDULER_WEBHOOK
                   value: "false"
                 ports:
-                - containerPort: 8080
+                - containerPort: 8383
                   name: metrics
+                - containerPort: 8686
+                  name: operatormetrics
                 - containerPort: 5720
                   name: podschedwebhook
   customresourcedefinitions:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -18,8 +18,10 @@ spec:
         - name: storageos-cluster-operator
           image: storageos/cluster-operator:test
           ports:
-          - containerPort: 60000
+          - containerPort: 8383
             name: metrics
+          - containerPort: 8686
+            name: operatormetrics
           - containerPort: 5720
             name: podschedwebhook
           command:
@@ -39,7 +41,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
-              value: "cluster-operator"
+              value: "storageos-cluster-operator"
             - name: DISABLE_SCHEDULER_WEBHOOK
               value: "false"
       tolerations:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -140,3 +140,11 @@ rules:
   - servicemonitors
   verbs:
   - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - storageos-cluster-operator
+  verbs:
+  - update

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -608,7 +608,7 @@ data:
         name: storageosoperator.0.0.0
         namespace: olm
         annotations:
-          capabilities: Full Lifecycle
+          capabilities: Deep Insights
           categories: "Storage"
           description: Cloud-native, persistent storage for containers.
           containerImage: storageos/cluster-operator:test
@@ -943,6 +943,14 @@ data:
                 - servicemonitors
                 verbs:
                 - '*'
+              - apiGroups:
+                - apps
+                resources:
+                - deployments/finalizers
+                resourceNames:
+                - storageos-cluster-operator
+                verbs:
+                - update
             deployments:
             - name: storageos-operator
               spec:
@@ -968,7 +976,7 @@ data:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
                       - name: OPERATOR_NAME
-                        value: "cluster-operator"
+                        value: "storageos-cluster-operator"
                       - name: POD_NAME
                         valueFrom:
                           fieldRef:
@@ -980,8 +988,10 @@ data:
                       - name: DISABLE_SCHEDULER_WEBHOOK
                         value: "false"
                       ports:
-                      - containerPort: 8080
+                      - containerPort: 8383
                         name: metrics
+                      - containerPort: 8686
+                        name: operatormetrics
                       - containerPort: 5720
                         name: podschedwebhook
                     - name: scorecard-proxy

--- a/docs/operator-prometheus-metrics/README.md
+++ b/docs/operator-prometheus-metrics/README.md
@@ -1,0 +1,75 @@
+# Setup Prometheus for Operator Metrics
+
+Install Prometheus-operator by cloning the [repo](https://github.com/coreos/prometheus-operator),
+and applying the manifests in `bundle.yaml` at the root of the repo. This will
+install the operator in the default namespace with all the permissions needed by
+the operator.
+```
+$ kubectl get all
+NAME                                      READY   STATUS    RESTARTS   AGE
+pod/prometheus-operator-6685db5c6-f948k   1/1     Running   0          3d1h
+
+NAME                          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
+service/kubernetes            ClusterIP   10.96.0.1    <none>        443/TCP    3d23h
+service/prometheus-operator   ClusterIP   None         <none>        8080/TCP   3d1h
+
+NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/prometheus-operator   1/1     1            1           3d1h
+
+NAME                                            DESIRED   CURRENT   READY   AGE
+replicaset.apps/prometheus-operator-6685db5c6   1         1         1       3d1h
+```
+
+__NOTE__: Prometheus-operator must be installed before installing 
+storageos-operator because the ServiceMonitor is created at startup. If
+storageos-operator is already installed, restarting the operator pod by deleting
+it should also result in startup and creation of Prometheus ServiceMonitor.
+
+Install StorageOS Operator. It will create a Service for metrics and a
+Prometheus ServiceMonitor.
+```
+$ kubectl -n storageos-operator get all
+NAME                                             READY   STATUS    RESTARTS   AGE
+pod/storageos-cluster-operator-77bffc958-wjpgx   1/1     Running   0          28m
+
+NAME                                         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
+service/storageos-cluster-operator-metrics   ClusterIP   10.110.236.21    <none>        8383/TCP,8686/TCP   28m
+service/storageos-scheduler-webhook          ClusterIP   10.103.159.179   <none>        443/TCP             28m
+
+NAME                                         READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/storageos-cluster-operator   1/1     1            1           28m
+
+NAME                                                   DESIRED   CURRENT   READY   AGE
+replicaset.apps/storageos-cluster-operator-77bffc958   1         1         1       28m
+
+
+$ kubectl -n storageos-operator get servicemonitors.monitoring.coreos.com 
+NAME                                 AGE
+storageos-cluster-operator-metrics   76s
+```
+
+In the above, `service/storageos-cluster-operator-metrics` is the metrics
+service and servicemonitor `storageos-cluster-operator-metrics` is the
+servicemonitor associated with the operator metrics service.
+
+Create a Prometheus server instance with `serviceMonitorSelector` matching
+label `name=storageos-cluster-operator`. Create ServiceMonitor for Prometheus
+instance with all the RBAC permission by applying
+[prometheus-rbac.yaml](prometheus-rbac.yaml) and create a prometheus server
+using the created ServiceAccount by applying
+[prometheus-stos-operator.yaml](prometheus-stos-operator.yaml).
+
+```
+$ kubectl -n storageos-operator get pods
+NAME                                         READY   STATUS    RESTARTS   AGE
+prometheus-prometheus-storageos-operator-0   3/3     Running   1          6s
+storageos-cluster-operator-77bffc958-wjpgx   1/1     Running   0          8m44s
+```
+
+In the above, `prometheus-prometheus-storageos-operator-0` is the prometheus
+server pod. Once created, port-forward to the prometheus server pod and view the
+collected metrics in the prometheus dashboard at `localhost:8080`.
+
+```
+$ kubectl -n storageos-operator port-forward prometheus-prometheus-storageos-operator-0 8080:9090
+```

--- a/docs/operator-prometheus-metrics/prometheus-rbac.yaml
+++ b/docs/operator-prometheus-metrics/prometheus-rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-storageos-operator
+  namespace: storageos-operator
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus-storageos-operator
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-storageos-operator
+  namespace: storageos-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-storageos-operator
+subjects:
+- kind: ServiceAccount
+  name: prometheus-storageos-operator
+  namespace: storageos-operator

--- a/docs/operator-prometheus-metrics/prometheus-stos-operator.yaml
+++ b/docs/operator-prometheus-metrics/prometheus-stos-operator.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus-storageos-operator
+  namespace: storageos-operator
+spec:
+  image: quay.io/prometheus/prometheus:v2.13.1
+  serviceAccountName: prometheus-storageos-operator
+  serviceMonitorSelector:
+    matchLabels:
+      name: storageos-cluster-operator
+  enableAdminAPI: false

--- a/vendor/k8s.io/kube-state-metrics/LICENSE
+++ b/vendor/k8s.io/kube-state-metrics/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/builder.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/builder.go
@@ -1,0 +1,485 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"sort"
+	"strings"
+
+	"k8s.io/klog"
+
+	"golang.org/x/net/context"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	certv1beta1 "k8s.io/api/certificates/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	policy "k8s.io/api/policy/v1beta1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	coll "k8s.io/kube-state-metrics/pkg/collector"
+	"k8s.io/kube-state-metrics/pkg/metric"
+	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
+	"k8s.io/kube-state-metrics/pkg/options"
+)
+
+type whiteBlackLister interface {
+	IsIncluded(string) bool
+	IsExcluded(string) bool
+}
+
+// Builder helps to build collector. It follows the builder pattern
+// (https://en.wikipedia.org/wiki/Builder_pattern).
+type Builder struct {
+	kubeClient        clientset.Interface
+	namespaces        options.NamespaceList
+	ctx               context.Context
+	enabledCollectors []string
+	whiteBlackList    whiteBlackLister
+}
+
+// NewBuilder returns a new builder.
+func NewBuilder(
+	ctx context.Context,
+) *Builder {
+	return &Builder{
+		ctx: ctx,
+	}
+}
+
+// WithEnabledCollectors sets the enabledCollectors property of a Builder.
+func (b *Builder) WithEnabledCollectors(c []string) {
+	var copy []string
+	copy = append(copy, c...)
+
+	sort.Strings(copy)
+
+	b.enabledCollectors = copy
+}
+
+// WithNamespaces sets the namespaces property of a Builder.
+func (b *Builder) WithNamespaces(n options.NamespaceList) {
+	b.namespaces = n
+}
+
+// WithKubeClient sets the kubeClient property of a Builder.
+func (b *Builder) WithKubeClient(c clientset.Interface) {
+	b.kubeClient = c
+}
+
+// WithWhiteBlackList configures the white or blacklisted metric to be exposed
+// by the collector build by the Builder
+func (b *Builder) WithWhiteBlackList(l whiteBlackLister) {
+	b.whiteBlackList = l
+}
+
+// Build initializes and registers all enabled collectors.
+func (b *Builder) Build() []*coll.Collector {
+	if b.whiteBlackList == nil {
+		panic("whiteBlackList should not be nil")
+	}
+
+	collectors := []*coll.Collector{}
+	activeCollectorNames := []string{}
+
+	for _, c := range b.enabledCollectors {
+		constructor, ok := availableCollectors[c]
+		if ok {
+			collector := constructor(b)
+			activeCollectorNames = append(activeCollectorNames, c)
+			collectors = append(collectors, collector)
+		}
+	}
+
+	klog.Infof("Active collectors: %s", strings.Join(activeCollectorNames, ","))
+
+	return collectors
+}
+
+var availableCollectors = map[string]func(f *Builder) *coll.Collector{
+	"certificatesigningrequests": func(b *Builder) *coll.Collector { return b.buildCsrCollector() },
+	"configmaps":                 func(b *Builder) *coll.Collector { return b.buildConfigMapCollector() },
+	"cronjobs":                   func(b *Builder) *coll.Collector { return b.buildCronJobCollector() },
+	"daemonsets":                 func(b *Builder) *coll.Collector { return b.buildDaemonSetCollector() },
+	"deployments":                func(b *Builder) *coll.Collector { return b.buildDeploymentCollector() },
+	"endpoints":                  func(b *Builder) *coll.Collector { return b.buildEndpointsCollector() },
+	"horizontalpodautoscalers":   func(b *Builder) *coll.Collector { return b.buildHPACollector() },
+	"ingresses":                  func(b *Builder) *coll.Collector { return b.buildIngressCollector() },
+	"jobs":                       func(b *Builder) *coll.Collector { return b.buildJobCollector() },
+	"limitranges":                func(b *Builder) *coll.Collector { return b.buildLimitRangeCollector() },
+	"namespaces":                 func(b *Builder) *coll.Collector { return b.buildNamespaceCollector() },
+	"nodes":                      func(b *Builder) *coll.Collector { return b.buildNodeCollector() },
+	"persistentvolumeclaims":     func(b *Builder) *coll.Collector { return b.buildPersistentVolumeClaimCollector() },
+	"persistentvolumes":          func(b *Builder) *coll.Collector { return b.buildPersistentVolumeCollector() },
+	"poddisruptionbudgets":       func(b *Builder) *coll.Collector { return b.buildPodDisruptionBudgetCollector() },
+	"pods":                       func(b *Builder) *coll.Collector { return b.buildPodCollector() },
+	"replicasets":                func(b *Builder) *coll.Collector { return b.buildReplicaSetCollector() },
+	"replicationcontrollers":     func(b *Builder) *coll.Collector { return b.buildReplicationControllerCollector() },
+	"resourcequotas":             func(b *Builder) *coll.Collector { return b.buildResourceQuotaCollector() },
+	"secrets":                    func(b *Builder) *coll.Collector { return b.buildSecretCollector() },
+	"services":                   func(b *Builder) *coll.Collector { return b.buildServiceCollector() },
+	"statefulsets":               func(b *Builder) *coll.Collector { return b.buildStatefulSetCollector() },
+}
+
+func (b *Builder) buildConfigMapCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, configMapMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ConfigMap{}, store, b.namespaces, createConfigMapListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildCronJobCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, cronJobMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &batchv1beta1.CronJob{}, store, b.namespaces, createCronJobListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildDaemonSetCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, daemonSetMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &appsv1.DaemonSet{}, store, b.namespaces, createDaemonSetListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildDeploymentCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, deploymentMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &appsv1.Deployment{}, store, b.namespaces, createDeploymentListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildEndpointsCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, endpointMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Endpoints{}, store, b.namespaces, createEndpointsListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildHPACollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, hpaMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &autoscaling.HorizontalPodAutoscaler{}, store, b.namespaces, createHPAListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildIngressCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, ingressMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &extensions.Ingress{}, store, b.namespaces, createIngressListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildJobCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, jobMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &batchv1.Job{}, store, b.namespaces, createJobListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildLimitRangeCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, limitRangeMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.LimitRange{}, store, b.namespaces, createLimitRangeListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildNamespaceCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, namespaceMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Namespace{}, store, b.namespaces, createNamespaceListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildNodeCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, nodeMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Node{}, store, b.namespaces, createNodeListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildPersistentVolumeClaimCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, persistentVolumeClaimMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.PersistentVolumeClaim{}, store, b.namespaces, createPersistentVolumeClaimListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildPersistentVolumeCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, persistentVolumeMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.PersistentVolume{}, store, b.namespaces, createPersistentVolumeListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildPodDisruptionBudgetCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, podDisruptionBudgetMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &policy.PodDisruptionBudget{}, store, b.namespaces, createPodDisruptionBudgetListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildReplicaSetCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, replicaSetMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &extensions.ReplicaSet{}, store, b.namespaces, createReplicaSetListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildReplicationControllerCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, replicationControllerMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ReplicationController{}, store, b.namespaces, createReplicationControllerListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildResourceQuotaCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, resourceQuotaMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ResourceQuota{}, store, b.namespaces, createResourceQuotaListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildSecretCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, secretMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Secret{}, store, b.namespaces, createSecretListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildServiceCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, serviceMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Service{}, store, b.namespaces, createServiceListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildStatefulSetCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, statefulSetMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &appsv1.StatefulSet{}, store, b.namespaces, createStatefulSetListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildPodCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, podMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Pod{}, store, b.namespaces, createPodListWatch)
+
+	return coll.NewCollector(store)
+}
+
+func (b *Builder) buildCsrCollector() *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, csrMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &certv1beta1.CertificateSigningRequest{}, store, b.namespaces, createCSRListWatch)
+
+	return coll.NewCollector(store)
+}
+
+// reflectorPerNamespace creates a Kubernetes client-go reflector with the given
+// listWatchFunc for each given namespace and registers it with the given store.
+func reflectorPerNamespace(
+	ctx context.Context,
+	kubeClient clientset.Interface,
+	expectedType interface{},
+	store cache.Store,
+	namespaces []string,
+	listWatchFunc func(kubeClient clientset.Interface, ns string) cache.ListWatch,
+) {
+	for _, ns := range namespaces {
+		lw := listWatchFunc(kubeClient, ns)
+		reflector := cache.NewReflector(&lw, expectedType, store, 0)
+		go reflector.Run(ctx.Done())
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/certificatesigningrequest.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/certificatesigningrequest.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	certv1beta1 "k8s.io/api/certificates/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descCSRLabelsName          = "kube_certificatesigningrequest_labels"
+	descCSRLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descCSRLabelsDefaultLabels = []string{"certificatesigningrequest"}
+
+	csrMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: descCSRLabelsName,
+			Type: metric.Gauge,
+			Help: descCSRLabelsHelp,
+			GenerateFunc: wrapCSRFunc(func(j *certv1beta1.CertificateSigningRequest) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(j.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_certificatesigningrequest_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapCSRFunc(func(csr *certv1beta1.CertificateSigningRequest) *metric.Family {
+				ms := []*metric.Metric{}
+				if !csr.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(csr.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_certificatesigningrequest_condition",
+			Type: metric.Gauge,
+			Help: "The number of each certificatesigningrequest condition",
+			GenerateFunc: wrapCSRFunc(func(csr *certv1beta1.CertificateSigningRequest) *metric.Family {
+				return &metric.Family{
+					Metrics: addCSRConditionMetrics(csr.Status),
+				}
+			}),
+		},
+		{
+			Name: "kube_certificatesigningrequest_cert_length",
+			Type: metric.Gauge,
+			Help: "Length of the issued cert",
+			GenerateFunc: wrapCSRFunc(func(csr *certv1beta1.CertificateSigningRequest) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(len(csr.Status.Certificate)),
+						},
+					},
+				}
+			}),
+		},
+	}
+)
+
+func wrapCSRFunc(f func(*certv1beta1.CertificateSigningRequest) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		csr := obj.(*certv1beta1.CertificateSigningRequest)
+
+		metricFamily := f(csr)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descCSRLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{csr.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createCSRListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CertificatesV1beta1().CertificateSigningRequests().List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CertificatesV1beta1().CertificateSigningRequests().Watch(opts)
+		},
+	}
+}
+
+// addCSRConditionMetrics generates one metric for each possible csr condition status
+func addCSRConditionMetrics(cs certv1beta1.CertificateSigningRequestStatus) []*metric.Metric {
+	cApproved := 0
+	cDenied := 0
+	for _, s := range cs.Conditions {
+		if s.Type == certv1beta1.CertificateApproved {
+			cApproved++
+		}
+		if s.Type == certv1beta1.CertificateDenied {
+			cDenied++
+		}
+	}
+
+	return []*metric.Metric{
+		{
+			LabelValues: []string{"approved"},
+			Value:       float64(cApproved),
+			LabelKeys:   []string{"condition"},
+		},
+		{
+			LabelValues: []string{"denied"},
+			Value:       float64(cDenied),
+			LabelKeys:   []string{"condition"},
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/configmap.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/configmap.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descConfigMapLabelsDefaultLabels = []string{"namespace", "configmap"}
+
+	configMapMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_configmap_info",
+			Type: metric.Gauge,
+			Help: "Information about configmap.",
+			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       1,
+					}},
+				}
+			}),
+		},
+		{
+			Name: "kube_configmap_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !c.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(c.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_configmap_metadata_resource_version",
+			Type: metric.Gauge,
+			Help: "Resource version representing a specific version of the configmap.",
+			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"resource_version"},
+							LabelValues: []string{string(c.ObjectMeta.ResourceVersion)},
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+	}
+)
+
+func createConfigMapListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().ConfigMaps(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().ConfigMaps(ns).Watch(opts)
+		},
+	}
+}
+
+func wrapConfigMapFunc(f func(*v1.ConfigMap) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		configMap := obj.(*v1.ConfigMap)
+
+		metricFamily := f(configMap)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descConfigMapLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{configMap.Namespace, configMap.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/cronjob.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/cronjob.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/robfig/cron"
+
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-state-metrics/pkg/metric"
+)
+
+var (
+	descCronJobLabelsName          = "kube_cronjob_labels"
+	descCronJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descCronJobLabelsDefaultLabels = []string{"namespace", "cronjob"}
+
+	cronJobMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: descCronJobLabelsName,
+			Type: metric.Gauge,
+			Help: descCronJobLabelsHelp,
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(j.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_cronjob_info",
+			Type: metric.Gauge,
+			Help: "Info about cronjob.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"schedule", "concurrency_policy"},
+							LabelValues: []string{j.Spec.Schedule, string(j.Spec.ConcurrencyPolicy)},
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_cronjob_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+				if !j.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(j.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_cronjob_status_active",
+			Type: metric.Gauge,
+			Help: "Active holds pointers to currently running jobs.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(len(j.Status.Active)),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_cronjob_status_last_schedule_time",
+			Type: metric.Gauge,
+			Help: "LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Status.LastScheduleTime != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(j.Status.LastScheduleTime.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_cronjob_spec_suspend",
+			Type: metric.Gauge,
+			Help: "Suspend flag tells the controller to suspend subsequent executions.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Spec.Suspend != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       boolFloat64(*j.Spec.Suspend),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_cronjob_spec_starting_deadline_seconds",
+			Type: metric.Gauge,
+			Help: "Deadline in seconds for starting the job if it misses scheduled time for any reason.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Spec.StartingDeadlineSeconds != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(*j.Spec.StartingDeadlineSeconds),
+					})
+
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_cronjob_next_schedule_time",
+			Type: metric.Gauge,
+			Help: "Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+
+				// If the cron job is suspended, don't track the next scheduled time
+				nextScheduledTime, err := getNextScheduledTime(j.Spec.Schedule, j.Status.LastScheduleTime, j.CreationTimestamp)
+				if err != nil {
+					panic(err)
+				} else if !*j.Spec.Suspend {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(nextScheduledTime.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+	}
+)
+
+func wrapCronJobFunc(f func(*batchv1beta1.CronJob) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		cronJob := obj.(*batchv1beta1.CronJob)
+
+		metricFamily := f(cronJob)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descCronJobLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{cronJob.Namespace, cronJob.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createCronJobListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.BatchV1beta1().CronJobs(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.BatchV1beta1().CronJobs(ns).Watch(opts)
+		},
+	}
+}
+
+func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, createdTime metav1.Time) (time.Time, error) {
+	sched, err := cron.ParseStandard(schedule)
+	if err != nil {
+		return time.Time{}, errors.Wrapf(err, "Failed to parse cron job schedule '%s'", schedule)
+	}
+	if !lastScheduleTime.IsZero() {
+		return sched.Next((*lastScheduleTime).Time), nil
+	}
+	if !createdTime.IsZero() {
+		return sched.Next(createdTime.Time), nil
+	}
+	return time.Time{}, errors.New("Created time and lastScheduleTime are both zero")
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/daemonset.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/daemonset.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-state-metrics/pkg/metric"
+)
+
+var (
+	descDaemonSetLabelsName          = "kube_daemonset_labels"
+	descDaemonSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descDaemonSetLabelsDefaultLabels = []string{"namespace", "daemonset"}
+
+	daemonSetMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_daemonset_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !d.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(d.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_daemonset_status_current_number_scheduled",
+			Type: metric.Gauge,
+			Help: "The number of nodes running at least one daemon pod and are supposed to.",
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.CurrentNumberScheduled),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_daemonset_status_desired_number_scheduled",
+			Type: metric.Gauge,
+			Help: "The number of nodes that should be running the daemon pod.",
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.DesiredNumberScheduled),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_daemonset_status_number_available",
+			Type: metric.Gauge,
+			Help: "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available",
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.NumberAvailable),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_daemonset_status_number_misscheduled",
+			Type: metric.Gauge,
+			Help: "The number of nodes running a daemon pod but are not supposed to.",
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.NumberMisscheduled),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_daemonset_status_number_ready",
+			Type: metric.Gauge,
+			Help: "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.NumberReady),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_daemonset_status_number_unavailable",
+			Type: metric.Gauge,
+			Help: "The number of nodes that should be running the daemon pod and have none of the daemon pod running and available",
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.NumberUnavailable),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_daemonset_updated_number_scheduled",
+			Type: metric.Gauge,
+			Help: "The total number of nodes that are running updated daemon pod",
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.UpdatedNumberScheduled),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_daemonset_metadata_generation",
+			Type: metric.Gauge,
+			Help: "Sequence number representing a specific generation of the desired state.",
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.ObjectMeta.Generation),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: descDaemonSetLabelsName,
+			Type: metric.Gauge,
+			Help: descDaemonSetLabelsHelp,
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.ObjectMeta.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+	}
+)
+
+func wrapDaemonSetFunc(f func(*v1.DaemonSet) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		daemonSet := obj.(*v1.DaemonSet)
+
+		metricFamily := f(daemonSet)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descDaemonSetLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{daemonSet.Namespace, daemonSet.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createDaemonSetListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.AppsV1().DaemonSets(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.AppsV1().DaemonSets(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/deployment.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/deployment.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descDeploymentLabelsName          = "kube_deployment_labels"
+	descDeploymentLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
+
+	deploymentMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_deployment_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !d.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						Value: float64(d.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_deployment_status_replicas",
+			Type: metric.Gauge,
+			Help: "The number of replicas per deployment.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.Replicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_deployment_status_replicas_available",
+			Type: metric.Gauge,
+			Help: "The number of available replicas per deployment.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.AvailableReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_deployment_status_replicas_unavailable",
+			Type: metric.Gauge,
+			Help: "The number of unavailable replicas per deployment.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.UnavailableReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_deployment_status_replicas_updated",
+			Type: metric.Gauge,
+			Help: "The number of updated replicas per deployment.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.UpdatedReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_deployment_status_observed_generation",
+			Type: metric.Gauge,
+			Help: "The generation observed by the deployment controller.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.ObservedGeneration),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_deployment_spec_replicas",
+			Type: metric.Gauge,
+			Help: "Number of desired pods for a deployment.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(*d.Spec.Replicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_deployment_spec_paused",
+			Type: metric.Gauge,
+			Help: "Whether the deployment is paused and will not be processed by the deployment controller.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: boolFloat64(d.Spec.Paused),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_deployment_spec_strategy_rollingupdate_max_unavailable",
+			Type: metric.Gauge,
+			Help: "Maximum number of unavailable replicas during a rolling update of a deployment.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				if d.Spec.Strategy.RollingUpdate == nil {
+					return &metric.Family{}
+				}
+
+				maxUnavailable, err := intstr.GetValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*d.Spec.Replicas), true)
+				if err != nil {
+					panic(err)
+				}
+
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(maxUnavailable),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_deployment_spec_strategy_rollingupdate_max_surge",
+			Type: metric.Gauge,
+			Help: "Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				if d.Spec.Strategy.RollingUpdate == nil {
+					return &metric.Family{}
+				}
+
+				maxSurge, err := intstr.GetValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxSurge, int(*d.Spec.Replicas), true)
+				if err != nil {
+					panic(err)
+				}
+
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(maxSurge),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_deployment_metadata_generation",
+			Type: metric.Gauge,
+			Help: "Sequence number representing a specific generation of the desired state.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.ObjectMeta.Generation),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: descDeploymentLabelsName,
+			Type: metric.Gauge,
+			Help: descDeploymentLabelsHelp,
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+	}
+)
+
+func wrapDeploymentFunc(f func(*v1.Deployment) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		deployment := obj.(*v1.Deployment)
+
+		metricFamily := f(deployment)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descDeploymentLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{deployment.Namespace, deployment.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createDeploymentListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.AppsV1().Deployments(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.AppsV1().Deployments(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/endpoint.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/endpoint.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descEndpointLabelsName          = "kube_endpoint_labels"
+	descEndpointLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descEndpointLabelsDefaultLabels = []string{"namespace", "endpoint"}
+
+	endpointMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_endpoint_info",
+			Type: metric.Gauge,
+			Help: "Information about endpoint.",
+			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: 1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_endpoint_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !e.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+
+						Value: float64(e.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: descEndpointLabelsName,
+			Type: metric.Gauge,
+			Help: descEndpointLabelsHelp,
+			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(e.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_endpoint_address_available",
+			Type: metric.Gauge,
+			Help: "Number of addresses available in endpoint.",
+			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+				var available int
+				for _, s := range e.Subsets {
+					available += len(s.Addresses) * len(s.Ports)
+				}
+
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(available),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_endpoint_address_not_ready",
+			Type: metric.Gauge,
+			Help: "Number of addresses not ready in endpoint",
+			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+				var notReady int
+				for _, s := range e.Subsets {
+					notReady += len(s.NotReadyAddresses) * len(s.Ports)
+				}
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(notReady),
+						},
+					},
+				}
+			}),
+		},
+	}
+)
+
+func wrapEndpointFunc(f func(*v1.Endpoints) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		endpoint := obj.(*v1.Endpoints)
+
+		metricFamily := f(endpoint)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descEndpointLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{endpoint.Namespace, endpoint.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createEndpointsListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().Endpoints(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().Endpoints(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/hpa.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/hpa.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descHorizontalPodAutoscalerLabelsName          = "kube_hpa_labels"
+	descHorizontalPodAutoscalerLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descHorizontalPodAutoscalerLabelsDefaultLabels = []string{"namespace", "hpa"}
+
+	hpaMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_hpa_metadata_generation",
+			Type: metric.Gauge,
+			Help: "The generation observed by the HorizontalPodAutoscaler controller.",
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(a.ObjectMeta.Generation),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_hpa_spec_max_replicas",
+			Type: metric.Gauge,
+			Help: "Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(a.Spec.MaxReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_hpa_spec_min_replicas",
+			Type: metric.Gauge,
+			Help: "Lower limit for the number of pods that can be set by the autoscaler, default 1.",
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(*a.Spec.MinReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_hpa_status_current_replicas",
+			Type: metric.Gauge,
+			Help: "Current number of replicas of pods managed by this autoscaler.",
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(a.Status.CurrentReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_hpa_status_desired_replicas",
+			Type: metric.Gauge,
+			Help: "Desired number of replicas of pods managed by this autoscaler.",
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(a.Status.DesiredReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: descHorizontalPodAutoscalerLabelsName,
+			Type: metric.Gauge,
+			Help: descHorizontalPodAutoscalerLabelsHelp,
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(a.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_hpa_status_condition",
+			Type: metric.Gauge,
+			Help: "The condition of this autoscaler.",
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				ms := make([]*metric.Metric, len(a.Status.Conditions)*len(conditionStatuses))
+
+				for i, c := range a.Status.Conditions {
+					metrics := addConditionMetrics(c.Status)
+
+					for j, m := range metrics {
+						metric := m
+						metric.LabelKeys = []string{"condition", "status"}
+						metric.LabelValues = append(metric.LabelValues, string(c.Type))
+						ms[i*len(conditionStatuses)+j] = metric
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+	}
+)
+
+func wrapHPAFunc(f func(*autoscaling.HorizontalPodAutoscaler) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		hpa := obj.(*autoscaling.HorizontalPodAutoscaler)
+
+		metricFamily := f(hpa)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descHorizontalPodAutoscalerLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{hpa.Namespace, hpa.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createHPAListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/ingress.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/ingress.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	"k8s.io/api/extensions/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descIngressLabelsName          = "kube_ingress_labels"
+	descIngressLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descIngressLabelsDefaultLabels = []string{"namespace", "ingress"}
+
+	ingressMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_ingress_info",
+			Type: metric.Gauge,
+			Help: "Information about ingress.",
+			GenerateFunc: wrapIngressFunc(func(s *v1beta1.Ingress) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: 1,
+						},
+					}}
+			}),
+		},
+		{
+			Name: descIngressLabelsName,
+			Type: metric.Gauge,
+			Help: descIngressLabelsHelp,
+			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(i.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					}}
+
+			}),
+		},
+		{
+			Name: "kube_ingress_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !i.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						Value: float64(i.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_ingress_metadata_resource_version",
+			Type: metric.Gauge,
+			Help: "Resource version representing a specific version of ingress.",
+			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"resource_version"},
+							LabelValues: []string{string(i.ObjectMeta.ResourceVersion)},
+							Value:       1,
+						},
+					}}
+			}),
+		},
+	}
+)
+
+func wrapIngressFunc(f func(*v1beta1.Ingress) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		ingress := obj.(*v1beta1.Ingress)
+
+		metricFamily := f(ingress)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descIngressLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{ingress.Namespace, ingress.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createIngressListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.ExtensionsV1beta1().Ingresses(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.ExtensionsV1beta1().Ingresses(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/job.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/job.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"strconv"
+
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	v1batch "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descJobLabelsName          = "kube_job_labels"
+	descJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descJobLabelsDefaultLabels = []string{"namespace", "job_name"}
+
+	jobMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: descJobLabelsName,
+			Type: metric.Gauge,
+			Help: descJobLabelsHelp,
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(j.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_job_info",
+			Type: metric.Gauge,
+			Help: "Information about job.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: 1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_job_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !j.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						Value: float64(j.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_job_spec_parallelism",
+			Type: metric.Gauge,
+			Help: "The maximum desired number of pods the job should run at any given time.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Spec.Parallelism != nil {
+					ms = append(ms, &metric.Metric{
+						Value: float64(*j.Spec.Parallelism),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_job_spec_completions",
+			Type: metric.Gauge,
+			Help: "The desired number of successfully finished pods the job should be run with.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Spec.Completions != nil {
+					ms = append(ms, &metric.Metric{
+						Value: float64(*j.Spec.Completions),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_job_spec_active_deadline_seconds",
+			Type: metric.Gauge,
+			Help: "The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Spec.ActiveDeadlineSeconds != nil {
+					ms = append(ms, &metric.Metric{
+						Value: float64(*j.Spec.ActiveDeadlineSeconds),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_job_status_succeeded",
+			Type: metric.Gauge,
+			Help: "The number of pods which reached Phase Succeeded.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(j.Status.Succeeded),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_job_status_failed",
+			Type: metric.Gauge,
+			Help: "The number of pods which reached Phase Failed.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(j.Status.Failed),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_job_status_active",
+			Type: metric.Gauge,
+			Help: "The number of actively running pods.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(j.Status.Active),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_job_complete",
+			Type: metric.Gauge,
+			Help: "The job has completed its execution.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				ms := []*metric.Metric{}
+				for _, c := range j.Status.Conditions {
+					if c.Type == v1batch.JobComplete {
+						metrics := addConditionMetrics(c.Status)
+						for _, m := range metrics {
+							metric := m
+							metric.LabelKeys = []string{"condition"}
+							ms = append(ms, metric)
+						}
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_job_failed",
+			Type: metric.Gauge,
+			Help: "The job has failed its execution.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, c := range j.Status.Conditions {
+					if c.Type == v1batch.JobFailed {
+						metrics := addConditionMetrics(c.Status)
+						for _, m := range metrics {
+							metric := m
+							metric.LabelKeys = []string{"condition"}
+							ms = append(ms, metric)
+						}
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_job_status_start_time",
+			Type: metric.Gauge,
+			Help: "StartTime represents time when the job was acknowledged by the Job Manager.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Status.StartTime != nil {
+					ms = append(ms, &metric.Metric{
+
+						Value: float64(j.Status.StartTime.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_job_status_completion_time",
+			Type: metric.Gauge,
+			Help: "CompletionTime represents time when the job was completed.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				ms := []*metric.Metric{}
+				if j.Status.CompletionTime != nil {
+					ms = append(ms, &metric.Metric{
+
+						Value: float64(j.Status.CompletionTime.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_job_owner",
+			Type: metric.Gauge,
+			Help: "Information about the Job's owner.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
+
+				owners := j.GetOwnerReferences()
+
+				if len(owners) == 0 {
+					return &metric.Family{
+						Metrics: []*metric.Metric{
+							{
+								LabelKeys:   labelKeys,
+								LabelValues: []string{"<none>", "<none>", "<none>"},
+								Value:       1,
+							},
+						},
+					}
+				}
+
+				ms := make([]*metric.Metric, len(owners))
+
+				for i, owner := range owners {
+					if owner.Controller != nil {
+						ms[i] = &metric.Metric{
+							LabelKeys:   labelKeys,
+							LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
+							Value:       1,
+						}
+					} else {
+						ms[i] = &metric.Metric{
+							LabelKeys:   labelKeys,
+							LabelValues: []string{owner.Kind, owner.Name, "false"},
+							Value:       1,
+						}
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+	}
+)
+
+func wrapJobFunc(f func(*v1batch.Job) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		job := obj.(*v1batch.Job)
+
+		metricFamily := f(job)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descJobLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{job.Namespace, job.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createJobListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.BatchV1().Jobs(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.BatchV1().Jobs(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/limitrange.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/limitrange.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descLimitRangeLabelsDefaultLabels = []string{"namespace", "limitrange"}
+
+	limitRangeMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_limitrange",
+			Type: metric.Gauge,
+			Help: "Information about limit range.",
+			GenerateFunc: wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
+				ms := []*metric.Metric{}
+
+				rawLimitRanges := r.Spec.Limits
+				for _, rawLimitRange := range rawLimitRanges {
+					for resource, min := range rawLimitRange.Min {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{string(resource), string(rawLimitRange.Type), "min"},
+							Value:       float64(min.MilliValue()) / 1000,
+						})
+					}
+
+					for resource, max := range rawLimitRange.Max {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{string(resource), string(rawLimitRange.Type), "max"},
+							Value:       float64(max.MilliValue()) / 1000,
+						})
+					}
+
+					for resource, df := range rawLimitRange.Default {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{string(resource), string(rawLimitRange.Type), "default"},
+							Value:       float64(df.MilliValue()) / 1000,
+						})
+					}
+
+					for resource, dfR := range rawLimitRange.DefaultRequest {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{string(resource), string(rawLimitRange.Type), "defaultRequest"},
+							Value:       float64(dfR.MilliValue()) / 1000,
+						})
+					}
+
+					for resource, mLR := range rawLimitRange.MaxLimitRequestRatio {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{string(resource), string(rawLimitRange.Type), "maxLimitRequestRatio"},
+							Value:       float64(mLR.MilliValue()) / 1000,
+						})
+					}
+				}
+
+				for _, m := range ms {
+					m.LabelKeys = []string{"resource", "type", "constraint"}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_limitrange_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !r.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+
+						Value: float64(r.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+	}
+)
+
+func wrapLimitRangeFunc(f func(*v1.LimitRange) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		limitRange := obj.(*v1.LimitRange)
+
+		metricFamily := f(limitRange)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descLimitRangeLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{limitRange.Namespace, limitRange.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createLimitRangeListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().LimitRanges(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().LimitRanges(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/namespace.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/namespace.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descNamespaceLabelsName          = "kube_namespace_labels"
+	descNamespaceLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descNamespaceLabelsDefaultLabels = []string{"namespace"}
+
+	descNamespaceAnnotationsName          = "kube_namespace_annotations"
+	descNamespaceAnnotationsHelp          = "Kubernetes annotations converted to Prometheus labels."
+	descNamespaceAnnotationsDefaultLabels = []string{"namespace"}
+
+	namespaceMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_namespace_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
+				ms := []*metric.Metric{}
+				if !n.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						Value: float64(n.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: descNamespaceLabelsName,
+			Type: metric.Gauge,
+			Help: descNamespaceLabelsHelp,
+			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(n.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: descNamespaceAnnotationsName,
+			Type: metric.Gauge,
+			Help: descNamespaceAnnotationsHelp,
+			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(n.Annotations)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   annotationKeys,
+							LabelValues: annotationValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_namespace_status_phase",
+			Type: metric.Gauge,
+			Help: "kubernetes namespace status phase.",
+			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{string(v1.NamespaceActive)},
+						Value:       boolFloat64(n.Status.Phase == v1.NamespaceActive),
+					},
+					{
+						LabelValues: []string{string(v1.NamespaceTerminating)},
+						Value:       boolFloat64(n.Status.Phase == v1.NamespaceTerminating),
+					},
+				}
+
+				for _, metric := range ms {
+					metric.LabelKeys = []string{"phase"}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+	}
+)
+
+func wrapNamespaceFunc(f func(*v1.Namespace) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		namespace := obj.(*v1.Namespace)
+
+		metricFamily := f(namespace)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descNamespaceLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{namespace.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createNamespaceListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().Namespaces().List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().Namespaces().Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/node.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/node.go
@@ -1,0 +1,508 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"k8s.io/kube-state-metrics/pkg/constant"
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descNodeLabelsName          = "kube_node_labels"
+	descNodeLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descNodeLabelsDefaultLabels = []string{"node"}
+
+	nodeMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_node_info",
+			Type: metric.Gauge,
+			Help: "Information about a cluster node.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys: []string{
+								"kernel_version",
+								"os_image",
+								"container_runtime_version",
+								"kubelet_version",
+								"kubeproxy_version",
+								"provider_id",
+							},
+							LabelValues: []string{
+								n.Status.NodeInfo.KernelVersion,
+								n.Status.NodeInfo.OSImage,
+								n.Status.NodeInfo.ContainerRuntimeVersion,
+								n.Status.NodeInfo.KubeletVersion,
+								n.Status.NodeInfo.KubeProxyVersion,
+								n.Spec.ProviderID,
+							},
+							Value: 1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_node_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !n.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+
+						Value: float64(n.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: descNodeLabelsName,
+			Type: metric.Gauge,
+			Help: descNodeLabelsHelp,
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(n.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_node_spec_unschedulable",
+			Type: metric.Gauge,
+			Help: "Whether a node can schedule new pods.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: boolFloat64(n.Spec.Unschedulable),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_node_spec_taint",
+			Type: metric.Gauge,
+			Help: "The taint of a cluster node.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				ms := make([]*metric.Metric, len(n.Spec.Taints))
+
+				for i, taint := range n.Spec.Taints {
+					// Taints are applied to repel pods from nodes that do not have a corresponding
+					// toleration.  Many node conditions are optionally reflected as taints
+					// by the node controller in order to simplify scheduling constraints.
+					ms[i] = &metric.Metric{
+						LabelKeys:   []string{"key", "value", "effect"},
+						LabelValues: []string{taint.Key, taint.Value, string(taint.Effect)},
+						Value:       1,
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		// This all-in-one metric family contains all conditions for extensibility.
+		// Third party plugin may report customized condition for cluster node
+		// (e.g. node-problem-detector), and Kubernetes may add new core
+		// conditions in future.
+		{
+			Name: "kube_node_status_condition",
+			Type: metric.Gauge,
+			Help: "The condition of a cluster node.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				ms := make([]*metric.Metric, len(n.Status.Conditions)*len(conditionStatuses))
+
+				// Collect node conditions and while default to false.
+				for i, c := range n.Status.Conditions {
+					conditionMetrics := addConditionMetrics(c.Status)
+
+					for j, m := range conditionMetrics {
+						metric := m
+
+						metric.LabelKeys = []string{"condition", "status"}
+						metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
+
+						ms[i*len(conditionStatuses)+j] = metric
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_node_status_phase",
+			Type: metric.Gauge,
+			Help: "The phase the node is currently in.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				p := n.Status.Phase
+
+				if p == "" {
+					return &metric.Family{
+						Metrics: []*metric.Metric{},
+					}
+				}
+
+				// Set current phase to 1, others to 0 if it is set.
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{string(v1.NodePending)},
+						Value:       boolFloat64(p == v1.NodePending),
+					},
+					{
+						LabelValues: []string{string(v1.NodeRunning)},
+						Value:       boolFloat64(p == v1.NodeRunning),
+					},
+					{
+						LabelValues: []string{string(v1.NodeTerminated)},
+						Value:       boolFloat64(p == v1.NodeTerminated),
+					},
+				}
+
+				for _, metric := range ms {
+					metric.LabelKeys = []string{"phase"}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_node_status_capacity",
+			Type: metric.Gauge,
+			Help: "The capacity for different resources of a node.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				ms := []*metric.Metric{}
+
+				capacity := n.Status.Capacity
+				for resourceName, val := range capacity {
+					switch resourceName {
+					case v1.ResourceCPU:
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{
+								sanitizeLabelName(string(resourceName)),
+								string(constant.UnitCore),
+							},
+							Value: float64(val.MilliValue()) / 1000,
+						})
+					case v1.ResourceStorage:
+						fallthrough
+					case v1.ResourceEphemeralStorage:
+						fallthrough
+					case v1.ResourceMemory:
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{
+								sanitizeLabelName(string(resourceName)),
+								string(constant.UnitByte),
+							},
+							Value: float64(val.MilliValue()) / 1000,
+						})
+					case v1.ResourcePods:
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{
+								sanitizeLabelName(string(resourceName)),
+								string(constant.UnitInteger),
+							},
+							Value: float64(val.MilliValue()) / 1000,
+						})
+					default:
+						if isHugePageResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{
+									sanitizeLabelName(string(resourceName)),
+									string(constant.UnitByte),
+								},
+								Value: float64(val.MilliValue()) / 1000,
+							})
+						}
+						if isAttachableVolumeResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{
+									sanitizeLabelName(string(resourceName)),
+									string(constant.UnitByte),
+								},
+								Value: float64(val.MilliValue()) / 1000,
+							})
+						}
+						if isExtendedResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{
+									sanitizeLabelName(string(resourceName)),
+									string(constant.UnitInteger),
+								},
+								Value: float64(val.MilliValue()) / 1000,
+							})
+						}
+					}
+				}
+
+				for _, metric := range ms {
+					metric.LabelKeys = []string{"resource", "unit"}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_node_status_capacity_pods",
+			Type: metric.Gauge,
+			Help: "The total pod resources of the node.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				ms := []*metric.Metric{}
+
+				// Add capacity and allocatable resources if they are set.
+				if v, ok := n.Status.Capacity[v1.ResourcePods]; ok {
+					ms = append(ms, &metric.Metric{
+
+						Value: float64(v.MilliValue()) / 1000,
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_node_status_capacity_cpu_cores",
+			Type: metric.Gauge,
+			Help: "The total CPU resources of the node.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				ms := []*metric.Metric{}
+
+				// Add capacity and allocatable resources if they are set.
+				if v, ok := n.Status.Capacity[v1.ResourceCPU]; ok {
+					ms = append(ms, &metric.Metric{
+						Value: float64(v.MilliValue()) / 1000,
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_node_status_capacity_memory_bytes",
+			Type: metric.Gauge,
+			Help: "The total memory resources of the node.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				ms := []*metric.Metric{}
+
+				// Add capacity and allocatable resources if they are set.
+				if v, ok := n.Status.Capacity[v1.ResourceMemory]; ok {
+					ms = append(ms, &metric.Metric{
+						Value: float64(v.MilliValue()) / 1000,
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_node_status_allocatable",
+			Type: metric.Gauge,
+			Help: "The allocatable for different resources of a node that are available for scheduling.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				ms := []*metric.Metric{}
+
+				allocatable := n.Status.Allocatable
+
+				for resourceName, val := range allocatable {
+					switch resourceName {
+					case v1.ResourceCPU:
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{
+								sanitizeLabelName(string(resourceName)),
+								string(constant.UnitCore),
+							},
+							Value: float64(val.MilliValue()) / 1000,
+						})
+					case v1.ResourceStorage:
+						fallthrough
+					case v1.ResourceEphemeralStorage:
+						fallthrough
+					case v1.ResourceMemory:
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{
+								sanitizeLabelName(string(resourceName)),
+								string(constant.UnitByte),
+							},
+							Value: float64(val.MilliValue()) / 1000,
+						})
+					case v1.ResourcePods:
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{
+								sanitizeLabelName(string(resourceName)),
+								string(constant.UnitInteger),
+							},
+							Value: float64(val.MilliValue()) / 1000,
+						})
+					default:
+						if isHugePageResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{
+									sanitizeLabelName(string(resourceName)),
+									string(constant.UnitByte),
+								},
+								Value: float64(val.MilliValue()) / 1000,
+							})
+						}
+						if isAttachableVolumeResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{
+									sanitizeLabelName(string(resourceName)),
+									string(constant.UnitByte),
+								},
+								Value: float64(val.MilliValue()) / 1000,
+							})
+						}
+						if isExtendedResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{
+									sanitizeLabelName(string(resourceName)),
+									string(constant.UnitInteger),
+								},
+								Value: float64(val.MilliValue()) / 1000,
+							})
+						}
+					}
+				}
+
+				for _, m := range ms {
+					m.LabelKeys = []string{"resource", "unit"}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_node_status_allocatable_pods",
+			Type: metric.Gauge,
+			Help: "The pod resources of a node that are available for scheduling.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				ms := []*metric.Metric{}
+
+				// Add capacity and allocatable resources if they are set.
+				if v, ok := n.Status.Allocatable[v1.ResourcePods]; ok {
+					ms = append(ms, &metric.Metric{
+						Value: float64(v.MilliValue()) / 1000,
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_node_status_allocatable_cpu_cores",
+			Type: metric.Gauge,
+			Help: "The CPU resources of a node that are available for scheduling.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				ms := []*metric.Metric{}
+
+				// Add capacity and allocatable resources if they are set.
+				if v, ok := n.Status.Allocatable[v1.ResourceCPU]; ok {
+					ms = append(ms, &metric.Metric{
+						Value: float64(v.MilliValue()) / 1000,
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_node_status_allocatable_memory_bytes",
+			Type: metric.Gauge,
+			Help: "The memory resources of a node that are available for scheduling.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				ms := []*metric.Metric{}
+
+				// Add capacity and allocatable resources if they are set.
+				if v, ok := n.Status.Allocatable[v1.ResourceMemory]; ok {
+					ms = append(ms, &metric.Metric{
+
+						Value: float64(v.MilliValue()) / 1000,
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+	}
+)
+
+func wrapNodeFunc(f func(*v1.Node) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		node := obj.(*v1.Node)
+
+		metricFamily := f(node)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descNodeLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{node.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createNodeListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().Nodes().List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().Nodes().Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/persistentvolume.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/persistentvolume.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descPersistentVolumeLabelsName          = "kube_persistentvolume_labels"
+	descPersistentVolumeLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descPersistentVolumeLabelsDefaultLabels = []string{"persistentvolume"}
+
+	persistentVolumeMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: descPersistentVolumeLabelsName,
+			Type: metric.Gauge,
+			Help: descPersistentVolumeLabelsHelp,
+			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_persistentvolume_status_phase",
+			Type: metric.Gauge,
+			Help: "The phase indicates if a volume is available, bound to a claim, or released by a claim.",
+			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+				phase := p.Status.Phase
+
+				if phase == "" {
+					return &metric.Family{
+						Metrics: []*metric.Metric{},
+					}
+				}
+
+				// Set current phase to 1, others to 0 if it is set.
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{string(v1.VolumePending)},
+						Value:       boolFloat64(phase == v1.VolumePending),
+					},
+					{
+						LabelValues: []string{string(v1.VolumeAvailable)},
+						Value:       boolFloat64(phase == v1.VolumeAvailable),
+					},
+					{
+						LabelValues: []string{string(v1.VolumeBound)},
+						Value:       boolFloat64(phase == v1.VolumeBound),
+					},
+					{
+						LabelValues: []string{string(v1.VolumeReleased)},
+						Value:       boolFloat64(phase == v1.VolumeReleased),
+					},
+					{
+						LabelValues: []string{string(v1.VolumeFailed)},
+						Value:       boolFloat64(phase == v1.VolumeFailed),
+					},
+				}
+
+				for _, m := range ms {
+					m.LabelKeys = []string{"phase"}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_persistentvolume_info",
+			Type: metric.Gauge,
+			Help: "Information about persistentvolume.",
+			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"storageclass"},
+							LabelValues: []string{p.Spec.StorageClassName},
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_persistentvolume_capacity_bytes",
+			Type: metric.Gauge,
+			Help: "Persistentvolume capacity in bytes.",
+			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+				storage := p.Spec.Capacity[v1.ResourceStorage]
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(storage.Value()),
+						},
+					},
+				}
+			}),
+		},
+	}
+)
+
+func wrapPersistentVolumeFunc(f func(*v1.PersistentVolume) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		persistentVolume := obj.(*v1.PersistentVolume)
+
+		metricFamily := f(persistentVolume)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descPersistentVolumeLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{persistentVolume.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createPersistentVolumeListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().PersistentVolumes().List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().PersistentVolumes().Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/persistentvolumeclaim.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/persistentvolumeclaim.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descPersistentVolumeClaimLabelsName          = "kube_persistentvolumeclaim_labels"
+	descPersistentVolumeClaimLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descPersistentVolumeClaimLabelsDefaultLabels = []string{"namespace", "persistentvolumeclaim"}
+
+	persistentVolumeClaimMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: descPersistentVolumeClaimLabelsName,
+			Type: metric.Gauge,
+			Help: descPersistentVolumeClaimLabelsHelp,
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_persistentvolumeclaim_info",
+			Type: metric.Gauge,
+			Help: "Information about persistent volume claim.",
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+				storageClassName := getPersistentVolumeClaimClass(p)
+				volumeName := p.Spec.VolumeName
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"storageclass", "volumename"},
+							LabelValues: []string{storageClassName, volumeName},
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_persistentvolumeclaim_status_phase",
+			Type: metric.Gauge,
+			Help: "The phase the persistent volume claim is currently in.",
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+				phase := p.Status.Phase
+
+				if phase == "" {
+					return &metric.Family{
+						Metrics: []*metric.Metric{},
+					}
+				}
+
+				// Set current phase to 1, others to 0 if it is set.
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{string(v1.ClaimLost)},
+						Value:       boolFloat64(phase == v1.ClaimLost),
+					},
+					{
+						LabelValues: []string{string(v1.ClaimBound)},
+						Value:       boolFloat64(phase == v1.ClaimBound),
+					},
+					{
+						LabelValues: []string{string(v1.ClaimPending)},
+						Value:       boolFloat64(phase == v1.ClaimPending),
+					},
+				}
+
+				for _, m := range ms {
+					m.LabelKeys = []string{"phase"}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_persistentvolumeclaim_resource_requests_storage_bytes",
+			Type: metric.Gauge,
+			Help: "The capacity of storage requested by the persistent volume claim.",
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if storage, ok := p.Spec.Resources.Requests[v1.ResourceStorage]; ok {
+					ms = append(ms, &metric.Metric{
+						Value: float64(storage.Value()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_persistentvolumeclaim_access_mode",
+			Type: metric.Gauge,
+			Help: "The access mode(s) specified by the persistent volume claim.",
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+				ms := make([]*metric.Metric, len(p.Spec.AccessModes))
+
+				for i, mode := range p.Spec.AccessModes {
+					ms[i] = &metric.Metric{
+						LabelKeys:   []string{"access_mode"},
+						LabelValues: []string{string(mode)},
+						Value:       1,
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+	}
+)
+
+func wrapPersistentVolumeClaimFunc(f func(*v1.PersistentVolumeClaim) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		persistentVolumeClaim := obj.(*v1.PersistentVolumeClaim)
+
+		metricFamily := f(persistentVolumeClaim)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descPersistentVolumeClaimLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{persistentVolumeClaim.Namespace, persistentVolumeClaim.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createPersistentVolumeClaimListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().PersistentVolumeClaims(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().PersistentVolumeClaims(ns).Watch(opts)
+		},
+	}
+}
+
+// getPersistentVolumeClaimClass returns StorageClassName. If no storage class was
+// requested, it returns "".
+func getPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
+	// Use beta annotation first
+	if class, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return class
+	}
+
+	if claim.Spec.StorageClassName != nil {
+		return *claim.Spec.StorageClassName
+	}
+
+	// Special non-empty string to indicate absence of storage class.
+	return "<none>"
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/pod.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/pod.go
@@ -1,0 +1,803 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"strconv"
+
+	"k8s.io/kube-state-metrics/pkg/constant"
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+const nodeUnreachablePodReason = "NodeLost"
+
+var (
+	descPodLabelsDefaultLabels = []string{"namespace", "pod"}
+	containerWaitingReasons    = []string{"ContainerCreating", "CrashLoopBackOff", "CreateContainerConfigError", "ErrImagePull", "ImagePullBackOff"}
+	containerTerminatedReasons = []string{"OOMKilled", "Completed", "Error", "ContainerCannotRun"}
+
+	podMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_pod_info",
+			Type: metric.Gauge,
+			Help: "Information about pod.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				createdBy := metav1.GetControllerOf(p)
+				createdByKind := "<none>"
+				createdByName := "<none>"
+				if createdBy != nil {
+					if createdBy.Kind != "" {
+						createdByKind = createdBy.Kind
+					}
+					if createdBy.Name != "" {
+						createdByName = createdBy.Name
+					}
+				}
+
+				m := metric.Metric{
+
+					LabelKeys:   []string{"host_ip", "pod_ip", "uid", "node", "created_by_kind", "created_by_name", "priority_class"},
+					LabelValues: []string{p.Status.HostIP, p.Status.PodIP, string(p.UID), p.Spec.NodeName, createdByKind, createdByName, p.Spec.PriorityClassName},
+					Value:       1,
+				}
+
+				return &metric.Family{
+					Metrics: []*metric.Metric{&m},
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_start_time",
+			Type: metric.Gauge,
+			Help: "Start time in unix timestamp for a pod.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if p.Status.StartTime != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64((*(p.Status.StartTime)).Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_completion_time",
+			Type: metric.Gauge,
+			Help: "Completion time in unix timestamp for a pod.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				var lastFinishTime float64
+				for _, cs := range p.Status.ContainerStatuses {
+					if cs.State.Terminated != nil {
+						if lastFinishTime == 0 || lastFinishTime < float64(cs.State.Terminated.FinishedAt.Unix()) {
+							lastFinishTime = float64(cs.State.Terminated.FinishedAt.Unix())
+						}
+					}
+				}
+
+				if lastFinishTime > 0 {
+					ms = append(ms, &metric.Metric{
+
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       lastFinishTime,
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_owner",
+			Type: metric.Gauge,
+			Help: "Information about the Pod's owner.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
+
+				owners := p.GetOwnerReferences()
+				if len(owners) == 0 {
+					return &metric.Family{
+						Metrics: []*metric.Metric{
+							{
+								LabelKeys:   labelKeys,
+								LabelValues: []string{"<none>", "<none>", "<none>"},
+								Value:       1,
+							},
+						},
+					}
+				}
+
+				ms := make([]*metric.Metric, len(owners))
+
+				for i, owner := range owners {
+					if owner.Controller != nil {
+						ms[i] = &metric.Metric{
+							LabelKeys:   labelKeys,
+							LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
+							Value:       1,
+						}
+					} else {
+						ms[i] = &metric.Metric{
+							LabelKeys:   labelKeys,
+							LabelValues: []string{owner.Kind, owner.Name, "false"},
+							Value:       1,
+						}
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_labels",
+			Type: metric.Gauge,
+			Help: "Kubernetes labels converted to Prometheus labels.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
+				m := metric.Metric{
+					LabelKeys:   labelKeys,
+					LabelValues: labelValues,
+					Value:       1,
+				}
+				return &metric.Family{
+					Metrics: []*metric.Metric{&m},
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !p.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(p.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_status_scheduled_time",
+			Type: metric.Gauge,
+			Help: "Unix timestamp when pod moved into scheduled status",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, c := range p.Status.Conditions {
+					switch c.Type {
+					case v1.PodScheduled:
+						if c.Status == v1.ConditionTrue {
+							ms = append(ms, &metric.Metric{
+								LabelKeys:   []string{},
+								LabelValues: []string{},
+								Value:       float64(c.LastTransitionTime.Unix()),
+							})
+						}
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_status_phase",
+			Type: metric.Gauge,
+			Help: "The pods current phase.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				phase := p.Status.Phase
+				if phase == "" {
+					return &metric.Family{
+						Metrics: []*metric.Metric{},
+					}
+				}
+
+				phases := []struct {
+					v bool
+					n string
+				}{
+					{phase == v1.PodPending, string(v1.PodPending)},
+					{phase == v1.PodSucceeded, string(v1.PodSucceeded)},
+					{phase == v1.PodFailed, string(v1.PodFailed)},
+					// This logic is directly copied from: https://github.com/kubernetes/kubernetes/blob/d39bfa0d138368bbe72b0eaf434501dcb4ec9908/pkg/printers/internalversion/printers.go#L597-L601
+					// For more info, please go to: https://github.com/kubernetes/kube-state-metrics/issues/410
+					{phase == v1.PodRunning && !(p.DeletionTimestamp != nil && p.Status.Reason == nodeUnreachablePodReason), string(v1.PodRunning)},
+					{phase == v1.PodUnknown || (p.DeletionTimestamp != nil && p.Status.Reason == nodeUnreachablePodReason), string(v1.PodUnknown)},
+				}
+
+				ms := make([]*metric.Metric, len(phases))
+
+				for i, p := range phases {
+					ms[i] = &metric.Metric{
+
+						LabelKeys:   []string{"phase"},
+						LabelValues: []string{p.n},
+						Value:       boolFloat64(p.v),
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_status_ready",
+			Type: metric.Gauge,
+			Help: "Describes whether the pod is ready to serve requests.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, c := range p.Status.Conditions {
+					switch c.Type {
+					case v1.PodReady:
+						conditionMetrics := addConditionMetrics(c.Status)
+
+						for _, m := range conditionMetrics {
+							metric := m
+							metric.LabelKeys = []string{"condition"}
+							ms = append(ms, metric)
+						}
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_status_scheduled",
+			Type: metric.Gauge,
+			Help: "Describes the status of the scheduling process for the pod.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, c := range p.Status.Conditions {
+					switch c.Type {
+					case v1.PodScheduled:
+						conditionMetrics := addConditionMetrics(c.Status)
+
+						for _, m := range conditionMetrics {
+							metric := m
+							metric.LabelKeys = []string{"condition"}
+							ms = append(ms, metric)
+						}
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_info",
+			Type: metric.Gauge,
+			Help: "Information about a container in a pod.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+				labelKeys := []string{"container", "image", "image_id", "container_id"}
+
+				for i, cs := range p.Status.ContainerStatuses {
+					ms[i] = &metric.Metric{
+						LabelKeys:   labelKeys,
+						LabelValues: []string{cs.Name, cs.Image, cs.ImageID, cs.ContainerID},
+						Value:       1,
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_status_waiting",
+			Type: metric.Gauge,
+			Help: "Describes whether the container is currently in waiting state.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+
+				for i, cs := range p.Status.ContainerStatuses {
+					ms[i] = &metric.Metric{
+						LabelKeys:   []string{"container"},
+						LabelValues: []string{cs.Name},
+						Value:       boolFloat64(cs.State.Waiting != nil),
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_status_waiting_reason",
+			Type: metric.Gauge,
+			Help: "Describes the reason the container is currently in waiting state.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerWaitingReasons))
+
+				for i, cs := range p.Status.ContainerStatuses {
+					for j, reason := range containerWaitingReasons {
+						ms[i*len(containerWaitingReasons)+j] = &metric.Metric{
+							LabelKeys:   []string{"container", "reason"},
+							LabelValues: []string{cs.Name, reason},
+							Value:       boolFloat64(waitingReason(cs, reason)),
+						}
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_status_running",
+			Type: metric.Gauge,
+			Help: "Describes whether the container is currently in running state.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+
+				for i, cs := range p.Status.ContainerStatuses {
+					ms[i] = &metric.Metric{
+						LabelKeys:   []string{"container"},
+						LabelValues: []string{cs.Name},
+						Value:       boolFloat64(cs.State.Running != nil),
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_status_terminated",
+			Type: metric.Gauge,
+			Help: "Describes whether the container is currently in terminated state.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+
+				for i, cs := range p.Status.ContainerStatuses {
+					ms[i] = &metric.Metric{
+						LabelKeys:   []string{"container"},
+						LabelValues: []string{cs.Name},
+						Value:       boolFloat64(cs.State.Terminated != nil),
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_status_terminated_reason",
+			Type: metric.Gauge,
+			Help: "Describes the reason the container is currently in terminated state.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerTerminatedReasons))
+
+				for i, cs := range p.Status.ContainerStatuses {
+					for j, reason := range containerTerminatedReasons {
+						ms[i*len(containerTerminatedReasons)+j] = &metric.Metric{
+							LabelKeys:   []string{"container", "reason"},
+							LabelValues: []string{cs.Name, reason},
+							Value:       boolFloat64(terminationReason(cs, reason)),
+						}
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_status_last_terminated_reason",
+			Type: metric.Gauge,
+			Help: "Describes the last reason the container was in terminated state.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerTerminatedReasons))
+
+				for i, cs := range p.Status.ContainerStatuses {
+					for j, reason := range containerTerminatedReasons {
+						ms[i*len(containerTerminatedReasons)+j] = &metric.Metric{
+							LabelKeys:   []string{"container", "reason"},
+							LabelValues: []string{cs.Name, reason},
+							Value:       boolFloat64(lastTerminationReason(cs, reason)),
+						}
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_status_ready",
+			Type: metric.Gauge,
+			Help: "Describes whether the containers readiness check succeeded.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+
+				for i, cs := range p.Status.ContainerStatuses {
+					ms[i] = &metric.Metric{
+						LabelKeys:   []string{"container"},
+						LabelValues: []string{cs.Name},
+						Value:       boolFloat64(cs.Ready),
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_status_restarts_total",
+			Type: metric.Counter,
+			Help: "The number of container restarts per container.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+
+				for i, cs := range p.Status.ContainerStatuses {
+					ms[i] = &metric.Metric{
+						LabelKeys:   []string{"container"},
+						LabelValues: []string{cs.Name},
+						Value:       float64(cs.RestartCount),
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_resource_requests",
+			Type: metric.Gauge,
+			Help: "The number of requested request resource by a container.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, c := range p.Spec.Containers {
+					req := c.Resources.Requests
+
+					for resourceName, val := range req {
+						switch resourceName {
+						case v1.ResourceCPU:
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+								Value:       float64(val.MilliValue()) / 1000,
+							})
+						case v1.ResourceStorage:
+							fallthrough
+						case v1.ResourceEphemeralStorage:
+							fallthrough
+						case v1.ResourceMemory:
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								Value:       float64(val.Value()),
+							})
+						default:
+							if isHugePageResourceName(resourceName) {
+								ms = append(ms, &metric.Metric{
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									Value:       float64(val.Value()),
+								})
+							}
+							if isAttachableVolumeResourceName(resourceName) {
+								ms = append(ms, &metric.Metric{
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									Value:       float64(val.Value()),
+								})
+							}
+							if isExtendedResourceName(resourceName) {
+								ms = append(ms, &metric.Metric{
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+									Value:       float64(val.Value()),
+								})
+							}
+						}
+					}
+				}
+
+				for _, metric := range ms {
+					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_resource_limits",
+			Type: metric.Gauge,
+			Help: "The number of requested limit resource by a container.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, c := range p.Spec.Containers {
+					lim := c.Resources.Limits
+
+					for resourceName, val := range lim {
+						switch resourceName {
+						case v1.ResourceCPU:
+							ms = append(ms, &metric.Metric{
+								Value:       float64(val.MilliValue()) / 1000,
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+							})
+						case v1.ResourceStorage:
+							fallthrough
+						case v1.ResourceEphemeralStorage:
+							fallthrough
+						case v1.ResourceMemory:
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								Value:       float64(val.Value()),
+							})
+						default:
+							if isHugePageResourceName(resourceName) {
+								ms = append(ms, &metric.Metric{
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									Value:       float64(val.Value()),
+								})
+							}
+							if isAttachableVolumeResourceName(resourceName) {
+								ms = append(ms, &metric.Metric{
+									Value:       float64(val.Value()),
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								})
+							}
+							if isExtendedResourceName(resourceName) {
+								ms = append(ms, &metric.Metric{
+									Value:       float64(val.Value()),
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+								})
+							}
+						}
+					}
+				}
+
+				for _, metric := range ms {
+					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_resource_requests_cpu_cores",
+			Type: metric.Gauge,
+			Help: "The number of requested cpu cores by a container.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, c := range p.Spec.Containers {
+					req := c.Resources.Requests
+					if cpu, ok := req[v1.ResourceCPU]; ok {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container", "node"},
+							LabelValues: []string{c.Name, p.Spec.NodeName},
+							Value:       float64(cpu.MilliValue()) / 1000,
+						})
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_resource_requests_memory_bytes",
+			Type: metric.Gauge,
+			Help: "The number of requested memory bytes by a container.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, c := range p.Spec.Containers {
+					req := c.Resources.Requests
+					if mem, ok := req[v1.ResourceMemory]; ok {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container", "node"},
+							LabelValues: []string{c.Name, p.Spec.NodeName},
+							Value:       float64(mem.Value()),
+						})
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_resource_limits_cpu_cores",
+			Type: metric.Gauge,
+			Help: "The limit on cpu cores to be used by a container.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, c := range p.Spec.Containers {
+					lim := c.Resources.Limits
+					if cpu, ok := lim[v1.ResourceCPU]; ok {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container", "node"},
+							LabelValues: []string{c.Name, p.Spec.NodeName},
+							Value:       float64(cpu.MilliValue()) / 1000,
+						})
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_resource_limits_memory_bytes",
+			Type: metric.Gauge,
+			Help: "The limit on memory to be used by a container in bytes.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, c := range p.Spec.Containers {
+					lim := c.Resources.Limits
+
+					if mem, ok := lim[v1.ResourceMemory]; ok {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container", "node"},
+							LabelValues: []string{c.Name, p.Spec.NodeName},
+							Value:       float64(mem.Value()),
+						})
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_spec_volumes_persistentvolumeclaims_info",
+			Type: metric.Gauge,
+			Help: "Information about persistentvolumeclaim volumes in a pod.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, v := range p.Spec.Volumes {
+					if v.PersistentVolumeClaim != nil {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"volume", "persistentvolumeclaim"},
+							LabelValues: []string{v.Name, v.PersistentVolumeClaim.ClaimName},
+							Value:       1,
+						})
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_spec_volumes_persistentvolumeclaims_readonly",
+			Type: metric.Gauge,
+			Help: "Describes whether a persistentvolumeclaim is mounted read only.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, v := range p.Spec.Volumes {
+					if v.PersistentVolumeClaim != nil {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"volume", "persistentvolumeclaim"},
+							LabelValues: []string{v.Name, v.PersistentVolumeClaim.ClaimName},
+							Value:       boolFloat64(v.PersistentVolumeClaim.ReadOnly),
+						})
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+	}
+)
+
+func wrapPodFunc(f func(*v1.Pod) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		pod := obj.(*v1.Pod)
+
+		metricFamily := f(pod)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descPodLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{pod.Namespace, pod.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createPodListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().Pods(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().Pods(ns).Watch(opts)
+		},
+	}
+}
+
+func waitingReason(cs v1.ContainerStatus, reason string) bool {
+	if cs.State.Waiting == nil {
+		return false
+	}
+	return cs.State.Waiting.Reason == reason
+}
+
+func terminationReason(cs v1.ContainerStatus, reason string) bool {
+	if cs.State.Terminated == nil {
+		return false
+	}
+	return cs.State.Terminated.Reason == reason
+}
+
+func lastTerminationReason(cs v1.ContainerStatus, reason string) bool {
+	if cs.LastTerminationState.Terminated == nil {
+		return false
+	}
+	return cs.LastTerminationState.Terminated.Reason == reason
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/poddisruptionbudget.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/poddisruptionbudget.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+var (
+	descPodDisruptionBudgetLabelsDefaultLabels = []string{"namespace", "poddisruptionbudget"}
+
+	podDisruptionBudgetMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_poddisruptionbudget_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !p.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						Value: float64(p.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_poddisruptionbudget_status_current_healthy",
+			Type: metric.Gauge,
+			Help: "Current number of healthy pods",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.CurrentHealthy),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_poddisruptionbudget_status_desired_healthy",
+			Type: metric.Gauge,
+			Help: "Minimum desired number of healthy pods",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.DesiredHealthy),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_poddisruptionbudget_status_pod_disruptions_allowed",
+			Type: metric.Gauge,
+			Help: "Number of pod disruptions that are currently allowed",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.PodDisruptionsAllowed),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_poddisruptionbudget_status_expected_pods",
+			Type: metric.Gauge,
+			Help: "Total number of pods counted by this disruption budget",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.ExpectedPods),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_poddisruptionbudget_status_observed_generation",
+			Type: metric.Gauge,
+			Help: "Most recent generation observed when updating this PDB status",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.ObservedGeneration),
+						},
+					},
+				}
+			}),
+		},
+	}
+)
+
+func wrapPodDisruptionBudgetFunc(f func(*v1beta1.PodDisruptionBudget) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		podDisruptionBudget := obj.(*v1beta1.PodDisruptionBudget)
+
+		metricFamily := f(podDisruptionBudget)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descPodDisruptionBudgetLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{podDisruptionBudget.Namespace, podDisruptionBudget.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createPodDisruptionBudgetListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.PolicyV1beta1().PodDisruptionBudgets(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.PolicyV1beta1().PodDisruptionBudgets(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/replicaset.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/replicaset.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"strconv"
+
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descReplicaSetLabelsDefaultLabels = []string{"namespace", "replicaset"}
+	descReplicaSetLabelsName          = "kube_replicaset_labels"
+	descReplicaSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+
+	replicaSetMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_replicaset_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !r.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+
+						Value: float64(r.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_replicaset_status_replicas",
+			Type: metric.Gauge,
+			Help: "The number of replicas per ReplicaSet.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.Replicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_replicaset_status_fully_labeled_replicas",
+			Type: metric.Gauge,
+			Help: "The number of fully labeled replicas per ReplicaSet.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.FullyLabeledReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_replicaset_status_ready_replicas",
+			Type: metric.Gauge,
+			Help: "The number of ready replicas per ReplicaSet.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.ReadyReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_replicaset_status_observed_generation",
+			Type: metric.Gauge,
+			Help: "The generation observed by the ReplicaSet controller.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.ObservedGeneration),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_replicaset_spec_replicas",
+			Type: metric.Gauge,
+			Help: "Number of desired pods for a ReplicaSet.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if r.Spec.Replicas != nil {
+					ms = append(ms, &metric.Metric{
+						Value: float64(*r.Spec.Replicas),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_replicaset_metadata_generation",
+			Type: metric.Gauge,
+			Help: "Sequence number representing a specific generation of the desired state.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.ObjectMeta.Generation),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_replicaset_owner",
+			Type: metric.Gauge,
+			Help: "Information about the ReplicaSet's owner.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				owners := r.GetOwnerReferences()
+
+				if len(owners) == 0 {
+					return &metric.Family{
+						Metrics: []*metric.Metric{
+							{
+								LabelKeys:   []string{"owner_kind", "owner_name", "owner_is_controller"},
+								LabelValues: []string{"<none>", "<none>", "<none>"},
+								Value:       1,
+							},
+						},
+					}
+				}
+
+				ms := make([]*metric.Metric, len(owners))
+
+				for i, owner := range owners {
+					if owner.Controller != nil {
+						ms[i] = &metric.Metric{
+							LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
+						}
+					} else {
+						ms[i] = &metric.Metric{
+							LabelValues: []string{owner.Kind, owner.Name, "false"},
+						}
+					}
+				}
+
+				for _, m := range ms {
+					m.LabelKeys = []string{"owner_kind", "owner_name", "owner_is_controller"}
+					m.Value = 1
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: descReplicaSetLabelsName,
+			Type: metric.Gauge,
+			Help: descReplicaSetLabelsHelp,
+			GenerateFunc: wrapReplicaSetFunc(func(d *v1beta1.ReplicaSet) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+	}
+)
+
+func wrapReplicaSetFunc(f func(*v1beta1.ReplicaSet) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		replicaSet := obj.(*v1beta1.ReplicaSet)
+
+		metricFamily := f(replicaSet)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descReplicaSetLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{replicaSet.Namespace, replicaSet.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createReplicaSetListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.ExtensionsV1beta1().ReplicaSets(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.ExtensionsV1beta1().ReplicaSets(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/replicationcontroller.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/replicationcontroller.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descReplicationControllerLabelsDefaultLabels = []string{"namespace", "replicationcontroller"}
+
+	replicationControllerMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_replicationcontroller_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !r.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						Value: float64(r.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_replicationcontroller_status_replicas",
+			Type: metric.Gauge,
+			Help: "The number of replicas per ReplicationController.",
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.Replicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_replicationcontroller_status_fully_labeled_replicas",
+			Type: metric.Gauge,
+			Help: "The number of fully labeled replicas per ReplicationController.",
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.FullyLabeledReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_replicationcontroller_status_ready_replicas",
+			Type: metric.Gauge,
+			Help: "The number of ready replicas per ReplicationController.",
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.ReadyReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_replicationcontroller_status_available_replicas",
+			Type: metric.Gauge,
+			Help: "The number of available replicas per ReplicationController.",
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.AvailableReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_replicationcontroller_status_observed_generation",
+			Type: metric.Gauge,
+			Help: "The generation observed by the ReplicationController controller.",
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.ObservedGeneration),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_replicationcontroller_spec_replicas",
+			Type: metric.Gauge,
+			Help: "Number of desired pods for a ReplicationController.",
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if r.Spec.Replicas != nil {
+					ms = append(ms, &metric.Metric{
+						Value: float64(*r.Spec.Replicas),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_replicationcontroller_metadata_generation",
+			Type: metric.Gauge,
+			Help: "Sequence number representing a specific generation of the desired state.",
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.ObjectMeta.Generation),
+						},
+					},
+				}
+			}),
+		},
+	}
+)
+
+func wrapReplicationControllerFunc(f func(*v1.ReplicationController) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		replicationController := obj.(*v1.ReplicationController)
+
+		metricFamily := f(replicationController)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descReplicationControllerLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{replicationController.Namespace, replicationController.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createReplicationControllerListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().ReplicationControllers(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().ReplicationControllers(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/resourcequota.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/resourcequota.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descResourceQuotaLabelsDefaultLabels = []string{"namespace", "resourcequota"}
+
+	resourceQuotaMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_resourcequota_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !r.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+
+						Value: float64(r.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_resourcequota",
+			Type: metric.Gauge,
+			Help: "Information about resource quota.",
+			GenerateFunc: wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for res, qty := range r.Status.Hard {
+					ms = append(ms, &metric.Metric{
+						LabelValues: []string{string(res), "hard"},
+						Value:       float64(qty.MilliValue()) / 1000,
+					})
+				}
+				for res, qty := range r.Status.Used {
+					ms = append(ms, &metric.Metric{
+						LabelValues: []string{string(res), "used"},
+						Value:       float64(qty.MilliValue()) / 1000,
+					})
+				}
+
+				for _, m := range ms {
+					m.LabelKeys = []string{"resource", "type"}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+	}
+)
+
+func wrapResourceQuotaFunc(f func(*v1.ResourceQuota) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		resourceQuota := obj.(*v1.ResourceQuota)
+
+		metricFamily := f(resourceQuota)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descResourceQuotaLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{resourceQuota.Namespace, resourceQuota.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createResourceQuotaListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().ResourceQuotas(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().ResourceQuotas(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/secret.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/secret.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descSecretLabelsName          = "kube_secret_labels"
+	descSecretLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descSecretLabelsDefaultLabels = []string{"namespace", "secret"}
+
+	secretMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_secret_info",
+			Type: metric.Gauge,
+			Help: "Information about secret.",
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: 1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_secret_type",
+			Type: metric.Gauge,
+			Help: "Type about secret.",
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"type"},
+							LabelValues: []string{string(s.Type)},
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: descSecretLabelsName,
+			Type: metric.Gauge,
+			Help: descSecretLabelsHelp,
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+
+			}),
+		},
+		{
+			Name: "kube_secret_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !s.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						Value: float64(s.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_secret_metadata_resource_version",
+			Type: metric.Gauge,
+			Help: "Resource version representing a specific version of secret.",
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"resource_version"},
+							LabelValues: []string{string(s.ObjectMeta.ResourceVersion)},
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+	}
+)
+
+func wrapSecretFunc(f func(*v1.Secret) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		secret := obj.(*v1.Secret)
+
+		metricFamily := f(secret)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descSecretLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{secret.Namespace, secret.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createSecretListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().Secrets(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().Secrets(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/service.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/service.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descServiceLabelsName          = "kube_service_labels"
+	descServiceLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descServiceLabelsDefaultLabels = []string{"namespace", "service"}
+
+	serviceMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_service_info",
+			Type: metric.Gauge,
+			Help: "Information about service.",
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+				m := metric.Metric{
+					LabelKeys:   []string{"cluster_ip", "external_name", "load_balancer_ip"},
+					LabelValues: []string{s.Spec.ClusterIP, s.Spec.ExternalName, s.Spec.LoadBalancerIP},
+					Value:       1,
+				}
+				return &metric.Family{Metrics: []*metric.Metric{&m}}
+			}),
+		},
+		{
+			Name: "kube_service_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+				if !s.CreationTimestamp.IsZero() {
+					m := metric.Metric{
+						LabelKeys:   nil,
+						LabelValues: nil,
+						Value:       float64(s.CreationTimestamp.Unix()),
+					}
+					return &metric.Family{Metrics: []*metric.Metric{&m}}
+				}
+				return &metric.Family{Metrics: []*metric.Metric{}}
+			}),
+		},
+		{
+			Name: "kube_service_spec_type",
+			Type: metric.Gauge,
+			Help: "Type about service.",
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+				m := metric.Metric{
+
+					LabelKeys:   []string{"type"},
+					LabelValues: []string{string(s.Spec.Type)},
+					Value:       1,
+				}
+				return &metric.Family{Metrics: []*metric.Metric{&m}}
+			}),
+		},
+		{
+			Name: descServiceLabelsName,
+			Type: metric.Gauge,
+			Help: descServiceLabelsHelp,
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
+				m := metric.Metric{
+
+					LabelKeys:   labelKeys,
+					LabelValues: labelValues,
+					Value:       1,
+				}
+				return &metric.Family{Metrics: []*metric.Metric{&m}}
+			}),
+		},
+		{
+			Name: "kube_service_spec_external_ip",
+			Type: metric.Gauge,
+			Help: "Service external ips. One series for each ip",
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+				if len(s.Spec.ExternalIPs) == 0 {
+					return &metric.Family{
+						Metrics: []*metric.Metric{},
+					}
+				}
+
+				ms := make([]*metric.Metric, len(s.Spec.ExternalIPs))
+
+				for i, externalIP := range s.Spec.ExternalIPs {
+					ms[i] = &metric.Metric{
+						LabelKeys:   []string{"external_ip"},
+						LabelValues: []string{externalIP},
+						Value:       1,
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_service_status_load_balancer_ingress",
+			Type: metric.Gauge,
+			Help: "Service load balancer ingress status",
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+				if len(s.Status.LoadBalancer.Ingress) == 0 {
+					return &metric.Family{
+						Metrics: []*metric.Metric{},
+					}
+				}
+
+				ms := make([]*metric.Metric, len(s.Status.LoadBalancer.Ingress))
+
+				for i, ingress := range s.Status.LoadBalancer.Ingress {
+					ms[i] = &metric.Metric{
+						LabelKeys:   []string{"ip", "hostname"},
+						LabelValues: []string{ingress.IP, ingress.Hostname},
+						Value:       1,
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+	}
+)
+
+func wrapSvcFunc(f func(*v1.Service) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		svc := obj.(*v1.Service)
+
+		metricFamily := f(svc)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descServiceLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{svc.Namespace, svc.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createServiceListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().Services(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().Services(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/statefulset.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/statefulset.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metric"
+
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descStatefulSetLabelsName          = "kube_statefulset_labels"
+	descStatefulSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descStatefulSetLabelsDefaultLabels = []string{"namespace", "statefulset"}
+
+	statefulSetMetricFamilies = []metric.FamilyGenerator{
+		{
+			Name: "kube_statefulset_created",
+			Type: metric.Gauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !s.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						Value: float64(s.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_statefulset_status_replicas",
+			Type: metric.Gauge,
+			Help: "The number of replicas per StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.Status.Replicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_statefulset_status_replicas_current",
+			Type: metric.Gauge,
+			Help: "The number of current replicas per StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.Status.CurrentReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_statefulset_status_replicas_ready",
+			Type: metric.Gauge,
+			Help: "The number of ready replicas per StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.Status.ReadyReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_statefulset_status_replicas_updated",
+			Type: metric.Gauge,
+			Help: "The number of updated replicas per StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.Status.UpdatedReplicas),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_statefulset_status_observed_generation",
+			Type: metric.Gauge,
+			Help: "The generation observed by the StatefulSet controller.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.Status.ObservedGeneration),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_statefulset_replicas",
+			Type: metric.Gauge,
+			Help: "Number of desired pods for a StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if s.Spec.Replicas != nil {
+					ms = append(ms, &metric.Metric{
+						Value: float64(*s.Spec.Replicas),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_statefulset_metadata_generation",
+			Type: metric.Gauge,
+			Help: "Sequence number representing a specific generation of the desired state for the StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.ObjectMeta.Generation),
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: descStatefulSetLabelsName,
+			Type: metric.Gauge,
+			Help: descStatefulSetLabelsHelp,
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_statefulset_status_current_revision",
+			Type: metric.Gauge,
+			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"revision"},
+							LabelValues: []string{s.Status.CurrentRevision},
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_statefulset_status_update_revision",
+			Type: metric.Gauge,
+			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"revision"},
+							LabelValues: []string{s.Status.UpdateRevision},
+							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+	}
+)
+
+func wrapStatefulSetFunc(f func(*v1.StatefulSet) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		statefulSet := obj.(*v1.StatefulSet)
+
+		metricFamily := f(statefulSet)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descStatefulSetLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{statefulSet.Namespace, statefulSet.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createStatefulSetListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.AppsV1().StatefulSets(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.AppsV1().StatefulSets(ns).Watch(opts)
+		},
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/testutils.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/testutils.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+// TODO: Does this file need to be renamed to not be compiled in production?
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
+)
+
+type generateMetricsTestCase struct {
+	Obj         interface{}
+	MetricNames []string
+	Want        string
+	Func        func(interface{}) []metricsstore.FamilyByteSlicer
+}
+
+func (testCase *generateMetricsTestCase) run() error {
+	metricFamilies := testCase.Func(testCase.Obj)
+	metricFamilyStrings := []string{}
+	for _, f := range metricFamilies {
+		metricFamilyStrings = append(metricFamilyStrings, string(f.ByteSlice()))
+	}
+
+	metric := strings.Split(strings.Join(metricFamilyStrings, ""), "\n")
+
+	metric = filterMetrics(metric, testCase.MetricNames)
+
+	out := strings.Join(metric, "\n")
+
+	if err := compareOutput(testCase.Want, out); err != nil {
+		return errors.Wrap(err, "expected wanted output to equal output")
+	}
+
+	return nil
+}
+
+func compareOutput(a, b string) error {
+	entities := []string{a, b}
+
+	// Align a and b
+	for i := 0; i < len(entities); i++ {
+		for _, f := range []func(string) string{removeUnusedWhitespace, sortLabels, sortByLine} {
+			entities[i] = f(entities[i])
+		}
+	}
+
+	if entities[0] != entities[1] {
+		return errors.Errorf("expected a to equal b but got:\n%v\nand:\n%v", entities[0], entities[1])
+	}
+
+	return nil
+}
+
+// sortLabels sorts the order of labels in each line of the given metric. The
+// Prometheus exposition format does not force ordering of labels. Hence a test
+// should not fail due to different metric orders.
+func sortLabels(s string) string {
+	sorted := []string{}
+
+	for _, line := range strings.Split(s, "\n") {
+		split := strings.Split(line, "{")
+		if len(split) != 2 {
+			panic(fmt.Sprintf("failed to sort labels in \"%v\"", line))
+		}
+		name := split[0]
+
+		split = strings.Split(split[1], "}")
+		value := split[1]
+
+		labels := strings.Split(split[0], ",")
+		sort.Strings(labels)
+
+		sorted = append(sorted, fmt.Sprintf("%v{%v}%v", name, strings.Join(labels, ","), value))
+	}
+
+	return strings.Join(sorted, "\n")
+}
+
+func sortByLine(s string) string {
+	split := strings.Split(s, "\n")
+	sort.Strings(split)
+	return strings.Join(split, "\n")
+}
+
+func filterMetrics(ms []string, names []string) []string {
+	// In case the test case is based on all returned metric, MetricNames does
+	// not need to me defined.
+	if names == nil {
+		return ms
+	}
+	filtered := []string{}
+
+	regexps := []*regexp.Regexp{}
+	for _, n := range names {
+		regexps = append(regexps, regexp.MustCompile(fmt.Sprintf("^%v", n)))
+	}
+
+	for _, m := range ms {
+		drop := true
+		for _, r := range regexps {
+			if r.MatchString(m) {
+				drop = false
+				break
+			}
+		}
+		if !drop {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
+}
+
+func removeUnusedWhitespace(s string) string {
+	var (
+		trimmedLine  string
+		trimmedLines []string
+		lines        = strings.Split(s, "\n")
+	)
+
+	for _, l := range lines {
+		trimmedLine = strings.TrimSpace(l)
+
+		if len(trimmedLine) > 0 {
+			trimmedLines = append(trimmedLines, trimmedLine)
+		}
+	}
+
+	return strings.Join(trimmedLines, "\n")
+}

--- a/vendor/k8s.io/kube-state-metrics/internal/collector/utils.go
+++ b/vendor/k8s.io/kube-state-metrics/internal/collector/utils.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	v1 "k8s.io/api/core/v1"
+
+	"k8s.io/kube-state-metrics/pkg/metric"
+)
+
+var (
+	resyncPeriod       = 5 * time.Minute
+	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+	conditionStatuses  = []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionUnknown}
+)
+
+func boolFloat64(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// addConditionMetrics generates one metric for each possible condition
+// status. For this function to work properly, the last label in the metric
+// description must be the condition.
+func addConditionMetrics(cs v1.ConditionStatus) []*metric.Metric {
+	ms := make([]*metric.Metric, len(conditionStatuses))
+
+	for i, status := range conditionStatuses {
+		ms[i] = &metric.Metric{
+			LabelValues: []string{strings.ToLower(string(status))},
+			Value:       boolFloat64(cs == status),
+		}
+	}
+
+	return ms
+}
+
+func kubeLabelsToPrometheusLabels(labels map[string]string) ([]string, []string) {
+	labelKeys := make([]string, len(labels))
+	labelValues := make([]string, len(labels))
+	i := 0
+	for k, v := range labels {
+		labelKeys[i] = "label_" + sanitizeLabelName(k)
+		labelValues[i] = v
+		i++
+	}
+	return labelKeys, labelValues
+}
+
+func kubeAnnotationsToPrometheusAnnotations(annotations map[string]string) ([]string, []string) {
+	annotationKeys := make([]string, len(annotations))
+	annotationValues := make([]string, len(annotations))
+	i := 0
+	for k, v := range annotations {
+		annotationKeys[i] = "annotation_" + sanitizeLabelName(k)
+		annotationValues[i] = v
+		i++
+	}
+	return annotationKeys, annotationValues
+}
+
+func sanitizeLabelName(s string) string {
+	return invalidLabelCharRE.ReplaceAllString(s, "_")
+}
+
+func isHugePageResourceName(name v1.ResourceName) bool {
+	return strings.HasPrefix(string(name), v1.ResourceHugePagesPrefix)
+}
+
+func isAttachableVolumeResourceName(name v1.ResourceName) bool {
+	return strings.HasPrefix(string(name), v1.ResourceAttachableVolumesPrefix)
+}
+
+func isExtendedResourceName(name v1.ResourceName) bool {
+	if isNativeResource(name) || strings.HasPrefix(string(name), v1.DefaultResourceRequestsPrefix) {
+		return false
+	}
+	// Ensure it satisfies the rules in IsQualifiedName() after converted into quota resource name
+	nameForQuota := fmt.Sprintf("%s%s", v1.DefaultResourceRequestsPrefix, string(name))
+	if errs := validation.IsQualifiedName(string(nameForQuota)); len(errs) != 0 {
+		return false
+	}
+	return true
+}
+
+func isNativeResource(name v1.ResourceName) bool {
+	return !strings.Contains(string(name), "/") ||
+		isPrefixedNativeResource(name)
+}
+
+func isPrefixedNativeResource(name v1.ResourceName) bool {
+	return strings.Contains(string(name), v1.ResourceDefaultNamespacePrefix)
+}

--- a/vendor/k8s.io/kube-state-metrics/main.go
+++ b/vendor/k8s.io/kube-state-metrics/main.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/openshift/origin/pkg/util/proc"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	clientset "k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+	kcoll "k8s.io/kube-state-metrics/internal/collector"
+	coll "k8s.io/kube-state-metrics/pkg/collector"
+	"k8s.io/kube-state-metrics/pkg/options"
+	"k8s.io/kube-state-metrics/pkg/version"
+	"k8s.io/kube-state-metrics/pkg/whiteblacklist"
+)
+
+const (
+	metricsPath = "/metrics"
+	healthzPath = "/healthz"
+)
+
+// promLogger implements promhttp.Logger
+type promLogger struct{}
+
+func (pl promLogger) Println(v ...interface{}) {
+	klog.Error(v...)
+}
+
+func main() {
+	opts := options.NewOptions()
+	opts.AddFlags()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := opts.Parse()
+	if err != nil {
+		klog.Fatalf("Error: %s", err)
+	}
+
+	if opts.Version {
+		fmt.Printf("%#v\n", version.GetVersion())
+		os.Exit(0)
+	}
+
+	if opts.Help {
+		opts.Usage()
+		os.Exit(0)
+	}
+
+	collectorBuilder := kcoll.NewBuilder(ctx)
+
+	if len(opts.Collectors) == 0 {
+		klog.Info("Using default collectors")
+		collectorBuilder.WithEnabledCollectors(options.DefaultCollectors.AsSlice())
+	} else {
+		klog.Infof("Using collectors %s", opts.Collectors.String())
+		collectorBuilder.WithEnabledCollectors(opts.Collectors.AsSlice())
+	}
+
+	if len(opts.Namespaces) == 0 {
+		klog.Info("Using all namespace")
+		collectorBuilder.WithNamespaces(options.DefaultNamespaces)
+	} else {
+		if opts.Namespaces.IsAllNamespaces() {
+			klog.Info("Using all namespace")
+		} else {
+			klog.Infof("Using %s namespaces", opts.Namespaces)
+		}
+		collectorBuilder.WithNamespaces(opts.Namespaces)
+	}
+
+	whiteBlackList, err := whiteblacklist.New(opts.MetricWhitelist, opts.MetricBlacklist)
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	if opts.DisablePodNonGenericResourceMetrics {
+		whiteBlackList.Exclude([]string{
+			"kube_pod_container_resource_requests_cpu_cores",
+			"kube_pod_container_resource_requests_memory_bytes",
+			"kube_pod_container_resource_limits_cpu_cores",
+			"kube_pod_container_resource_limits_memory_bytes",
+		})
+	}
+
+	if opts.DisableNodeNonGenericResourceMetrics {
+		whiteBlackList.Exclude([]string{
+			"kube_node_status_capacity_cpu_cores",
+			"kube_node_status_capacity_memory_bytes",
+			"kube_node_status_capacity_pods",
+			"kube_node_status_allocatable_cpu_cores",
+			"kube_node_status_allocatable_memory_bytes",
+			"kube_node_status_allocatable_pods",
+		})
+	}
+
+	klog.Infof("metric white-blacklisting: %v", whiteBlackList.Status())
+
+	collectorBuilder.WithWhiteBlackList(whiteBlackList)
+
+	proc.StartReaper()
+
+	kubeClient, err := createKubeClient(opts.Apiserver, opts.Kubeconfig)
+	if err != nil {
+		klog.Fatalf("Failed to create client: %v", err)
+	}
+	collectorBuilder.WithKubeClient(kubeClient)
+
+	ksmMetricsRegistry := prometheus.NewRegistry()
+	ksmMetricsRegistry.Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+	ksmMetricsRegistry.Register(prometheus.NewGoCollector())
+	go telemetryServer(ksmMetricsRegistry, opts.TelemetryHost, opts.TelemetryPort)
+
+	collectors := collectorBuilder.Build()
+
+	serveMetrics(collectors, opts.Host, opts.Port, opts.EnableGZIPEncoding)
+}
+
+func createKubeClient(apiserver string, kubeconfig string) (clientset.Interface, error) {
+	config, err := clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	config.UserAgent = version.GetVersion().String()
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
+
+	kubeClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Informers don't seem to do a good job logging error messages when it
+	// can't reach the server, making debugging hard. This makes it easier to
+	// figure out if apiserver is configured incorrectly.
+	klog.Infof("Testing communication with server")
+	v, err := kubeClient.Discovery().ServerVersion()
+	if err != nil {
+		return nil, errors.Wrap(err, "ERROR communicating with apiserver")
+	}
+	klog.Infof("Running with Kubernetes cluster version: v%s.%s. git version: %s. git tree state: %s. commit: %s. platform: %s",
+		v.Major, v.Minor, v.GitVersion, v.GitTreeState, v.GitCommit, v.Platform)
+	klog.Infof("Communication with server successful")
+
+	return kubeClient, nil
+}
+
+func telemetryServer(registry prometheus.Gatherer, host string, port int) {
+	// Address to listen on for web interface and telemetry
+	listenAddress := net.JoinHostPort(host, strconv.Itoa(port))
+
+	klog.Infof("Starting kube-state-metrics self metrics server: %s", listenAddress)
+
+	mux := http.NewServeMux()
+
+	// Add metricsPath
+	mux.Handle(metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorLog: promLogger{}}))
+	// Add index
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+             <head><title>Kube-State-Metrics Metrics Server</title></head>
+             <body>
+             <h1>Kube-State-Metrics Metrics</h1>
+			 <ul>
+             <li><a href='` + metricsPath + `'>metrics</a></li>
+			 </ul>
+             </body>
+             </html>`))
+	})
+	log.Fatal(http.ListenAndServe(listenAddress, mux))
+}
+
+// TODO: How about accepting an interface Collector instead?
+func serveMetrics(collectors []*coll.Collector, host string, port int, enableGZIPEncoding bool) {
+	// Address to listen on for web interface and telemetry
+	listenAddress := net.JoinHostPort(host, strconv.Itoa(port))
+
+	klog.Infof("Starting metrics server: %s", listenAddress)
+
+	mux := http.NewServeMux()
+
+	// TODO: This doesn't belong into serveMetrics
+	mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+	mux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+	mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+	mux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+
+	// Add metricsPath
+	mux.Handle(metricsPath, &metricHandler{collectors, enableGZIPEncoding})
+	// Add healthzPath
+	mux.HandleFunc(healthzPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	})
+	// Add index
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+             <head><title>Kube Metrics Server</title></head>
+             <body>
+             <h1>Kube Metrics</h1>
+			 <ul>
+             <li><a href='` + metricsPath + `'>metrics</a></li>
+             <li><a href='` + healthzPath + `'>healthz</a></li>
+			 </ul>
+             </body>
+             </html>`))
+	})
+	log.Fatal(http.ListenAndServe(listenAddress, mux))
+}
+
+type metricHandler struct {
+	collectors         []*coll.Collector
+	enableGZIPEncoding bool
+}
+
+func (m *metricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	resHeader := w.Header()
+	var writer io.Writer = w
+
+	resHeader.Set("Content-Type", `text/plain; version=`+"0.0.4")
+
+	if m.enableGZIPEncoding {
+		// Gzip response if requested. Taken from
+		// github.com/prometheus/client_golang/prometheus/promhttp.decorateWriter.
+		reqHeader := r.Header.Get("Accept-Encoding")
+		parts := strings.Split(reqHeader, ",")
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part == "gzip" || strings.HasPrefix(part, "gzip;") {
+				writer = gzip.NewWriter(writer)
+				resHeader.Set("Content-Encoding", "gzip")
+			}
+		}
+	}
+
+	for _, c := range m.collectors {
+		c.Collect(w)
+	}
+
+	// In case we gzipped the response, we have to close the writer.
+	if closer, ok := writer.(io.Closer); ok {
+		closer.Close()
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/collector/collector.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/collector/collector.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"io"
+)
+
+// Store represents a metrics store e.g.
+// k8s.io/kube-state-metrics/pkg/metrics_store.
+type Store interface {
+	WriteAll(io.Writer)
+}
+
+// Collector represents a kube-state-metrics metric collector. It is a stripped
+// down version of the Prometheus client_golang collector.
+type Collector struct {
+	Store Store
+}
+
+// NewCollector constructs a collector with the given Store.
+func NewCollector(s Store) *Collector {
+	return &Collector{s}
+}
+
+// Collect returns all metrics of the underlying store of the collector.
+func (c *Collector) Collect(w io.Writer) {
+	c.Store.WriteAll(w)
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/constant/resource_unit.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/constant/resource_unit.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constant
+
+// ResourceUnit represents the unit of measure for certain metrics.
+type ResourceUnit string
+
+const (
+	// UnitByte is the unit of measure in bytes.
+	UnitByte ResourceUnit = "byte"
+	// UnitCore is the unit of measure in CPU cores.
+	UnitCore ResourceUnit = "core"
+	// UnitInteger is the unit of measure in integers.
+	UnitInteger ResourceUnit = "integer"
+)

--- a/vendor/k8s.io/kube-state-metrics/pkg/metric/family.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/metric/family.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"strings"
+)
+
+// Family represents a set of metrics with the same name and help text.
+type Family struct {
+	Name    string
+	Metrics []*Metric
+}
+
+// ByteSlice returns the given Family in its string representation.
+func (f Family) ByteSlice() []byte {
+	b := strings.Builder{}
+	for _, m := range f.Metrics {
+		b.WriteString(f.Name)
+		m.Write(&b)
+	}
+
+	return []byte(b.String())
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/metric/generator.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/metric/generator.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"strings"
+
+	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
+)
+
+// FamilyGenerator provides everything needed to generate a metric family with a
+// Kubernetes object.
+type FamilyGenerator struct {
+	Name         string
+	Help         string
+	Type         Type
+	GenerateFunc func(obj interface{}) *Family
+}
+
+// Generate calls the FamilyGenerator.GenerateFunc and gives the family its
+// name. The reasoning behind injecting the name at such a late point in time is
+// deduplication in the code, preventing typos made by developers as
+// well as saving memory.
+func (g *FamilyGenerator) Generate(obj interface{}) *Family {
+	family := g.GenerateFunc(obj)
+	family.Name = g.Name
+	return family
+}
+
+func (g *FamilyGenerator) generateHeader() string {
+	header := strings.Builder{}
+	header.WriteString("# HELP ")
+	header.WriteString(g.Name)
+	header.WriteByte(' ')
+	header.WriteString(g.Help)
+	header.WriteByte('\n')
+	header.WriteString("# TYPE ")
+	header.WriteString(g.Name)
+	header.WriteByte(' ')
+	header.WriteString(string(g.Type))
+
+	return header.String()
+}
+
+// ExtractMetricFamilyHeaders takes in a slice of FamilyGenerator metrics and
+// returns the extracted headers.
+func ExtractMetricFamilyHeaders(families []FamilyGenerator) []string {
+	headers := make([]string, len(families))
+
+	for i, f := range families {
+		headers[i] = f.generateHeader()
+	}
+
+	return headers
+}
+
+// ComposeMetricGenFuncs takes a slice of metric families and returns a function
+// that composes their metric generation functions into a single one.
+func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) []metricsstore.FamilyByteSlicer {
+	return func(obj interface{}) []metricsstore.FamilyByteSlicer {
+		families := make([]metricsstore.FamilyByteSlicer, len(familyGens))
+
+		for i, gen := range familyGens {
+			families[i] = gen.Generate(obj)
+		}
+
+		return families
+	}
+}
+
+type whiteBlackLister interface {
+	IsIncluded(string) bool
+	IsExcluded(string) bool
+}
+
+// FilterMetricFamilies takes a white- and a blacklist and a slice of metric
+// families and returns a filtered slice.
+func FilterMetricFamilies(l whiteBlackLister, families []FamilyGenerator) []FamilyGenerator {
+	filtered := []FamilyGenerator{}
+
+	for _, f := range families {
+		if l.IsIncluded(f.Name) {
+			filtered = append(filtered, f)
+		}
+	}
+
+	return filtered
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/metric/metric.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/metric/metric.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	initialNumBufSize = 24
+)
+
+var (
+	numBufPool = sync.Pool{
+		New: func() interface{} {
+			b := make([]byte, 0, initialNumBufSize)
+			return &b
+		},
+	}
+)
+
+// Type represents the type of a metric e.g. a counter. See
+// https://prometheus.io/docs/concepts/metric_types/.
+type Type string
+
+// Gauge defines a Prometheus gauge.
+var Gauge Type = "gauge"
+
+// Counter defines a Prometheus counter.
+var Counter Type = "counter"
+
+// Metric represents a single time series.
+type Metric struct {
+	// The name of a metric is injected by its family to reduce duplication.
+	LabelKeys   []string
+	LabelValues []string
+	Value       float64
+}
+
+func (m *Metric) Write(s *strings.Builder) {
+	if len(m.LabelKeys) != len(m.LabelValues) {
+		panic(fmt.Sprintf(
+			"expected labelKeys %q to be of same length as labelValues %q",
+			m.LabelKeys, m.LabelValues,
+		))
+	}
+
+	labelsToString(s, m.LabelKeys, m.LabelValues)
+	s.WriteByte(' ')
+	writeFloat(s, m.Value)
+	s.WriteByte('\n')
+}
+
+func labelsToString(m *strings.Builder, keys, values []string) {
+	if len(keys) > 0 {
+		var separator byte = '{'
+
+		for i := 0; i < len(keys); i++ {
+			m.WriteByte(separator)
+			m.WriteString(keys[i])
+			m.WriteString("=\"")
+			escapeString(m, values[i])
+			m.WriteByte('"')
+			separator = ','
+		}
+
+		m.WriteByte('}')
+	}
+}
+
+var (
+	escapeWithDoubleQuote = strings.NewReplacer("\\", `\\`, "\n", `\n`, "\"", `\"`)
+)
+
+// escapeString replaces '\' by '\\', new line character by '\n', and '"' by
+// '\"'.
+// Taken from github.com/prometheus/common/expfmt/text_create.go.
+func escapeString(m *strings.Builder, v string) {
+	escapeWithDoubleQuote.WriteString(m, v)
+}
+
+// writeFloat is equivalent to fmt.Fprint with a float64 argument but hardcodes
+// a few common cases for increased efficiency. For non-hardcoded cases, it uses
+// strconv.AppendFloat to avoid allocations, similar to writeInt.
+// Taken from github.com/prometheus/common/expfmt/text_create.go.
+func writeFloat(w *strings.Builder, f float64) {
+	switch {
+	case f == 1:
+		w.WriteByte('1')
+	case f == 0:
+		w.WriteByte('0')
+	case f == -1:
+		w.WriteString("-1")
+	case math.IsNaN(f):
+		w.WriteString("NaN")
+	case math.IsInf(f, +1):
+		w.WriteString("+Inf")
+	case math.IsInf(f, -1):
+		w.WriteString("-Inf")
+	default:
+		bp := numBufPool.Get().(*[]byte)
+		*bp = strconv.AppendFloat((*bp)[:0], f, 'g', -1, 64)
+		w.Write(*bp)
+		numBufPool.Put(bp)
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/metrics_store/metrics_store.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/metrics_store/metrics_store.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsstore
+
+import (
+	"io"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// FamilyByteSlicer represents a metric family that can be converted to its string
+// representation.
+type FamilyByteSlicer interface {
+	ByteSlice() []byte
+}
+
+// MetricsStore implements the k8s.io/client-go/tools/cache.Store
+// interface. Instead of storing entire Kubernetes objects, it stores metrics
+// generated based on those objects.
+type MetricsStore struct {
+	// Protects metrics
+	mutex sync.RWMutex
+	// metrics is a map indexed by Kubernetes object id, containing a slice of
+	// metric families, containing a slice of metrics. We need to keep metrics
+	// grouped by metric families in order to zip families with their help text in
+	// MetricsStore.WriteAll().
+	metrics map[types.UID][][]byte
+	// headers contains the header (TYPE and HELP) of each metric family. It is
+	// later on zipped with with their corresponding metric families in
+	// MetricStore.WriteAll().
+	headers []string
+
+	// generateMetricsFunc generates metrics based on a given Kubernetes object
+	// and returns them grouped by metric family.
+	generateMetricsFunc func(interface{}) []FamilyByteSlicer
+}
+
+// NewMetricsStore returns a new MetricsStore
+func NewMetricsStore(headers []string, generateFunc func(interface{}) []FamilyByteSlicer) *MetricsStore {
+	return &MetricsStore{
+		generateMetricsFunc: generateFunc,
+		headers:             headers,
+		metrics:             map[types.UID][][]byte{},
+	}
+}
+
+// Implementing k8s.io/client-go/tools/cache.Store interface
+
+// Add inserts adds to the MetricsStore by calling the metrics generator functions and
+// adding the generated metrics to the metrics map that underlies the MetricStore.
+func (s *MetricsStore) Add(obj interface{}) error {
+	o, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	families := s.generateMetricsFunc(obj)
+	familyStrings := make([][]byte, len(families))
+
+	for i, f := range families {
+		familyStrings[i] = f.ByteSlice()
+	}
+
+	s.metrics[o.GetUID()] = familyStrings
+
+	return nil
+}
+
+// Update updates the existing entry in the MetricsStore.
+func (s *MetricsStore) Update(obj interface{}) error {
+	// TODO: For now, just call Add, in the future one could check if the resource version changed?
+	return s.Add(obj)
+}
+
+// Delete deletes an existing entry in the MetricsStore.
+func (s *MetricsStore) Delete(obj interface{}) error {
+
+	o, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	delete(s.metrics, o.GetUID())
+
+	return nil
+}
+
+// List implements the List method of the store interface.
+func (s *MetricsStore) List() []interface{} {
+	return nil
+}
+
+// ListKeys implements the ListKeys method of the store interface.
+func (s *MetricsStore) ListKeys() []string {
+	return nil
+}
+
+// Get implements the Get method of the store interface.
+func (s *MetricsStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	return nil, false, nil
+}
+
+// GetByKey implements the GetByKey method of the store interface.
+func (s *MetricsStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+	return nil, false, nil
+}
+
+// Replace will delete the contents of the store, using instead the
+// given list.
+func (s *MetricsStore) Replace(list []interface{}, _ string) error {
+	s.mutex.Lock()
+	s.metrics = map[types.UID][][]byte{}
+	s.mutex.Unlock()
+
+	for _, o := range list {
+		err := s.Add(o)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Resync implements the Resync method of the store interface.
+func (s *MetricsStore) Resync() error {
+	return nil
+}
+
+// WriteAll writes all metrics of the store into the given writer, zipped with the
+// help text of each metric family.
+func (s *MetricsStore) WriteAll(w io.Writer) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	for i, help := range s.headers {
+		w.Write([]byte(help))
+		w.Write([]byte{'\n'})
+		for _, metricFamilies := range s.metrics {
+			w.Write([]byte(metricFamilies[i]))
+		}
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/options/collector.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/options/collector.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	// DefaultNamespaces is the default namespace selector for selecting and filtering across all namespaces.
+	DefaultNamespaces = NamespaceList{metav1.NamespaceAll}
+
+	// DefaultCollectors represents the default set of collectors in kube-state-metrics.
+	DefaultCollectors = CollectorSet{
+		"certificatesigningrequests": struct{}{},
+		"configmaps":                 struct{}{},
+		"cronjobs":                   struct{}{},
+		"daemonsets":                 struct{}{},
+		"deployments":                struct{}{},
+		"endpoints":                  struct{}{},
+		"horizontalpodautoscalers":   struct{}{},
+		"ingresses":                  struct{}{},
+		"jobs":                       struct{}{},
+		"limitranges":                struct{}{},
+		"namespaces":                 struct{}{},
+		"nodes":                      struct{}{},
+		"persistentvolumes":          struct{}{},
+		"persistentvolumeclaims":     struct{}{},
+		"poddisruptionbudgets":       struct{}{},
+		"pods":                       struct{}{},
+		"replicasets":                struct{}{},
+		"replicationcontrollers":     struct{}{},
+		"resourcequotas":             struct{}{},
+		"secrets":                    struct{}{},
+		"services":                   struct{}{},
+		"statefulsets":               struct{}{},
+	}
+)

--- a/vendor/k8s.io/kube-state-metrics/pkg/options/options.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/options/options.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"k8s.io/klog"
+
+	"github.com/spf13/pflag"
+)
+
+// Options are the configurable parameters for kube-state-metrics.
+type Options struct {
+	Apiserver                            string
+	Kubeconfig                           string
+	Help                                 bool
+	Port                                 int
+	Host                                 string
+	TelemetryPort                        int
+	TelemetryHost                        string
+	Collectors                           CollectorSet
+	Namespaces                           NamespaceList
+	MetricBlacklist                      MetricSet
+	MetricWhitelist                      MetricSet
+	Version                              bool
+	DisablePodNonGenericResourceMetrics  bool
+	DisableNodeNonGenericResourceMetrics bool
+
+	EnableGZIPEncoding bool
+
+	flags *pflag.FlagSet
+}
+
+// NewOptions returns a new instance of `Options`.
+func NewOptions() *Options {
+	return &Options{
+		Collectors:      CollectorSet{},
+		MetricWhitelist: MetricSet{},
+		MetricBlacklist: MetricSet{},
+	}
+}
+
+// AddFlags populated the Options struct from the command line arguments passed.
+func (o *Options) AddFlags() {
+	o.flags = pflag.NewFlagSet("", pflag.ExitOnError)
+	// add klog flags
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	o.flags.AddGoFlagSet(klogFlags)
+	o.flags.Lookup("logtostderr").Value.Set("true")
+	o.flags.Lookup("logtostderr").DefValue = "true"
+	o.flags.Lookup("logtostderr").NoOptDefVal = "true"
+
+	o.flags.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		o.flags.PrintDefaults()
+	}
+
+	o.flags.StringVar(&o.Apiserver, "apiserver", "", `The URL of the apiserver to use as a master`)
+	o.flags.StringVar(&o.Kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file")
+	o.flags.BoolVarP(&o.Help, "help", "h", false, "Print Help text")
+	o.flags.IntVar(&o.Port, "port", 80, `Port to expose metrics on.`)
+	o.flags.StringVar(&o.Host, "host", "0.0.0.0", `Host to expose metrics on.`)
+	o.flags.IntVar(&o.TelemetryPort, "telemetry-port", 81, `Port to expose kube-state-metrics self metrics on.`)
+	o.flags.StringVar(&o.TelemetryHost, "telemetry-host", "0.0.0.0", `Host to expose kube-state-metrics self metrics on.`)
+	o.flags.Var(&o.Collectors, "collectors", fmt.Sprintf("Comma-separated list of collectors to be enabled. Defaults to %q", &DefaultCollectors))
+	o.flags.Var(&o.Namespaces, "namespace", fmt.Sprintf("Comma-separated list of namespaces to be enabled. Defaults to %q", &DefaultNamespaces))
+	o.flags.Var(&o.MetricWhitelist, "metric-whitelist", "Comma-separated list of metrics to be exposed. The whitelist and blacklist are mutually exclusive.")
+	o.flags.Var(&o.MetricBlacklist, "metric-blacklist", "Comma-separated list of metrics not to be enabled. The whitelist and blacklist are mutually exclusive.")
+	o.flags.BoolVarP(&o.Version, "version", "", false, "kube-state-metrics build version information")
+	o.flags.BoolVarP(&o.DisablePodNonGenericResourceMetrics, "disable-pod-non-generic-resource-metrics", "", false, "Disable pod non generic resource request and limit metrics")
+	o.flags.BoolVarP(&o.DisableNodeNonGenericResourceMetrics, "disable-node-non-generic-resource-metrics", "", false, "Disable node non generic resource request and limit metrics")
+	o.flags.BoolVar(&o.EnableGZIPEncoding, "enable-gzip-encoding", false, "Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.")
+}
+
+// Parse parses the flag definitions from the argument list.
+func (o *Options) Parse() error {
+	err := o.flags.Parse(os.Args)
+	return err
+}
+
+// Usage is the function called when an error occurs while parsing flags.
+func (o *Options) Usage() {
+	o.flags.Usage()
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/options/types.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/options/types.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MetricSet represents a collection which has a unique set of metrics.
+type MetricSet map[string]struct{}
+
+func (ms *MetricSet) String() string {
+	s := *ms
+	ss := s.asSlice()
+	sort.Strings(ss)
+	return strings.Join(ss, ",")
+}
+
+// Set converts a comma-separated string of metrics into a slice and appends it to the MetricSet.
+func (ms *MetricSet) Set(value string) error {
+	s := *ms
+	metrics := strings.Split(value, ",")
+	for _, metric := range metrics {
+		metric = strings.TrimSpace(metric)
+		if len(metric) != 0 {
+			s[metric] = struct{}{}
+		}
+	}
+	return nil
+}
+
+// asSlice returns the MetricSet in the form of plain string slice.
+func (ms MetricSet) asSlice() []string {
+	metrics := []string{}
+	for metric := range ms {
+		metrics = append(metrics, metric)
+	}
+	return metrics
+}
+
+// IsEmpty returns true if the length of the MetricSet is zero.
+func (ms MetricSet) IsEmpty() bool {
+	return len(ms.asSlice()) == 0
+}
+
+// Type returns a descriptive string about the MetricSet type.
+func (ms *MetricSet) Type() string {
+	return "string"
+}
+
+// CollectorSet represents a collection which has a unique set of collectors.
+type CollectorSet map[string]struct{}
+
+func (c *CollectorSet) String() string {
+	s := *c
+	ss := s.AsSlice()
+	sort.Strings(ss)
+	return strings.Join(ss, ",")
+}
+
+// Set converts a comma-separated string of collectors into a slice and appends it to the CollectorSet.
+func (c *CollectorSet) Set(value string) error {
+	s := *c
+	cols := strings.Split(value, ",")
+	for _, col := range cols {
+		col = strings.TrimSpace(col)
+		if len(col) != 0 {
+			_, ok := DefaultCollectors[col]
+			if !ok {
+				return errors.Errorf("collector \"%s\" does not exist", col)
+			}
+			s[col] = struct{}{}
+		}
+	}
+	return nil
+}
+
+// AsSlice returns the Collector in the form of a plain string slice.
+func (c CollectorSet) AsSlice() []string {
+	cols := []string{}
+	for col := range c {
+		cols = append(cols, col)
+	}
+	return cols
+}
+
+// isEmpty() returns true if the length of the CollectorSet is zero.
+func (c CollectorSet) isEmpty() bool {
+	return len(c.AsSlice()) == 0
+}
+
+// Type returns a descriptive string about the CollectorSet type.
+func (c *CollectorSet) Type() string {
+	return "string"
+}
+
+// NamespaceList represents a list of namespaces to query forom.
+type NamespaceList []string
+
+func (n *NamespaceList) String() string {
+	return strings.Join(*n, ",")
+}
+
+// IsAllNamespaces checks if the Namespace selector is that of `NamespaceAll` which is used for
+// selecting or filtering across all namespaces.
+func (n *NamespaceList) IsAllNamespaces() bool {
+	return len(*n) == 1 && (*n)[0] == metav1.NamespaceAll
+}
+
+// Set converts a comma-separated string of namespaces into a slice and appends it to the NamespaceList
+func (n *NamespaceList) Set(value string) error {
+	splitNamespaces := strings.Split(value, ",")
+	for _, ns := range splitNamespaces {
+		ns = strings.TrimSpace(ns)
+		if len(ns) != 0 {
+			*n = append(*n, ns)
+		}
+	}
+	return nil
+}
+
+// Type returns a descriptive string about the NamespaceList type.
+func (n *NamespaceList) Type() string {
+	return "string"
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/version/version.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/version/version.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+var (
+	// Release returns the release version
+	Release = "UNKNOWN"
+	// Commit returns the short sha from git
+	Commit = "UNKNOWN"
+	// BuildDate is the build date
+	BuildDate = ""
+)
+
+// Version is the current version of kube-state-metrics.
+// Update this whenever making a new release.
+// The version is of the format Major.Minor.Patch
+//
+// Increment major number for new feature additions and behavioral changes.
+// Increment minor number for bug fixes and performance enhancements.
+// Increment patch number for critical fixes to existing releases.
+type Version struct {
+	GitCommit string
+	BuildDate string
+	Release   string
+	GoVersion string
+	Compiler  string
+	Platform  string
+}
+
+func (v Version) String() string {
+	return fmt.Sprintf("%s/%s (%s/%s) kube-state-metrics/%s",
+		filepath.Base(os.Args[0]), v.Release,
+		runtime.GOOS, runtime.GOARCH, v.GitCommit)
+}
+
+// GetVersion returns the kube-state-metrics version.
+func GetVersion() Version {
+	return Version{
+		GitCommit: Commit,
+		BuildDate: BuildDate,
+		Release:   Release,
+		GoVersion: runtime.Version(),
+		Compiler:  runtime.Compiler,
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/whiteblacklist/whiteblacklist.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/whiteblacklist/whiteblacklist.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package whiteblacklist
+
+import (
+	"errors"
+	"strings"
+)
+
+// WhiteBlackList encapsulates the logic needed to filter based on a string.
+type WhiteBlackList struct {
+	list        map[string]struct{}
+	isWhiteList bool
+}
+
+// New constructs a new WhiteBlackList based on a white- and a
+// blacklist. Only one of them can be not empty.
+func New(w, b map[string]struct{}) (*WhiteBlackList, error) {
+	if len(w) != 0 && len(b) != 0 {
+		return nil, errors.New(
+			"whitelist and blacklist are both set, they are mutually exclusive, only one of them can be set",
+		)
+	}
+
+	white := copyList(w)
+	black := copyList(b)
+
+	var list map[string]struct{}
+	var isWhiteList bool
+
+	// Default to blacklisting
+	if len(white) != 0 {
+		list = white
+		isWhiteList = true
+	} else {
+		list = black
+		isWhiteList = false
+	}
+
+	return &WhiteBlackList{
+		list:        list,
+		isWhiteList: isWhiteList,
+	}, nil
+}
+
+// Include includes the given items in the list.
+func (l *WhiteBlackList) Include(items []string) {
+	if l.isWhiteList {
+		for _, item := range items {
+			l.list[item] = struct{}{}
+		}
+	} else {
+		for _, item := range items {
+			delete(l.list, item)
+		}
+	}
+}
+
+// Exclude excludes the given items from the list.
+func (l *WhiteBlackList) Exclude(items []string) {
+	if l.isWhiteList {
+		for _, item := range items {
+			delete(l.list, item)
+		}
+	} else {
+		for _, item := range items {
+			l.list[item] = struct{}{}
+		}
+	}
+}
+
+// IsIncluded returns if the given item is included.
+func (l *WhiteBlackList) IsIncluded(item string) bool {
+	_, exists := l.list[item]
+
+	if l.isWhiteList {
+		return exists
+	}
+
+	return !exists
+}
+
+// IsExcluded returns if the given item is excluded.
+func (l *WhiteBlackList) IsExcluded(item string) bool {
+	return !l.IsIncluded(item)
+}
+
+// Status returns the status of the WhiteBlackList that can e.g. be passed into
+// a logger.
+func (l *WhiteBlackList) Status() string {
+	items := []string{}
+	for key := range l.list {
+		items = append(items, key)
+	}
+
+	if l.isWhiteList {
+		return "whitelisting the following items: " + strings.Join(items, ", ")
+	}
+
+	return "blacklisting the following items: " + strings.Join(items, ", ")
+}
+
+func copyList(l map[string]struct{}) map[string]struct{} {
+	newList := map[string]struct{}{}
+	for k, v := range l {
+		newList[k] = v
+	}
+	return newList
+}

--- a/vendor/k8s.io/kube-state-metrics/tests/lib/doc.go
+++ b/vendor/k8s.io/kube-state-metrics/tests/lib/doc.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package lib enables other projects to reuse the performance optimized metric
+exposition logic. While this package ensures this use-case is possible, it does
+not give any stability guarantees for the interface.
+*/
+package lib


### PR DESCRIPTION
With this change, the operator will create a metrics Service and prometheus
ServiceMonitor (when servicemonitor CRD is defined in the cluster), and
expose metrics of the CRDs and the operator itself.
Also updates the OLM operator capability to `Deep Insights`.

Refer:
- Usage docs - docs/operator-prometheus-metrics/README.md
- [Operator SDK metrics](https://github.com/operator-framework/operator-sdk/blob/master/doc/user/metrics/README.md)