### PR TITLE
Add k8s recommended labels to all the resources

### DIFF
--- a/internal/pkg/admission/scheduler/handler.go
+++ b/internal/pkg/admission/scheduler/handler.go
@@ -12,6 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	"github.com/storageos/cluster-operator/internal/pkg/storageoscluster"
 )
 
 // PodSchedulerSetter is responsible for mutating and setting pod scheduler
@@ -81,7 +83,7 @@ func (p *PodSchedulerSetter) mutatePodsFn(ctx context.Context, pod *corev1.Pod, 
 	// Set scheduler name only if there are managed volumes.
 	if len(managedVols) > 0 {
 		// Check if StorageOS scheduler is enabled before setting the scheduler.
-		cluster, err := p.getCurrentStorageOSCluster()
+		cluster, err := storageoscluster.GetCurrentStorageOSCluster(p.client)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/admission/scheduler/helper.go
+++ b/internal/pkg/admission/scheduler/helper.go
@@ -2,18 +2,12 @@ package scheduler
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// ErrNoCluster is the error when there's no running StorageOS cluster found.
-var ErrNoCluster = errors.New("no storageos cluster found")
 
 // pvcStorageClassKey is the annotation used to refer to the StorageClass when
 // the PVC storageClassName wasn't used.  This is now deprecated but should
@@ -67,37 +61,4 @@ func (p *PodSchedulerSetter) IsManagedVolume(volume corev1.Volume, namespace str
 	}
 
 	return false, nil
-}
-
-// getCurrentStorageOSCluster returns the currently running StorageOS cluster.
-// TODO: Move this to a separate package as a helper function.
-func (p *PodSchedulerSetter) getCurrentStorageOSCluster() (*storageosv1.StorageOSCluster, error) {
-	var currentCluster *storageosv1.StorageOSCluster
-
-	// Get a list of all the StorageOS clusters.
-	clusterList := &storageosv1.StorageOSClusterList{}
-	if err := p.client.List(context.Background(), &client.ListOptions{}, clusterList); err != nil {
-		return nil, fmt.Errorf("failed to list storageos clusters: %v", err)
-	}
-
-	// If there's only one cluster, return it as the current cluster.
-	if len(clusterList.Items) == 1 {
-		currentCluster = &clusterList.Items[0]
-	}
-
-	// If there are multiple clusters, consider the status of the cluster.
-	for _, cluster := range clusterList.Items {
-		// Only one cluster can be in running phase at a time.
-		if cluster.Status.Phase == storageosv1.ClusterPhaseRunning {
-			currentCluster = &cluster
-			break
-		}
-	}
-
-	// If no current cluster found, fail.
-	if currentCluster != nil {
-		return currentCluster, nil
-	}
-
-	return currentCluster, ErrNoCluster
 }

--- a/internal/pkg/storageoscluster/cluster.go
+++ b/internal/pkg/storageoscluster/cluster.go
@@ -1,0 +1,45 @@
+package storageoscluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ErrNoCluster is the error when there's no running StorageOS cluster found.
+var ErrNoCluster = errors.New("no storageos cluster found")
+
+// GetCurrentStorageOSCluster returns the currently running StorageOS cluster.
+func GetCurrentStorageOSCluster(kclient client.Client) (*storageosv1.StorageOSCluster, error) {
+	var currentCluster *storageosv1.StorageOSCluster
+
+	// Get a list of all the StorageOS clusters.
+	clusterList := &storageosv1.StorageOSClusterList{}
+	if err := kclient.List(context.Background(), &client.ListOptions{}, clusterList); err != nil {
+		return nil, fmt.Errorf("failed to list storageos clusters: %v", err)
+	}
+
+	// If there's only one cluster, return it as the current cluster.
+	if len(clusterList.Items) == 1 {
+		currentCluster = &clusterList.Items[0]
+	}
+
+	// If there are multiple clusters, consider the status of the cluster.
+	for _, cluster := range clusterList.Items {
+		// Only one cluster can be in running phase at a time.
+		if cluster.Status.Phase == storageosv1.ClusterPhaseRunning {
+			currentCluster = &cluster
+			break
+		}
+	}
+
+	// If no current cluster found, fail.
+	if currentCluster != nil {
+		return currentCluster, nil
+	}
+
+	return currentCluster, ErrNoCluster
+}

--- a/internal/pkg/storageoscluster/cluster_test.go
+++ b/internal/pkg/storageoscluster/cluster_test.go
@@ -1,0 +1,110 @@
+package storageoscluster
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	storageosapis "github.com/storageos/cluster-operator/pkg/apis"
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+)
+
+// getTestCluster returns a StorageOSCluster object with the given properties.
+func getTestCluster(
+	name string, namespace string,
+	spec storageosv1.StorageOSClusterSpec,
+	status storageosv1.StorageOSClusterStatus) *storageosv1.StorageOSCluster {
+
+	return &storageosv1.StorageOSCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec:   spec,
+		Status: status,
+	}
+}
+
+func TestGetCurrentStorageOSCluster(t *testing.T) {
+	emptySpec := storageosv1.StorageOSClusterSpec{}
+	emptyStatus := storageosv1.StorageOSClusterStatus{}
+
+	// Create a new scheme and add the required schemes to it.
+	scheme := runtime.NewScheme()
+	kscheme.AddToScheme(scheme)
+	storageosapis.AddToScheme(scheme)
+
+	testcases := []struct {
+		name            string
+		clusters        []*storageosv1.StorageOSCluster
+		wantClusterName string
+		wantErr         error
+	}{
+		{
+			name: "multiple clusters with one ready",
+			clusters: []*storageosv1.StorageOSCluster{
+				getTestCluster("cluster1", "default", emptySpec, emptyStatus),
+				getTestCluster("cluster2", "foo", emptySpec,
+					storageosv1.StorageOSClusterStatus{
+						Phase: storageosv1.ClusterPhaseRunning,
+					}),
+				getTestCluster("cluster3", "default", emptySpec, emptyStatus),
+			},
+			wantClusterName: "cluster2",
+		},
+		{
+			name: "multiple clusters with none ready",
+			clusters: []*storageosv1.StorageOSCluster{
+				getTestCluster("cluster1", "default", emptySpec, emptyStatus),
+				getTestCluster("cluster2", "default", emptySpec,
+					storageosv1.StorageOSClusterStatus{
+						Phase: storageosv1.ClusterPhaseInitial,
+					}),
+				getTestCluster("cluster3", "default", emptySpec, emptyStatus),
+			},
+			wantErr: ErrNoCluster,
+		},
+		{
+			name: "single cluster not ready",
+			clusters: []*storageosv1.StorageOSCluster{
+				getTestCluster("cluster1", "default", emptySpec, emptyStatus),
+			},
+			wantClusterName: "cluster1",
+		},
+		{
+			name:    "no cluster",
+			wantErr: ErrNoCluster,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Create fake client.
+			client := fake.NewFakeClientWithScheme(scheme)
+
+			// Create the clusters.
+			for _, c := range tc.clusters {
+				if err := client.Create(context.TODO(), c); err != nil {
+					t.Fatalf("failed to create StorageOSCluster: %v", err)
+				}
+			}
+
+			cc, err := GetCurrentStorageOSCluster(client)
+			if err != nil {
+				if !reflect.DeepEqual(tc.wantErr, err) {
+					t.Fatalf("unexpected error while getting current cluster: %v", err)
+				}
+			} else {
+				if tc.wantClusterName != cc.Name {
+					t.Errorf("unexpected current cluster selection:\n\t(WNT) %s\n\t(GOT) %s", tc.wantClusterName, cc.Name)
+				}
+			}
+		})
+	}
+}

--- a/internal/pkg/storageoscluster/doc.go
+++ b/internal/pkg/storageoscluster/doc.go
@@ -1,0 +1,2 @@
+// Package storageoscluster provides helpers related to StorageOSCluster object.
+package storageoscluster

--- a/pkg/controller/nfsserver/nfsserver_controller.go
+++ b/pkg/controller/nfsserver/nfsserver_controller.go
@@ -6,13 +6,9 @@ import (
 	"strings"
 	"time"
 
-	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
-	stosClientset "github.com/storageos/cluster-operator/pkg/client/clientset/versioned"
-	"github.com/storageos/cluster-operator/pkg/nfs"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
@@ -23,6 +19,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/storageos/cluster-operator/internal/pkg/storageoscluster"
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+	stosClientset "github.com/storageos/cluster-operator/pkg/client/clientset/versioned"
+	"github.com/storageos/cluster-operator/pkg/nfs"
+	"github.com/storageos/cluster-operator/pkg/util/k8s"
 )
 
 // ErrNoCluster is the error when there's no associated running StorageOS
@@ -31,7 +33,10 @@ var ErrNoCluster = goerrors.New("no storageos cluster found")
 
 var log = logf.Log.WithName("controller_nfsserver")
 
-const finalizer = "finalizer.nfsserver.storageos.com"
+const (
+	finalizer    = "finalizer.nfsserver.storageos.com"
+	appComponent = "nfs-server"
+)
 
 // Add creates a new NFSServer Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -158,7 +163,7 @@ func (r *ReconcileNFSServer) reconcile(instance *storageosv1.NFSServer) error {
 	}
 
 	// Get a StorageOS cluster to associate the NFS server with.
-	stosCluster, err := r.getCurrentStorageOSCluster()
+	stosCluster, err := storageoscluster.GetCurrentStorageOSCluster(r.client)
 	if err != nil {
 		return err
 	}
@@ -262,38 +267,6 @@ func (r *ReconcileNFSServer) updateSpec(instance *storageosv1.NFSServer, cluster
 		return true, nil
 	}
 	return false, nil
-}
-
-// getCurrentStorageOSCluster returns a running StorageOS cluster.
-func (r *ReconcileNFSServer) getCurrentStorageOSCluster() (*storageosv1.StorageOSCluster, error) {
-	var currentCluster *storageosv1.StorageOSCluster
-
-	// Get a list of all the StorageOS clusters.
-	stosClusters, err := r.stosClientset.StorageosV1().StorageOSClusters("").List(metav1.ListOptions{})
-	if err != nil {
-		return currentCluster, err
-	}
-
-	// If there's only one cluster, select it as the current cluster.
-	if len(stosClusters.Items) == 1 {
-		currentCluster = &stosClusters.Items[0]
-	}
-
-	// If there are multiple clusters, consider the status of the cluster.
-	for _, cluster := range stosClusters.Items {
-		// Only one cluster can be in running phase at a time.
-		if cluster.Status.Phase == storageosv1.ClusterPhaseRunning {
-			currentCluster = &cluster
-			break
-		}
-	}
-
-	// If no current cluster found, fail.
-	if currentCluster != nil {
-		return currentCluster, nil
-	}
-
-	return currentCluster, ErrNoCluster
 }
 
 func contains(list []string, s string) bool {

--- a/pkg/controller/nfsserver/nfsserver_controller.go
+++ b/pkg/controller/nfsserver/nfsserver_controller.go
@@ -189,7 +189,15 @@ func (r *ReconcileNFSServer) reconcile(instance *storageosv1.NFSServer) error {
 		labels = map[string]string{}
 	}
 	// Add default labels.
+	// TODO: This is legacy label. Remove this with care. Ensure it's not used
+	// by any label selectors.
 	labels["app"] = "storageos"
+
+	// Set the app component.
+	labels[k8s.AppComponent] = appComponent
+
+	// Add default resource app labels.
+	labels = k8s.AddDefaultAppLabels(stosCluster.Name, labels)
 
 	d := nfs.NewDeployment(r.client, r.kConfig, stosCluster, instance, labels, r.recorder, r.scheme)
 

--- a/pkg/controller/nfsserver/nfsserver_controller_test.go
+++ b/pkg/controller/nfsserver/nfsserver_controller_test.go
@@ -5,13 +5,13 @@ import (
 	"reflect"
 	"testing"
 
-	storageosapis "github.com/storageos/cluster-operator/pkg/apis"
-	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
-	fakeStosClientset "github.com/storageos/cluster-operator/pkg/client/clientset/versioned/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	storageosapis "github.com/storageos/cluster-operator/pkg/apis"
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 )
 
 // getTestCluster returns a StorageOSCluster object with the given properties.
@@ -43,86 +43,6 @@ func getTestNFSServer(
 		},
 		Spec:   spec,
 		Status: status,
-	}
-}
-
-func TestGetCurrentStorageOSCluster(t *testing.T) {
-	emptySpec := storageosv1.StorageOSClusterSpec{}
-	emptyStatus := storageosv1.StorageOSClusterStatus{}
-
-	testcases := []struct {
-		name            string
-		clusters        []*storageosv1.StorageOSCluster
-		wantClusterName string
-		wantErr         error
-	}{
-		{
-			name: "multiple clusters with one ready",
-			clusters: []*storageosv1.StorageOSCluster{
-				getTestCluster("cluster1", "default", emptySpec, emptyStatus),
-				getTestCluster("cluster2", "foo", emptySpec,
-					storageosv1.StorageOSClusterStatus{
-						Phase: storageosv1.ClusterPhaseRunning,
-					}),
-				getTestCluster("cluster3", "default", emptySpec, emptyStatus),
-			},
-			wantClusterName: "cluster2",
-		},
-		{
-			name: "multiple clusters with none ready",
-			clusters: []*storageosv1.StorageOSCluster{
-				getTestCluster("cluster1", "default", emptySpec, emptyStatus),
-				getTestCluster("cluster2", "default", emptySpec,
-					storageosv1.StorageOSClusterStatus{
-						Phase: storageosv1.ClusterPhaseInitial,
-					}),
-				getTestCluster("cluster3", "default", emptySpec, emptyStatus),
-			},
-			wantErr: ErrNoCluster,
-		},
-		{
-			name: "single cluster not ready",
-			clusters: []*storageosv1.StorageOSCluster{
-				getTestCluster("cluster1", "default", emptySpec, emptyStatus),
-			},
-			wantClusterName: "cluster1",
-		},
-		{
-			name:    "no cluster",
-			wantErr: ErrNoCluster,
-		},
-	}
-
-	for _, tc := range testcases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			// Create fake storageos client.
-			stosClient := fakeStosClientset.NewSimpleClientset()
-
-			// Create the clusters.
-			for _, c := range tc.clusters {
-				_, err := stosClient.StorageosV1().StorageOSClusters(c.Namespace).Create(c)
-				if err != nil {
-					t.Fatalf("failed to create StorageOSCluster: %v", err)
-				}
-			}
-
-			// Create a reconciler.
-			reconciler := ReconcileNFSServer{
-				stosClientset: stosClient,
-			}
-
-			cc, err := reconciler.getCurrentStorageOSCluster()
-			if err != nil {
-				if !reflect.DeepEqual(tc.wantErr, err) {
-					t.Fatalf("unexpected error while getting current cluster: %v", err)
-				}
-			} else {
-				if tc.wantClusterName != cc.Name {
-					t.Errorf("unexpected current cluster selection:\n\t(WNT) %s\n\t(GOT) %s", tc.wantClusterName, cc.Name)
-				}
-			}
-		})
 	}
 }
 

--- a/pkg/controller/storageoscluster/cluster.go
+++ b/pkg/controller/storageoscluster/cluster.go
@@ -3,6 +3,7 @@ package storageoscluster
 import (
 	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 	"github.com/storageos/cluster-operator/pkg/storageos"
+	"github.com/storageos/cluster-operator/pkg/util/k8s"
 )
 
 // StorageOSCluster stores the current cluster's information. It binds the
@@ -37,7 +38,12 @@ func (c *StorageOSCluster) SetDeployment(r *ReconcileStorageOSCluster) {
 		labels = map[string]string{}
 	}
 	// Add default labels.
+	// TODO: This is legacy label. Remove this with care. Ensure it's not used
+	// by any label selectors.
 	labels["app"] = "storageos"
+
+	// Add default resource app labels.
+	labels = k8s.AddDefaultAppLabels(c.cluster.Name, labels)
 
 	c.deployment = storageos.NewDeployment(r.client, c.cluster, labels, r.recorder, r.scheme, r.k8sVersion, updateIfExists)
 }

--- a/pkg/nfs/configmap.go
+++ b/pkg/nfs/configmap.go
@@ -195,5 +195,5 @@ func (d *Deployment) createNFSConfigMap() error {
 		d.nfsServer.Name: nfsConfig,
 	}
 
-	return d.k8sResourceManager.ConfigMap(d.nfsServer.Name, d.nfsServer.Namespace, data).Create()
+	return d.k8sResourceManager.ConfigMap(d.nfsServer.Name, d.nfsServer.Namespace, nil, data).Create()
 }

--- a/pkg/nfs/delete.go
+++ b/pkg/nfs/delete.go
@@ -7,10 +7,10 @@ package nfs
 // especially when a cluster reboots. Althrough the operator re-creates the
 // resources, we want to avoid this behavior by implementing an explcit delete.
 func (d *Deployment) Delete() error {
-	if err := d.k8sResourceManager.StatefulSet(d.nfsServer.Name, d.nfsServer.Namespace, nil).Delete(); err != nil {
+	if err := d.k8sResourceManager.StatefulSet(d.nfsServer.Name, d.nfsServer.Namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
-	if err := d.k8sResourceManager.ConfigMap(d.nfsServer.Name, d.nfsServer.Namespace, nil).Delete(); err != nil {
+	if err := d.k8sResourceManager.ConfigMap(d.nfsServer.Name, d.nfsServer.Namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
 	if err := d.k8sResourceManager.Service(d.nfsServer.Name, d.nfsServer.Namespace, nil, nil, nil).Delete(); err != nil {
@@ -19,10 +19,10 @@ func (d *Deployment) Delete() error {
 	if err := d.k8sResourceManager.Service(d.getMetricsServiceName(), d.nfsServer.Namespace, nil, nil, nil).Delete(); err != nil {
 		return err
 	}
-	if err := d.k8sResourceManager.ClusterRoleBinding(d.getClusterRoleBindingName(), nil, nil).Delete(); err != nil {
+	if err := d.k8sResourceManager.ClusterRoleBinding(d.getClusterRoleBindingName(), nil, nil, nil).Delete(); err != nil {
 		return err
 	}
-	if err := d.k8sResourceManager.ServiceAccount(d.getServiceAccountName(), d.nfsServer.Namespace).Delete(); err != nil {
+	if err := d.k8sResourceManager.ServiceAccount(d.getServiceAccountName(), d.nfsServer.Namespace, nil).Delete(); err != nil {
 		return err
 	}
 
@@ -33,7 +33,7 @@ func (d *Deployment) Delete() error {
 	// must be used to set volume reclaim policy. NFS Server spec reclaim policy
 	// will be removed in StorageOS cluster-operator v2 APIs.
 	if d.nfsServer.Spec.PersistentVolumeClaim.ClaimName == "" {
-		if err := d.k8sResourceManager.PersistentVolumeClaim(d.nfsServer.Name, d.nfsServer.Namespace, nil).Delete(); err != nil {
+		if err := d.k8sResourceManager.PersistentVolumeClaim(d.nfsServer.Name, d.nfsServer.Namespace, nil, nil).Delete(); err != nil {
 			return err
 		}
 	}

--- a/pkg/nfs/deploy.go
+++ b/pkg/nfs/deploy.go
@@ -5,11 +5,13 @@ import (
 	"strings"
 
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
-	"github.com/storageos/cluster-operator/pkg/storageos"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/storageos/cluster-operator/pkg/storageos"
+	"github.com/storageos/cluster-operator/pkg/util/k8s"
 )
 
 const (
@@ -126,7 +128,8 @@ func (d *Deployment) labelsForStatefulSet(name string, labels map[string]string)
 		labels["storageos.com/fenced"] = "true"
 	}
 
-	return labels
+	// Add default resource labels.
+	return k8s.AddDefaultAppLabels(d.cluster.Name, labels)
 }
 
 func (d *Deployment) createClusterRoleBindingForSCC() error {

--- a/pkg/nfs/deploy.go
+++ b/pkg/nfs/deploy.go
@@ -142,7 +142,7 @@ func (d *Deployment) createClusterRoleBindingForSCC() error {
 		Name:     storageos.OpenShiftSCCClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return d.k8sResourceManager.ClusterRoleBinding(d.getClusterRoleBindingName(), subjects, roleRef).Create()
+	return d.k8sResourceManager.ClusterRoleBinding(d.getClusterRoleBindingName(), nil, subjects, roleRef).Create()
 }
 
 func (d *Deployment) getClusterRoleBindingName() string {
@@ -154,7 +154,7 @@ func (d *Deployment) getServiceAccountName() string {
 }
 
 func (d *Deployment) createServiceAccountForNFSServer() error {
-	return d.k8sResourceManager.ServiceAccount(d.getServiceAccountName(), d.nfsServer.Namespace).Create()
+	return d.k8sResourceManager.ServiceAccount(d.getServiceAccountName(), d.nfsServer.Namespace, nil).Create()
 }
 
 func (d *Deployment) createServiceMonitor() error {

--- a/pkg/nfs/pvc.go
+++ b/pkg/nfs/pvc.go
@@ -18,5 +18,5 @@ func (d *Deployment) createPVC(size *resource.Quantity) error {
 		},
 	}
 
-	return d.k8sResourceManager.PersistentVolumeClaim(d.nfsServer.Name, d.nfsServer.Namespace, spec).Create()
+	return d.k8sResourceManager.PersistentVolumeClaim(d.nfsServer.Name, d.nfsServer.Namespace, nil, spec).Create()
 }

--- a/pkg/nfs/statefulset.go
+++ b/pkg/nfs/statefulset.go
@@ -38,7 +38,7 @@ func (d *Deployment) createStatefulSet(pvcVS *corev1.PersistentVolumeClaimVolume
 	// TODO: Add node affinity support for NFS server pods.
 	util.AddTolerations(&spec.Template.Spec, d.nfsServer.Spec.Tolerations)
 
-	return d.k8sResourceManager.StatefulSet(d.nfsServer.Name, d.nfsServer.Namespace, spec).Create()
+	return d.k8sResourceManager.StatefulSet(d.nfsServer.Name, d.nfsServer.Namespace, nil, spec).Create()
 }
 
 func (d *Deployment) createPodTemplateSpec(nfsPort int, httpPort int) corev1.PodTemplateSpec {

--- a/pkg/nfs/status.go
+++ b/pkg/nfs/status.go
@@ -48,7 +48,7 @@ func (s *Deployment) getStatus() (*storageosv1.NFSServerStatus, error) {
 	}
 
 	// Check if the StatefulSet exists.
-	_, err := s.k8sResourceManager.StatefulSet(s.nfsServer.Name, s.nfsServer.Namespace, nil).Get()
+	_, err := s.k8sResourceManager.StatefulSet(s.nfsServer.Name, s.nfsServer.Namespace, nil, nil).Get()
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Return empty status without any error. Resources haven't been

--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -49,7 +49,7 @@ func (s Deployment) createCSIHelperStatefulSet(replicas int32) error {
 
 	s.addCommonPodProperties(&spec.Template.Spec)
 
-	return s.k8sResourceManager.StatefulSet(statefulsetName, s.stos.Spec.GetResourceNS(), spec).Create()
+	return s.k8sResourceManager.StatefulSet(statefulsetName, s.stos.Spec.GetResourceNS(), nil, spec).Create()
 }
 
 // csiHelperDeployment returns a CSI helper Deployment object.
@@ -74,7 +74,7 @@ func (s Deployment) createCSIHelperDeployment(replicas int32) error {
 
 	s.addCommonPodProperties(&spec.Template.Spec)
 
-	return s.k8sResourceManager.Deployment(csiHelperName, s.stos.Spec.GetResourceNS(), spec).Create()
+	return s.k8sResourceManager.Deployment(csiHelperName, s.stos.Spec.GetResourceNS(), nil, spec).Create()
 }
 
 // addCommonPodProperties adds common pod properties to a given pod spec. The
@@ -204,9 +204,9 @@ func (s Deployment) deleteCSIHelper() error {
 	// different kinds.
 	switch s.stos.Spec.GetCSIDeploymentStrategy() {
 	case deploymentKind:
-		return s.k8sResourceManager.Deployment(csiHelperName, s.stos.Spec.GetResourceNS(), nil).Delete()
+		return s.k8sResourceManager.Deployment(csiHelperName, s.stos.Spec.GetResourceNS(), nil, nil).Delete()
 	default:
-		return s.k8sResourceManager.StatefulSet(statefulsetName, s.stos.Spec.GetResourceNS(), nil).Delete()
+		return s.k8sResourceManager.StatefulSet(statefulsetName, s.stos.Spec.GetResourceNS(), nil, nil).Delete()
 	}
 }
 

--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -4,6 +4,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/storageos/cluster-operator/pkg/util/k8s"
 )
 
 const (
@@ -213,9 +215,11 @@ func (s Deployment) deleteCSIHelper() error {
 // podLabelsForCSIHelpers takes the name of a cluster custom resource and the
 // kind of helper, and returns labels for the pods of the helpers.
 func podLabelsForCSIHelpers(name, kind string) map[string]string {
-	return map[string]string{
+	// Combine CSI Helper specific labels with the default app labels.
+	labels := map[string]string{
 		"app":          appName,
 		"storageos_cr": name,
 		"kind":         kind,
 	}
+	return k8s.AddDefaultAppLabels(name, labels)
 }

--- a/pkg/storageos/daemonset.go
+++ b/pkg/storageos/daemonset.go
@@ -300,7 +300,7 @@ func (s *Deployment) createDaemonSet() error {
 
 	s.addCSI(podSpec)
 
-	return s.k8sResourceManager.DaemonSet(daemonsetName, s.stos.Spec.GetResourceNS(), spec).Create()
+	return s.k8sResourceManager.DaemonSet(daemonsetName, s.stos.Spec.GetResourceNS(), nil, spec).Create()
 }
 
 // addKVBackendEnvVars checks if KVBackend is set and sets the appropriate env vars.

--- a/pkg/storageos/daemonset.go
+++ b/pkg/storageos/daemonset.go
@@ -7,6 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/storageos/cluster-operator/pkg/util/k8s"
 )
 
 const (
@@ -343,9 +345,11 @@ func (s *Deployment) addDebugEnvVars(env []corev1.EnvVar) []corev1.EnvVar {
 // podLabelsForDaemonSet takes the name of a cluster custom resource and returns
 // labels for the pods of StorageOS node DaemonSet.
 func podLabelsForDaemonSet(name string) map[string]string {
-	return map[string]string{
+	// Combine DaemonSet specific labels with the default app labels.
+	labels := map[string]string{
 		"app":          appName,
 		"storageos_cr": name,
 		"kind":         daemonsetKind,
 	}
+	return k8s.AddDefaultAppLabels(name, labels)
 }

--- a/pkg/storageos/delete.go
+++ b/pkg/storageos/delete.go
@@ -15,7 +15,7 @@ import (
 func (s *Deployment) Delete() error {
 	namespace := s.stos.Spec.GetResourceNS()
 
-	if err := s.k8sResourceManager.StorageClass(s.stos.Spec.GetStorageClassName(), "", nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.StorageClass(s.stos.Spec.GetStorageClassName(), nil, "", nil).Delete(); err != nil {
 		return err
 	}
 
@@ -23,39 +23,39 @@ func (s *Deployment) Delete() error {
 		return err
 	}
 
-	if err := s.k8sResourceManager.DaemonSet(daemonsetName, namespace, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.DaemonSet(daemonsetName, namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
 
-	if err := s.k8sResourceManager.Secret(initSecretName, namespace, corev1.SecretTypeOpaque, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.Secret(initSecretName, namespace, nil, corev1.SecretTypeOpaque, nil).Delete(); err != nil {
 		return err
 	}
 
-	if err := s.k8sResourceManager.ClusterRoleBinding(InitClusterBindingName, nil, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ClusterRoleBinding(InitClusterBindingName, nil, nil, nil).Delete(); err != nil {
 		return err
 	}
 
-	if err := s.k8sResourceManager.ClusterRole(InitClusterRoleName, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ClusterRole(InitClusterRoleName, nil, nil).Delete(); err != nil {
 		return err
 	}
 
-	if err := s.k8sResourceManager.RoleBinding(KeyManagementBindingName, namespace, nil, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.RoleBinding(KeyManagementBindingName, namespace, nil, nil, nil).Delete(); err != nil {
 		return err
 	}
 
-	if err := s.k8sResourceManager.Role(KeyManagementRoleName, namespace, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.Role(KeyManagementRoleName, namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
 
-	if err := s.k8sResourceManager.RoleBinding(NFSClusterBindingName, namespace, nil, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.RoleBinding(NFSClusterBindingName, namespace, nil, nil, nil).Delete(); err != nil {
 		return err
 	}
 
-	if err := s.k8sResourceManager.Role(NFSClusterRoleName, namespace, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.Role(NFSClusterRoleName, namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
 
-	if err := s.k8sResourceManager.ServiceAccount(DaemonsetSA, namespace).Delete(); err != nil {
+	if err := s.k8sResourceManager.ServiceAccount(DaemonsetSA, namespace, nil).Delete(); err != nil {
 		return err
 	}
 
@@ -64,35 +64,35 @@ func (s *Deployment) Delete() error {
 			return err
 		}
 
-		if err := s.k8sResourceManager.ClusterRoleBinding(CSIAttacherClusterBindingName, nil, nil).Delete(); err != nil {
+		if err := s.k8sResourceManager.ClusterRoleBinding(CSIAttacherClusterBindingName, nil, nil, nil).Delete(); err != nil {
 			return err
 		}
 
-		if err := s.k8sResourceManager.ClusterRoleBinding(CSIProvisionerClusterBindingName, nil, nil).Delete(); err != nil {
+		if err := s.k8sResourceManager.ClusterRoleBinding(CSIProvisionerClusterBindingName, nil, nil, nil).Delete(); err != nil {
 			return err
 		}
 
-		if err := s.k8sResourceManager.ClusterRole(CSIAttacherClusterRoleName, nil).Delete(); err != nil {
+		if err := s.k8sResourceManager.ClusterRole(CSIAttacherClusterRoleName, nil, nil).Delete(); err != nil {
 			return err
 		}
 
-		if err := s.k8sResourceManager.ClusterRole(CSIProvisionerClusterRoleName, nil).Delete(); err != nil {
+		if err := s.k8sResourceManager.ClusterRole(CSIProvisionerClusterRoleName, nil, nil).Delete(); err != nil {
 			return err
 		}
 
-		if err := s.k8sResourceManager.ServiceAccount(s.getCSIHelperServiceAccountName(), namespace).Delete(); err != nil {
+		if err := s.k8sResourceManager.ServiceAccount(s.getCSIHelperServiceAccountName(), namespace, nil).Delete(); err != nil {
 			return err
 		}
 
-		if err := s.k8sResourceManager.ClusterRoleBinding(CSIK8SDriverRegistrarClusterBindingName, nil, nil).Delete(); err != nil {
+		if err := s.k8sResourceManager.ClusterRoleBinding(CSIK8SDriverRegistrarClusterBindingName, nil, nil, nil).Delete(); err != nil {
 			return err
 		}
 
-		if err := s.k8sResourceManager.ClusterRoleBinding(CSIDriverRegistrarClusterBindingName, nil, nil).Delete(); err != nil {
+		if err := s.k8sResourceManager.ClusterRoleBinding(CSIDriverRegistrarClusterBindingName, nil, nil, nil).Delete(); err != nil {
 			return err
 		}
 
-		if err := s.k8sResourceManager.ClusterRole(CSIDriverRegistrarClusterRoleName, nil).Delete(); err != nil {
+		if err := s.k8sResourceManager.ClusterRole(CSIDriverRegistrarClusterRoleName, nil, nil).Delete(); err != nil {
 			return err
 		}
 
@@ -109,22 +109,22 @@ func (s *Deployment) Delete() error {
 
 	// Delete cluster role for openshift security context constraints.
 	if strings.Contains(s.stos.Spec.K8sDistro, K8SDistroOpenShift) {
-		if err := s.k8sResourceManager.ClusterRoleBinding(OpenShiftSCCClusterBindingName, nil, nil).Delete(); err != nil {
+		if err := s.k8sResourceManager.ClusterRoleBinding(OpenShiftSCCClusterBindingName, nil, nil, nil).Delete(); err != nil {
 			return err
 		}
 
-		if err := s.k8sResourceManager.ClusterRole(OpenShiftSCCClusterRoleName, nil).Delete(); err != nil {
+		if err := s.k8sResourceManager.ClusterRole(OpenShiftSCCClusterRoleName, nil, nil).Delete(); err != nil {
 			return err
 		}
 	}
 
 	// Delete role for Pod Fencing.
 	if !s.stos.Spec.DisableFencing {
-		if err := s.k8sResourceManager.ClusterRoleBinding(FencingClusterBindingName, nil, nil).Delete(); err != nil {
+		if err := s.k8sResourceManager.ClusterRoleBinding(FencingClusterBindingName, nil, nil, nil).Delete(); err != nil {
 			return err
 		}
 
-		if err := s.k8sResourceManager.ClusterRole(FencingClusterRoleName, nil).Delete(); err != nil {
+		if err := s.k8sResourceManager.ClusterRole(FencingClusterRoleName, nil, nil).Delete(); err != nil {
 			return err
 		}
 	}

--- a/pkg/storageos/ingress.go
+++ b/pkg/storageos/ingress.go
@@ -26,5 +26,5 @@ func (s *Deployment) createIngress() error {
 		}
 	}
 
-	return s.k8sResourceManager.Ingress(ingressName, s.stos.Spec.GetResourceNS(), s.stos.Spec.Ingress.Annotations, spec).Create()
+	return s.k8sResourceManager.Ingress(ingressName, s.stos.Spec.GetResourceNS(), nil, s.stos.Spec.Ingress.Annotations, spec).Create()
 }

--- a/pkg/storageos/rbac.go
+++ b/pkg/storageos/rbac.go
@@ -55,19 +55,19 @@ func (s *Deployment) getCSIHelperServiceAccountName() string {
 // createServiceAccountForDaemonSet creates a service account fot the DaemonSet
 // pods.
 func (s *Deployment) createServiceAccountForDaemonSet() error {
-	return s.k8sResourceManager.ServiceAccount(DaemonsetSA, s.stos.Spec.GetResourceNS()).Create()
+	return s.k8sResourceManager.ServiceAccount(DaemonsetSA, s.stos.Spec.GetResourceNS(), nil).Create()
 }
 
 // createServiceAccountForCSIHelper creates service account for the appropriate
 // CSI helper kind based on the cluster config.
 func (s *Deployment) createServiceAccountForCSIHelper() error {
-	return s.k8sResourceManager.ServiceAccount(s.getCSIHelperServiceAccountName(), s.stos.Spec.GetResourceNS()).Create()
+	return s.k8sResourceManager.ServiceAccount(s.getCSIHelperServiceAccountName(), s.stos.Spec.GetResourceNS(), nil).Create()
 }
 
 // createServiceAccountForScheduler creates a service account for scheduler
 // extender.
 func (s *Deployment) createServiceAccountForScheduler() error {
-	return s.k8sResourceManager.ServiceAccount(SchedulerSA, s.stos.Spec.GetResourceNS()).Create()
+	return s.k8sResourceManager.ServiceAccount(SchedulerSA, s.stos.Spec.GetResourceNS(), nil).Create()
 }
 
 func (s *Deployment) createRoleForKeyMgmt() error {
@@ -78,7 +78,7 @@ func (s *Deployment) createRoleForKeyMgmt() error {
 			Verbs:     []string{"get", "list", "create", "delete"},
 		},
 	}
-	return s.k8sResourceManager.Role(KeyManagementRoleName, s.stos.Spec.GetResourceNS(), rules).Create()
+	return s.k8sResourceManager.Role(KeyManagementRoleName, s.stos.Spec.GetResourceNS(), nil, rules).Create()
 }
 
 func (s *Deployment) createClusterRoleForFencing() error {
@@ -114,7 +114,7 @@ func (s *Deployment) createClusterRoleForFencing() error {
 			Verbs:     []string{"list", "watch", "create", "update", "patch"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(FencingClusterRoleName, rules).Create()
+	return s.k8sResourceManager.ClusterRole(FencingClusterRoleName, nil, rules).Create()
 }
 
 func (s *Deployment) createClusterRoleForNFS() error {
@@ -125,7 +125,7 @@ func (s *Deployment) createClusterRoleForNFS() error {
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(NFSClusterRoleName, rules).Create()
+	return s.k8sResourceManager.ClusterRole(NFSClusterRoleName, nil, rules).Create()
 }
 
 func (s *Deployment) createClusterRoleForDriverRegistrar() error {
@@ -151,7 +151,7 @@ func (s *Deployment) createClusterRoleForDriverRegistrar() error {
 			Verbs:     []string{"create"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(CSIDriverRegistrarClusterRoleName, rules).Create()
+	return s.k8sResourceManager.ClusterRole(CSIDriverRegistrarClusterRoleName, nil, rules).Create()
 }
 
 func (s *Deployment) createClusterRoleForProvisioner() error {
@@ -182,7 +182,7 @@ func (s *Deployment) createClusterRoleForProvisioner() error {
 			Verbs:     []string{"list", "watch", "create", "update", "patch"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(CSIProvisionerClusterRoleName, rules).Create()
+	return s.k8sResourceManager.ClusterRole(CSIProvisionerClusterRoleName, nil, rules).Create()
 }
 
 func (s *Deployment) createClusterRoleForAttacher() error {
@@ -218,7 +218,7 @@ func (s *Deployment) createClusterRoleForAttacher() error {
 			Verbs:     []string{"list", "watch", "create", "update", "patch"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(CSIAttacherClusterRoleName, rules).Create()
+	return s.k8sResourceManager.ClusterRole(CSIAttacherClusterRoleName, nil, rules).Create()
 }
 
 // createClusterRoleForScheduler creates a ClusterRole resource for scheduler
@@ -257,7 +257,7 @@ func (s *Deployment) createClusterRoleForScheduler() error {
 			Verbs:     []string{"list", "watch"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(SchedulerClusterRoleName, rules).Create()
+	return s.k8sResourceManager.ClusterRole(SchedulerClusterRoleName, nil, rules).Create()
 }
 
 func (s *Deployment) createRoleBindingForKeyMgmt() error {
@@ -273,7 +273,7 @@ func (s *Deployment) createRoleBindingForKeyMgmt() error {
 		Name:     KeyManagementRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.RoleBinding(KeyManagementBindingName, s.stos.Spec.GetResourceNS(), subjects, roleRef).Create()
+	return s.k8sResourceManager.RoleBinding(KeyManagementBindingName, s.stos.Spec.GetResourceNS(), nil, subjects, roleRef).Create()
 }
 
 func (s *Deployment) createClusterRoleBindingForFencing() error {
@@ -289,7 +289,7 @@ func (s *Deployment) createClusterRoleBindingForFencing() error {
 		Name:     FencingClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(FencingClusterBindingName, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(FencingClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 func (s *Deployment) createClusterRoleBindingForNFS() error {
@@ -305,7 +305,7 @@ func (s *Deployment) createClusterRoleBindingForNFS() error {
 		Name:     NFSClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(NFSClusterBindingName, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(NFSClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 func (s *Deployment) createClusterRoleBindingForDriverRegistrar() error {
@@ -321,7 +321,7 @@ func (s *Deployment) createClusterRoleBindingForDriverRegistrar() error {
 		Name:     CSIDriverRegistrarClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(CSIDriverRegistrarClusterBindingName, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(CSIDriverRegistrarClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 func (s *Deployment) createClusterRoleBindingForK8SDriverRegistrar() error {
@@ -337,7 +337,7 @@ func (s *Deployment) createClusterRoleBindingForK8SDriverRegistrar() error {
 		Name:     CSIDriverRegistrarClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(CSIK8SDriverRegistrarClusterBindingName, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(CSIK8SDriverRegistrarClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 func (s *Deployment) createClusterRoleBindingForProvisioner() error {
@@ -353,7 +353,7 @@ func (s *Deployment) createClusterRoleBindingForProvisioner() error {
 		Name:     CSIProvisionerClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(CSIProvisionerClusterBindingName, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(CSIProvisionerClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 func (s *Deployment) createClusterRoleBindingForAttacher() error {
@@ -369,7 +369,7 @@ func (s *Deployment) createClusterRoleBindingForAttacher() error {
 		Name:     CSIAttacherClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(CSIAttacherClusterBindingName, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(CSIAttacherClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 // createClusterRoleForSCC creates cluster role with api group and resource
@@ -384,7 +384,7 @@ func (s *Deployment) createClusterRoleForSCC() error {
 			ResourceNames: []string{"privileged"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(OpenShiftSCCClusterRoleName, rules).Create()
+	return s.k8sResourceManager.ClusterRole(OpenShiftSCCClusterRoleName, nil, rules).Create()
 }
 
 // createClusterRoleBindingForSCC creates a cluster role binding of the
@@ -412,7 +412,7 @@ func (s *Deployment) createClusterRoleBindingForSCC() error {
 		Name:     OpenShiftSCCClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(OpenShiftSCCClusterBindingName, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(OpenShiftSCCClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 // createClusterRoleBindingForScheduler creates a cluster role binding for the
@@ -430,7 +430,7 @@ func (s *Deployment) createClusterRoleBindingForScheduler() error {
 		Name:     SchedulerClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(SchedulerClusterBindingName, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(SchedulerClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 // createClusterRoleForInit creates cluster role for the init container. This is
@@ -444,7 +444,7 @@ func (s *Deployment) createClusterRoleForInit() error {
 			Verbs:     []string{"get"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(InitClusterRoleName, rules).Create()
+	return s.k8sResourceManager.ClusterRole(InitClusterRoleName, nil, rules).Create()
 }
 
 // createClusterRoleBindingForInit creates a cluster role binding of the init
@@ -462,5 +462,5 @@ func (s *Deployment) createClusterRoleBindingForInit() error {
 		Name:     InitClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(InitClusterBindingName, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(InitClusterBindingName, nil, subjects, roleRef).Create()
 }

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -8,6 +8,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/storageos/cluster-operator/pkg/util/k8s"
 )
 
 const (
@@ -245,9 +247,11 @@ func (s Deployment) createSchedulerConfiguration() error {
 
 // podLabelsForScheduler returns labels for the scheduler pod.
 func podLabelsForScheduler(name string) map[string]string {
-	return map[string]string{
+	// Combine CSI Helper specific labels with the default app labels.
+	labels := map[string]string{
 		"app":          appName,
 		"storageos_cr": name,
 		"kind":         deploymentKind,
 	}
+	return k8s.AddDefaultAppLabels(name, labels)
 }

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -71,7 +71,7 @@ func (s Deployment) createSchedulerDeployment(replicas int32) error {
 	// Add pod toleration for quick recovery on node failure.
 	addPodTolerationForRecovery(&spec.Template.Spec)
 
-	return s.k8sResourceManager.Deployment(SchedulerExtenderName, s.stos.Spec.GetResourceNS(), spec).Create()
+	return s.k8sResourceManager.Deployment(SchedulerExtenderName, s.stos.Spec.GetResourceNS(), nil, spec).Create()
 }
 
 // schedulerContainers returns a list of containers that should be part of the
@@ -115,22 +115,22 @@ func (s Deployment) schedulerVolumes() []corev1.Volume {
 // deleteSchedulerExtender deletes all the scheduler related resources.
 func (s Deployment) deleteSchedulerExtender() error {
 	namespace := s.stos.Spec.GetResourceNS()
-	if err := s.k8sResourceManager.Deployment(SchedulerExtenderName, namespace, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.Deployment(SchedulerExtenderName, namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
-	if err := s.k8sResourceManager.ConfigMap(policyConfigMapName, namespace, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ConfigMap(policyConfigMapName, namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
-	if err := s.k8sResourceManager.ConfigMap(schedulerConfigConfigMapName, namespace, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ConfigMap(schedulerConfigConfigMapName, namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
-	if err := s.k8sResourceManager.ClusterRoleBinding(SchedulerClusterBindingName, nil, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ClusterRoleBinding(SchedulerClusterBindingName, nil, nil, nil).Delete(); err != nil {
 		return err
 	}
-	if err := s.k8sResourceManager.ServiceAccount(SchedulerSA, namespace).Delete(); err != nil {
+	if err := s.k8sResourceManager.ServiceAccount(SchedulerSA, namespace, nil).Delete(); err != nil {
 		return err
 	}
-	if err := s.k8sResourceManager.ClusterRole(SchedulerClusterRoleName, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ClusterRole(SchedulerClusterRoleName, nil, nil).Delete(); err != nil {
 		return err
 	}
 	return nil
@@ -190,7 +190,7 @@ func (s Deployment) createSchedulerPolicy() error {
 	data := map[string]string{
 		"policy.cfg": policyConfig.String(),
 	}
-	return s.k8sResourceManager.ConfigMap(policyConfigMapName, s.stos.Spec.GetResourceNS(), data).Create()
+	return s.k8sResourceManager.ConfigMap(policyConfigMapName, s.stos.Spec.GetResourceNS(), nil, data).Create()
 }
 
 // schedulerConfigTemplate contains fields for rendering the scheduler
@@ -240,7 +240,7 @@ func (s Deployment) createSchedulerConfiguration() error {
 	data := map[string]string{
 		"config.yaml": schedConfig.String(),
 	}
-	return s.k8sResourceManager.ConfigMap(schedulerConfigConfigMapName, s.stos.Spec.GetResourceNS(), data).Create()
+	return s.k8sResourceManager.ConfigMap(schedulerConfigConfigMapName, s.stos.Spec.GetResourceNS(), nil, data).Create()
 }
 
 // podLabelsForScheduler returns labels for the scheduler pod.

--- a/pkg/storageos/secret.go
+++ b/pkg/storageos/secret.go
@@ -17,7 +17,7 @@ func (s *Deployment) createInitSecret() error {
 		credUsernameKey: username,
 		credPasswordKey: password,
 	}
-	return s.k8sResourceManager.Secret(initSecretName, s.stos.Spec.GetResourceNS(), corev1.SecretTypeOpaque, data).Create()
+	return s.k8sResourceManager.Secret(initSecretName, s.stos.Spec.GetResourceNS(), nil, corev1.SecretTypeOpaque, data).Create()
 }
 
 func (s *Deployment) createTLSSecret() error {
@@ -29,13 +29,13 @@ func (s *Deployment) createTLSSecret() error {
 		tlsCertKey: cert,
 		tlsKeyKey:  key,
 	}
-	return s.k8sResourceManager.Secret(tlsSecretName, s.stos.Spec.GetResourceNS(), corev1.SecretTypeTLS, data).Create()
+	return s.k8sResourceManager.Secret(tlsSecretName, s.stos.Spec.GetResourceNS(), nil, corev1.SecretTypeTLS, data).Create()
 }
 
 func (s *Deployment) getAdminCreds() ([]byte, []byte, error) {
 	var username, password []byte
 	if s.stos.Spec.SecretRefName != "" && s.stos.Spec.SecretRefNamespace != "" {
-		secret, err := s.k8sResourceManager.Secret(s.stos.Spec.SecretRefName, s.stos.Spec.SecretRefNamespace, corev1.SecretTypeOpaque, nil).Get()
+		secret, err := s.k8sResourceManager.Secret(s.stos.Spec.SecretRefName, s.stos.Spec.SecretRefNamespace, nil, corev1.SecretTypeOpaque, nil).Get()
 		if err != nil {
 			return nil, nil, err
 		}
@@ -55,7 +55,7 @@ func (s *Deployment) getAdminCreds() ([]byte, []byte, error) {
 func (s *Deployment) getTLSData() ([]byte, []byte, error) {
 	var cert, key []byte
 	if s.stos.Spec.SecretRefName != "" && s.stos.Spec.SecretRefNamespace != "" {
-		secret, err := s.k8sResourceManager.Secret(s.stos.Spec.SecretRefName, s.stos.Spec.SecretRefNamespace, corev1.SecretTypeTLS, nil).Get()
+		secret, err := s.k8sResourceManager.Secret(s.stos.Spec.SecretRefName, s.stos.Spec.SecretRefNamespace, nil, corev1.SecretTypeTLS, nil).Get()
 		if err != nil {
 			return nil, nil, err
 		}
@@ -84,7 +84,7 @@ func (s *Deployment) createCSISecrets() error {
 			credUsernameKey: username,
 			credPasswordKey: password,
 		}
-		if err := s.k8sResourceManager.Secret(csiProvisionerSecretName, s.stos.Spec.GetResourceNS(), corev1.SecretTypeOpaque, data).Create(); err != nil {
+		if err := s.k8sResourceManager.Secret(csiProvisionerSecretName, s.stos.Spec.GetResourceNS(), nil, corev1.SecretTypeOpaque, data).Create(); err != nil {
 			return err
 		}
 	}
@@ -99,7 +99,7 @@ func (s *Deployment) createCSISecrets() error {
 			credUsernameKey: username,
 			credPasswordKey: password,
 		}
-		if err := s.k8sResourceManager.Secret(csiControllerPublishSecretName, s.stos.Spec.GetResourceNS(), corev1.SecretTypeOpaque, data).Create(); err != nil {
+		if err := s.k8sResourceManager.Secret(csiControllerPublishSecretName, s.stos.Spec.GetResourceNS(), nil, corev1.SecretTypeOpaque, data).Create(); err != nil {
 			return err
 		}
 	}
@@ -114,7 +114,7 @@ func (s *Deployment) createCSISecrets() error {
 			credUsernameKey: username,
 			credPasswordKey: password,
 		}
-		if err := s.k8sResourceManager.Secret(csiNodePublishSecretName, s.stos.Spec.GetResourceNS(), corev1.SecretTypeOpaque, data).Create(); err != nil {
+		if err := s.k8sResourceManager.Secret(csiNodePublishSecretName, s.stos.Spec.GetResourceNS(), nil, corev1.SecretTypeOpaque, data).Create(); err != nil {
 			return err
 		}
 	}
@@ -125,11 +125,11 @@ func (s *Deployment) createCSISecrets() error {
 // deleteCSISecrets deletes all the CSI related secrets.
 func (s *Deployment) deleteCSISecrets() error {
 	namespace := s.stos.Spec.GetResourceNS()
-	if err := s.k8sResourceManager.Secret(csiProvisionerSecretName, namespace, corev1.SecretTypeOpaque, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.Secret(csiProvisionerSecretName, namespace, nil, corev1.SecretTypeOpaque, nil).Delete(); err != nil {
 		return err
 	}
 
-	if err := s.k8sResourceManager.Secret(csiControllerPublishSecretName, namespace, corev1.SecretTypeOpaque, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.Secret(csiControllerPublishSecretName, namespace, nil, corev1.SecretTypeOpaque, nil).Delete(); err != nil {
 		return err
 	}
 
@@ -140,7 +140,7 @@ func (s *Deployment) deleteCSISecrets() error {
 // storageos-api secret and returns them.
 func (s *Deployment) getCSICreds(usernameKey, passwordKey string) (username []byte, password []byte, err error) {
 	// Get the username and password from storageos-api secret object.
-	secret, err := s.k8sResourceManager.Secret(s.stos.Spec.SecretRefName, s.stos.Spec.SecretRefNamespace, corev1.SecretTypeOpaque, nil).Get()
+	secret, err := s.k8sResourceManager.Secret(s.stos.Spec.SecretRefName, s.stos.Spec.SecretRefNamespace, nil, corev1.SecretTypeOpaque, nil).Get()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,11 +163,11 @@ func (s *Deployment) createTLSEtcdSecret() error {
 	}
 
 	// Fetch etcd TLS secret.
-	secret, err := s.k8sResourceManager.Secret(s.stos.Spec.TLSEtcdSecretRefName, s.stos.Spec.TLSEtcdSecretRefNamespace, corev1.SecretTypeOpaque, nil).Get()
+	secret, err := s.k8sResourceManager.Secret(s.stos.Spec.TLSEtcdSecretRefName, s.stos.Spec.TLSEtcdSecretRefNamespace, nil, corev1.SecretTypeOpaque, nil).Get()
 	if err != nil {
 		return err
 	}
 
 	// Create new secret with etcd TLS secret data.
-	return s.k8sResourceManager.Secret(TLSEtcdSecretName, s.stos.Spec.GetResourceNS(), secret.Type, secret.Data).Create()
+	return s.k8sResourceManager.Secret(TLSEtcdSecretName, s.stos.Spec.GetResourceNS(), nil, secret.Type, secret.Data).Create()
 }

--- a/pkg/storageos/service.go
+++ b/pkg/storageos/service.go
@@ -35,7 +35,7 @@ func (s *Deployment) createService() error {
 
 	// Patch storageos-api secret with above service IP in apiAddress.
 	if !s.stos.Spec.CSI.Enable {
-		secret, err := s.k8sResourceManager.Secret(s.stos.Spec.SecretRefName, s.stos.Spec.SecretRefNamespace, corev1.SecretTypeOpaque, nil).Get()
+		secret, err := s.k8sResourceManager.Secret(s.stos.Spec.SecretRefName, s.stos.Spec.SecretRefNamespace, nil, corev1.SecretTypeOpaque, nil).Get()
 		if err != nil {
 			return err
 		}

--- a/pkg/storageos/storageclass.go
+++ b/pkg/storageos/storageclass.go
@@ -51,5 +51,5 @@ func (s *Deployment) createStorageClass() error {
 		parameters[secretNameKey] = s.stos.Spec.SecretRefName
 	}
 
-	return s.k8sResourceManager.StorageClass(s.stos.Spec.GetStorageClassName(), provisioner, parameters).Create()
+	return s.k8sResourceManager.StorageClass(s.stos.Spec.GetStorageClassName(), nil, provisioner, parameters).Create()
 }

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -52,57 +52,76 @@ func (r *ResourceManager) SetLabels(labels map[string]string) *ResourceManager {
 // This can also be used to delete an existing object without any references to
 // the actual object. The name and namespace, without data, can be used to refer
 // the object and perform operations on it.
-func (r ResourceManager) ConfigMap(name, namespace string, data map[string]string) *resource.ConfigMap {
-	return resource.NewConfigMap(r.client, name, namespace, r.labels, data)
+func (r ResourceManager) ConfigMap(name, namespace string, labels map[string]string, data map[string]string) *resource.ConfigMap {
+	return resource.NewConfigMap(r.client, name, namespace, r.combineLabels(labels), data)
 }
 
 // DaemonSet returns a DaemonSet object.
-func (r ResourceManager) DaemonSet(name, namespace string, spec *appsv1.DaemonSetSpec) *resource.DaemonSet {
-	return resource.NewDaemonSet(r.client, name, namespace, r.labels, spec)
+func (r ResourceManager) DaemonSet(name, namespace string, labels map[string]string, spec *appsv1.DaemonSetSpec) *resource.DaemonSet {
+	return resource.NewDaemonSet(r.client, name, namespace, r.combineLabels(labels), spec)
 }
 
 // Deployment returns a Deployment object.
-func (r ResourceManager) Deployment(name, namespace string, spec *appsv1.DeploymentSpec) *resource.Deployment {
-	return resource.NewDeployment(r.client, name, namespace, r.labels, spec)
+func (r ResourceManager) Deployment(name, namespace string, labels map[string]string, spec *appsv1.DeploymentSpec) *resource.Deployment {
+	return resource.NewDeployment(r.client, name, namespace, r.combineLabels(labels), spec)
 }
 
 // Ingress returns an Ingress object.
-func (r ResourceManager) Ingress(name, namespace string, annotations map[string]string, spec *extensionsv1beta1.IngressSpec) *resource.Ingress {
-	return resource.NewIngress(r.client, name, namespace, r.labels, annotations, spec)
+func (r ResourceManager) Ingress(name, namespace string, labels map[string]string, annotations map[string]string, spec *extensionsv1beta1.IngressSpec) *resource.Ingress {
+	return resource.NewIngress(r.client, name, namespace, r.combineLabels(labels), annotations, spec)
 }
 
 // ServiceAccount returns a ServiceAccount object.
-func (r ResourceManager) ServiceAccount(name, namespace string) *resource.ServiceAccount {
-	return resource.NewServiceAccount(r.client, name, namespace, r.labels)
+func (r ResourceManager) ServiceAccount(name, namespace string, labels map[string]string) *resource.ServiceAccount {
+	return resource.NewServiceAccount(r.client, name, namespace, r.combineLabels(labels))
 }
 
 // Role returns a Role object.
-func (r ResourceManager) Role(name, namespace string, rules []rbacv1.PolicyRule) *resource.Role {
-	return resource.NewRole(r.client, name, namespace, r.labels, rules)
+func (r ResourceManager) Role(name, namespace string, labels map[string]string, rules []rbacv1.PolicyRule) *resource.Role {
+	return resource.NewRole(r.client, name, namespace, r.combineLabels(labels), rules)
 }
 
 // RoleBinding returns a RoleBinding object.
-func (r ResourceManager) RoleBinding(name, namespace string, subjects []rbacv1.Subject, roleRef *rbacv1.RoleRef) *resource.RoleBinding {
-	return resource.NewRoleBinding(r.client, name, namespace, r.labels, subjects, roleRef)
+func (r ResourceManager) RoleBinding(name, namespace string, labels map[string]string, subjects []rbacv1.Subject, roleRef *rbacv1.RoleRef) *resource.RoleBinding {
+	return resource.NewRoleBinding(r.client, name, namespace, r.combineLabels(labels), subjects, roleRef)
 }
 
 // ClusterRole returns a ClusterRole object.
-func (r ResourceManager) ClusterRole(name string, rules []rbacv1.PolicyRule) *resource.ClusterRole {
-	return resource.NewClusterRole(r.client, name, r.labels, rules)
+func (r ResourceManager) ClusterRole(name string, labels map[string]string, rules []rbacv1.PolicyRule) *resource.ClusterRole {
+	return resource.NewClusterRole(r.client, name, r.combineLabels(labels), rules)
 }
 
 // ClusterRoleBinding returns a ClusterRoleBinding object.
-func (r ResourceManager) ClusterRoleBinding(name string, subjects []rbacv1.Subject, roleRef *rbacv1.RoleRef) *resource.ClusterRoleBinding {
-	return resource.NewClusterRoleBinding(r.client, name, r.labels, subjects, roleRef)
+func (r ResourceManager) ClusterRoleBinding(name string, labels map[string]string, subjects []rbacv1.Subject, roleRef *rbacv1.RoleRef) *resource.ClusterRoleBinding {
+	return resource.NewClusterRoleBinding(r.client, name, r.combineLabels(labels), subjects, roleRef)
 }
 
 // Secret returns a Secret object.
-func (r ResourceManager) Secret(name, namespace string, secType corev1.SecretType, data map[string][]byte) *resource.Secret {
-	return resource.NewSecret(r.client, name, namespace, r.labels, secType, data)
+func (r ResourceManager) Secret(name, namespace string, labels map[string]string, secType corev1.SecretType, data map[string][]byte) *resource.Secret {
+	return resource.NewSecret(r.client, name, namespace, r.combineLabels(labels), secType, data)
 }
 
 // Service returns a Service object.
 func (r ResourceManager) Service(name, namespace string, labels map[string]string, annotations map[string]string, spec *corev1.ServiceSpec) *resource.Service {
+	return resource.NewService(r.client, name, namespace, r.combineLabels(labels), annotations, spec)
+}
+
+// StatefulSet returns a StatefulSet object.
+func (r ResourceManager) StatefulSet(name, namespace string, labels map[string]string, spec *appsv1.StatefulSetSpec) *resource.StatefulSet {
+	return resource.NewStatefulSet(r.client, name, namespace, r.combineLabels(labels), spec)
+}
+
+// StorageClass returns a StorageClass object.
+func (r ResourceManager) StorageClass(name string, labels map[string]string, provisioner string, params map[string]string) *resource.StorageClass {
+	return resource.NewStorageClass(r.client, name, r.combineLabels(labels), provisioner, params)
+}
+
+// PersistentVolumeClaim returns a PersistentVolumeClaim object.
+func (r ResourceManager) PersistentVolumeClaim(name, namespace string, labels map[string]string, spec *corev1.PersistentVolumeClaimSpec) *resource.PVC {
+	return resource.NewPVC(r.client, name, namespace, r.combineLabels(labels), spec)
+}
+
+func (r ResourceManager) combineLabels(labels map[string]string) map[string]string {
 	// Combine the common labels and resource specific labels.
 	if labels == nil {
 		labels = map[string]string{}
@@ -110,20 +129,5 @@ func (r ResourceManager) Service(name, namespace string, labels map[string]strin
 	for k, v := range r.labels {
 		labels[k] = v
 	}
-	return resource.NewService(r.client, name, namespace, labels, annotations, spec)
-}
-
-// StatefulSet returns a StatefulSet object.
-func (r ResourceManager) StatefulSet(name, namespace string, spec *appsv1.StatefulSetSpec) *resource.StatefulSet {
-	return resource.NewStatefulSet(r.client, name, namespace, r.labels, spec)
-}
-
-// StorageClass returns a StorageClass object.
-func (r ResourceManager) StorageClass(name string, provisioner string, params map[string]string) *resource.StorageClass {
-	return resource.NewStorageClass(r.client, name, r.labels, provisioner, params)
-}
-
-// PersistentVolumeClaim returns a PersistentVolumeClaim object.
-func (r ResourceManager) PersistentVolumeClaim(name, namespace string, spec *corev1.PersistentVolumeClaimSpec) *resource.PVC {
-	return resource.NewPVC(r.client, name, namespace, r.labels, spec)
+	return labels
 }

--- a/pkg/util/k8s/k8s_test.go
+++ b/pkg/util/k8s/k8s_test.go
@@ -36,100 +36,100 @@ func TestResourceManager(t *testing.T) {
 		{
 			name: resource.ConfigMapKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.ConfigMap(nsName.Name, nsName.Namespace, nil).Create()
+				return rm.ConfigMap(nsName.Name, nsName.Namespace, nil, nil).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.ConfigMap(nsName.Name, nsName.Namespace, nil).Delete()
+				return rm.ConfigMap(nsName.Name, nsName.Namespace, nil, nil).Delete()
 			},
 			wantResource: &corev1.ConfigMap{},
 		},
 		{
 			name: resource.DaemonSetKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.DaemonSet(nsName.Name, nsName.Namespace, &appsv1.DaemonSetSpec{}).Create()
+				return rm.DaemonSet(nsName.Name, nsName.Namespace, nil, &appsv1.DaemonSetSpec{}).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.DaemonSet(nsName.Name, nsName.Namespace, nil).Delete()
+				return rm.DaemonSet(nsName.Name, nsName.Namespace, nil, nil).Delete()
 			},
 			wantResource: &appsv1.DaemonSet{},
 		},
 		{
 			name: resource.DeploymentKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.Deployment(nsName.Name, nsName.Namespace, &appsv1.DeploymentSpec{}).Create()
+				return rm.Deployment(nsName.Name, nsName.Namespace, nil, &appsv1.DeploymentSpec{}).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.Deployment(nsName.Name, nsName.Namespace, nil).Delete()
+				return rm.Deployment(nsName.Name, nsName.Namespace, nil, nil).Delete()
 			},
 			wantResource: &appsv1.Deployment{},
 		},
 		{
 			name: resource.IngressKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.Ingress(nsName.Name, nsName.Namespace, nil, &extensionsv1beta1.IngressSpec{}).Create()
+				return rm.Ingress(nsName.Name, nsName.Namespace, nil, nil, &extensionsv1beta1.IngressSpec{}).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.Ingress(nsName.Name, nsName.Namespace, nil, nil).Delete()
+				return rm.Ingress(nsName.Name, nsName.Namespace, nil, nil, nil).Delete()
 			},
 			wantResource: &extensionsv1beta1.Ingress{},
 		},
 		{
 			name: resource.ServiceAccountKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.ServiceAccount(nsName.Name, nsName.Namespace).Create()
+				return rm.ServiceAccount(nsName.Name, nsName.Namespace, nil).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.ServiceAccount(nsName.Name, nsName.Namespace).Delete()
+				return rm.ServiceAccount(nsName.Name, nsName.Namespace, nil).Delete()
 			},
 			wantResource: &corev1.ServiceAccount{},
 		},
 		{
 			name: resource.RoleKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.Role(nsName.Name, nsName.Namespace, []rbacv1.PolicyRule{}).Create()
+				return rm.Role(nsName.Name, nsName.Namespace, nil, []rbacv1.PolicyRule{}).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.Role(nsName.Name, nsName.Namespace, nil).Delete()
+				return rm.Role(nsName.Name, nsName.Namespace, nil, nil).Delete()
 			},
 			wantResource: &rbacv1.Role{},
 		},
 		{
 			name: resource.RoleBindingKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.RoleBinding(nsName.Name, nsName.Namespace, nil, &rbacv1.RoleRef{}).Create()
+				return rm.RoleBinding(nsName.Name, nsName.Namespace, nil, nil, &rbacv1.RoleRef{}).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.RoleBinding(nsName.Name, nsName.Namespace, nil, nil).Delete()
+				return rm.RoleBinding(nsName.Name, nsName.Namespace, nil, nil, nil).Delete()
 			},
 			wantResource: &rbacv1.RoleBinding{},
 		},
 		{
 			name: resource.ClusterRoleKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.ClusterRole(nsName.Name, []rbacv1.PolicyRule{}).Create()
+				return rm.ClusterRole(nsName.Name, nil, []rbacv1.PolicyRule{}).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.ClusterRole(nsName.Name, nil).Delete()
+				return rm.ClusterRole(nsName.Name, nil, nil).Delete()
 			},
 			wantResource: &rbacv1.ClusterRole{},
 		},
 		{
 			name: resource.ClusterRoleBindingKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.ClusterRoleBinding(nsName.Name, nil, &rbacv1.RoleRef{}).Create()
+				return rm.ClusterRoleBinding(nsName.Name, nil, nil, &rbacv1.RoleRef{}).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.ClusterRoleBinding(nsName.Name, nil, nil).Delete()
+				return rm.ClusterRoleBinding(nsName.Name, nil, nil, nil).Delete()
 			},
 			wantResource: &rbacv1.ClusterRoleBinding{},
 		},
 		{
 			name: resource.SecretKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.Secret(nsName.Name, nsName.Namespace, corev1.SecretTypeOpaque, map[string][]byte{}).Create()
+				return rm.Secret(nsName.Name, nsName.Namespace, nil, corev1.SecretTypeOpaque, map[string][]byte{}).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.Secret(nsName.Name, nsName.Namespace, corev1.SecretTypeOpaque, nil).Delete()
+				return rm.Secret(nsName.Name, nsName.Namespace, nil, corev1.SecretTypeOpaque, nil).Delete()
 			},
 			wantResource: &corev1.Secret{},
 		},
@@ -146,30 +146,30 @@ func TestResourceManager(t *testing.T) {
 		{
 			name: resource.StatefulSetKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.StatefulSet(nsName.Name, nsName.Namespace, &appsv1.StatefulSetSpec{}).Create()
+				return rm.StatefulSet(nsName.Name, nsName.Namespace, nil, &appsv1.StatefulSetSpec{}).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.StatefulSet(nsName.Name, nsName.Namespace, nil).Delete()
+				return rm.StatefulSet(nsName.Name, nsName.Namespace, nil, nil).Delete()
 			},
 			wantResource: &appsv1.StatefulSet{},
 		},
 		{
 			name: resource.StorageClassKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.StorageClass(nsName.Name, "storageos", map[string]string{}).Create()
+				return rm.StorageClass(nsName.Name, nil, "storageos", map[string]string{}).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.StorageClass(nsName.Name, "storageos", nil).Delete()
+				return rm.StorageClass(nsName.Name, nil, "storageos", nil).Delete()
 			},
 			wantResource: &storagev1.StorageClass{},
 		},
 		{
 			name: resource.PVCKind,
 			create: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.PersistentVolumeClaim(nsName.Name, nsName.Namespace, &corev1.PersistentVolumeClaimSpec{}).Create()
+				return rm.PersistentVolumeClaim(nsName.Name, nsName.Namespace, nil, &corev1.PersistentVolumeClaimSpec{}).Create()
 			},
 			delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
-				return rm.PersistentVolumeClaim(nsName.Name, nsName.Namespace, nil).Delete()
+				return rm.PersistentVolumeClaim(nsName.Name, nsName.Namespace, nil, nil).Delete()
 			},
 			wantResource: &corev1.PersistentVolumeClaim{},
 		},

--- a/pkg/util/k8s/labels.go
+++ b/pkg/util/k8s/labels.go
@@ -1,0 +1,41 @@
+package k8s
+
+// k8s recommended labels from https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/ .
+const (
+	AppName      = "app.kubernetes.io/name"
+	AppInstance  = "app.kubernetes.io/instance"
+	AppVersion   = "app.kubernetes.io/version"
+	AppComponent = "app.kubernetes.io/component"
+	AppPartOf    = "app.kubernetes.io/part-of"
+	AppManagedBy = "app.kubernetes.io/managed-by"
+)
+
+// GetDefaultAppLabels returns the default k8s app labels for resources created
+// by the operator. appInstanceName should be the name of the StorageOSCluster
+// object.
+func GetDefaultAppLabels(appInstanceName string) map[string]string {
+	return map[string]string{
+		AppName:      "storageos",
+		AppInstance:  appInstanceName,
+		AppComponent: "cluster",
+		AppPartOf:    "storageos",
+		AppManagedBy: "storageos-operator",
+		// NOTE: StorageOSCluster CR isn't aware of StorageOS node version. Add
+		// version only when the StorageOSCluster becomes node version aware.
+		// AppVersion: "",
+	}
+}
+
+// AddDefaultAppLabels adds the default app labels to given labels.
+func AddDefaultAppLabels(appInstanceName string, labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	// Get the default labels and apply the existing labels over it. Passed
+	// labels should override the default labels.
+	outLabels := GetDefaultAppLabels(appInstanceName)
+	for k, v := range labels {
+		outLabels[k] = v
+	}
+	return outLabels
+}


### PR DESCRIPTION
This adds labels argument to all the k8s resource manager functions and provides a default set of labels for all the resources. The default labels are overridden by the passed labels per resource.

k8s recommended labels doc: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

This results in the resources that are part of the StorageOSCluster to have labels:
```
                        app.kubernetes.io/component=cluster
                        app.kubernetes.io/instance=example-storageoscluster
                        app.kubernetes.io/managed-by=storageos-operator
                        app.kubernetes.io/name=storageos
                        app.kubernetes.io/part-of=storageos
```
And the NFS Server resources (nfs-server pod, pvc, service) to have the component label as nfs-server:
```
               ...
               app.kubernetes.io/component=nfs-server
               app.kubernetes.io/instance=example-storageoscluster
               app.kubernetes.io/managed-by=storageos-operator
               ...
```

Also, move `GetCurrentStorageOSCluster()` to a new package.