### PR TITLE
dockerfile: create home dir in rhel build

### DIFF
--- a/build/rhel-build-service/Dockerfile
+++ b/build/rhel-build-service/Dockerfile
@@ -31,6 +31,7 @@ LABEL name="StorageOS Cluster Operator" \
 
 # Create a working directory that's writable by non-root users. This is needed
 # for writing the certificate generation.
+RUN mkdir -p /home/operator
 WORKDIR /home/operator
 RUN chmod -R g+rwX /home/operator
 


### PR DESCRIPTION
RHEL build service fails when using WORKDIR without creating the directory first.
 
```
--> WORKDIR /home/operator
--> RUN chmod -R g+rwX /home/operator
/bin/sh: line 0: cd: /home/operator: No such file or directory
error: build error: running 'chmod -R g+rwX /home/operator' failed with exit code 1
```