### PR TITLE
Refactor cluster controller

### DIFF
--- a/deploy/olm/olm.sh
+++ b/deploy/olm/olm.sh
@@ -96,6 +96,7 @@ uninstall_storageos_operator() {
 
 uninstall_olm_quick() {
     echo "Uninstalling OLM"
-    kubectl delete -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml
+    kubectl delete -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.12.0/olm.yaml
+    kubectl delete -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.12.0/crds.yaml
     echo
 }

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -17,7 +17,19 @@ type ClusterPhase string
 // Constants for operator defaults values and different phases.
 const (
 	ClusterPhaseInitial ClusterPhase = ""
-	ClusterPhaseRunning              = "Running"
+	// A cluster is in running phase when the cluster health is reported
+	// healthy, all the StorageOS nodes are ready.
+	ClusterPhaseRunning ClusterPhase = "Running"
+	// A cluster is in creating phase when the cluster resource provisioning as
+	// started
+	ClusterPhaseCreating ClusterPhase = "Creating"
+	// A cluster is in pending phase when the creation hasn't started. This can
+	// happen if there's an existing cluster and the new cluster provisioning is
+	// not allowed by the operator.
+	ClusterPhasePending ClusterPhase = "Pending"
+	// A cluster is in terminating phase when the cluster delete is initiated.
+	// The cluster object is waiting for the finalizers to be executed.
+	ClusterPhaseTerminating ClusterPhase = "Terminating"
 
 	DefaultNamespace = "storageos"
 

--- a/pkg/controller/storageoscluster/cluster.go
+++ b/pkg/controller/storageoscluster/cluster.go
@@ -67,6 +67,9 @@ func (c *StorageOSCluster) Deploy(r *ReconcileStorageOSCluster) error {
 }
 
 // DeleteDeployment deletes the StorageOS Cluster deployment.
-func (c *StorageOSCluster) DeleteDeployment() error {
+func (c *StorageOSCluster) DeleteDeployment(r *ReconcileStorageOSCluster) error {
+	if c.deployment == nil {
+		c.SetDeployment(r)
+	}
 	return c.deployment.Delete()
 }

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -6,9 +6,6 @@ import (
 	"strings"
 	"time"
 
-	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
-	"github.com/storageos/cluster-operator/pkg/storageos"
-	"github.com/storageos/cluster-operator/pkg/util/k8sutil"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -23,9 +20,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/storageos/cluster-operator/internal/pkg/storageoscluster"
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+	"github.com/storageos/cluster-operator/pkg/storageos"
+	"github.com/storageos/cluster-operator/pkg/util/k8sutil"
 )
 
 var log = logf.Log.WithName("storageos.cluster")
+
+const clusterFinalizer = "finalizer.storageoscluster.storageos.com"
 
 // Add creates a new StorageOSCluster Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -83,12 +87,22 @@ type ReconcileStorageOSCluster struct {
 	currentCluster *StorageOSCluster
 }
 
-// SetCurrentClusterIfNone checks if there's any existing current cluster and
-// sets a new current cluster if it wasn't set before.
-func (r *ReconcileStorageOSCluster) SetCurrentClusterIfNone(cluster *storageosv1.StorageOSCluster) {
-	if r.currentCluster == nil {
-		r.SetCurrentCluster(cluster)
+// UpdateCurrentCluster checks if there are any existing cluster and updates the
+// current cluster with the new cluster is no existing cluster is found.
+func (r *ReconcileStorageOSCluster) UpdateCurrentCluster(cluster *storageosv1.StorageOSCluster) error {
+	cc, err := storageoscluster.GetCurrentStorageOSCluster(r.client)
+	if err != nil {
+		if err == storageoscluster.ErrNoCluster {
+			// If there's no existing cluster, set the passed cluster as the
+			// current cluster.
+			r.SetCurrentCluster(cluster)
+		} else {
+			return fmt.Errorf("failed to get current cluster: %v", err)
+		}
+	} else {
+		r.SetCurrentCluster(cc)
 	}
+	return nil
 }
 
 // SetCurrentCluster sets the currently active cluster in the controller.
@@ -110,42 +124,90 @@ func (r *ReconcileStorageOSCluster) Reconcile(request reconcile.Request) (reconc
 	log := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	// log.Info("Reconciling Cluster")
 
+	// Return this for a retry of the reconciliation loop after a period of
+	// time.
 	reconcilePeriod := 15 * time.Second
 	reconcileResult := reconcile.Result{RequeueAfter: reconcilePeriod}
+
+	// Return this for a immediate retry of the reconciliation loop with the
+	// same request object.
+	immediateRetryResult := reconcile.Result{Requeue: true}
 
 	// Fetch the StorageOSCluster instance
 	instance := &storageosv1.StorageOSCluster{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// Cluster instance not found. Delete the resources and reset the
-			// current cluster.
-			if r.currentCluster != nil {
-				if err := r.currentCluster.DeleteDeployment(); err != nil {
-					// Error deleting - requeue the request.
-					return reconcileResult, err
-				}
-			}
-			r.ResetCurrentCluster()
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return reconcileResult, err
+		return immediateRetryResult, err
 	}
 
 	// Set as the current cluster if there's no current cluster.
-	r.SetCurrentClusterIfNone(instance)
+	if err := r.UpdateCurrentCluster(instance); err != nil {
+		log.Info("Failed to update current cluster", "error", err)
+		// Failed to determine or set current cluster, requeue the request.
+		return immediateRetryResult, nil
+	}
+
+	// Check if the cluster instance is marked to be deleted, which is indicated
+	// by the deletion timestamp being set.
+	if instance.GetDeletionTimestamp() != nil {
+		if contains(instance.GetFinalizers(), clusterFinalizer) {
+			// Update status subresource.
+			instance.Status.Phase = storageosv1.ClusterPhaseTerminating
+			if err := r.client.Status().Update(context.TODO(), instance); err != nil {
+				log.Info("Failed to update cluster status", "error", err)
+				return immediateRetryResult, nil
+			}
+
+			// Finalize the cluster.
+			if err := r.finalizeCluster(instance); err != nil {
+				log.Info("Failed to finalize cluster", "error", err)
+				return immediateRetryResult, nil
+			}
+
+			// Remove finalizer and update cluster status.
+			instance.SetFinalizers(remove(instance.GetFinalizers(), clusterFinalizer))
+			if err := r.client.Update(context.TODO(), instance); err != nil {
+				log.Info("Failed to update cluster finalizers", "error", err)
+				return immediateRetryResult, nil
+			}
+		}
+		// Return and do not requeue. Successful deletion.
+		return reconcile.Result{}, nil
+	}
+
+	// Add finalizer if not exists already.
+	if !contains(instance.GetFinalizers(), clusterFinalizer) {
+		if err := r.addFinalizer(instance); err != nil {
+			log.Info("Failed to update cluster with finalizer", "error", err)
+			// Requeue if adding finalizer fails for a retry.
+			return immediateRetryResult, nil
+		}
+	}
 
 	// If the event doesn't belongs to the current cluster, do not reconcile.
 	// There must be only a single instance of storageos in a cluster.
 	if !r.currentCluster.IsCurrentCluster(instance) {
 		err := fmt.Errorf("can't create more than one storageos cluster")
 		r.recorder.Event(instance, corev1.EventTypeWarning, "FailedCreation", err.Error())
-		// Do not requeue the request.
-		return reconcile.Result{}, nil
+
+		// Set the cluster status to pending.
+		instance.Status.Phase = storageosv1.ClusterPhasePending
+		if err := r.client.Status().Update(context.Background(), instance); err != nil {
+			log.Info("Failed to update cluster status", "error", err)
+			// Requeue so that a status update is attempted again.
+			return immediateRetryResult, nil
+		}
+
+		// Requeue the request so that this cluster is deployed as soon as it
+		// becomes the current cluster.
+		return immediateRetryResult, nil
 	} else if r.currentCluster.cluster.GetUID() != instance.GetUID() {
 		// If the cluster name and namespace match with the current cluster, but
 		// the resource UIDs are different, maybe the current cluster reset
@@ -158,10 +220,40 @@ func (r *ReconcileStorageOSCluster) Reconcile(request reconcile.Request) (reconc
 
 	if err := r.reconcile(instance); err != nil {
 		log.Info("Reconcile failed", "error", err)
-		return reconcileResult, nil
+		return immediateRetryResult, nil
 	}
 
+	// Requeue to reconcile after a period of time.
 	return reconcileResult, nil
+}
+
+// finalizeCluster performs cleanup of the resources before deleting the cluster
+// custom resource. Cluster deployment is deleted only when passed cluster is
+// the currently running StorageOS cluster. No cleanup is needed for a pending
+// cluster.
+func (r *ReconcileStorageOSCluster) finalizeCluster(m *storageosv1.StorageOSCluster) error {
+	// Check if the cluster being finalized is the currently running cluster.
+	if r.currentCluster.cluster.Name == m.Name {
+		r.recorder.Event(m, corev1.EventTypeNormal, "Terminating", "Deleting all the resources...")
+		if err := r.currentCluster.DeleteDeployment(r); err != nil {
+			return fmt.Errorf("failed to delete the cluster: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// addFinalizer adds a finalizer on the cluster object to avoid instant deletion
+// of the object without finalizing it.
+func (r *ReconcileStorageOSCluster) addFinalizer(m *storageosv1.StorageOSCluster) error {
+	log.Info("Adding Finalizer for the StorageOSCluster")
+	m.SetFinalizers(append(m.GetFinalizers(), clusterFinalizer))
+
+	// Update CR.
+	if err := r.client.Update(context.TODO(), m); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *ReconcileStorageOSCluster) reconcile(m *storageosv1.StorageOSCluster) error {
@@ -184,49 +276,21 @@ func (r *ReconcileStorageOSCluster) reconcile(m *storageosv1.StorageOSCluster) e
 		return nil
 	}
 
-	// Finalizers are set when an object should be deleted. Apply deploy only
-	// when finalizers is empty.
-	if len(m.GetFinalizers()) == 0 {
-		// // Check if there's a new version of the cluster config and create a new
-		// // deployment accordingly to update the resources that already exist.
-		// // TODO: Add more granular checks. Resource version check is not enough
-		// // to detect and apply changes. Maybe add an admission webhook to
-		// // perform validation when the cluster config is updated and handle the
-		// // resource update at an individual level. Updating all the resources
-		// // is dangerous.
-		// updateIfExists := false
-		// if r.currentCluster.GetResourceVersion() != m.GetResourceVersion() {
-		// 	log.Println("new cluster config detected")
-		// 	updateIfExists = true
-		// 	r.SetCurrentCluster(m)
-		// }
-
-		if err := r.currentCluster.Deploy(r); err != nil {
-			// Ignore "Operation cannot be fulfilled" error. It happens when the
-			// actual state of object is different from what is known to the operator.
-			// Operator would resync and retry the failed operation on its own.
-			if !strings.HasPrefix(err.Error(), "Operation cannot be fulfilled") {
-				r.recorder.Event(m, corev1.EventTypeWarning, "FailedCreation", err.Error())
-			}
-			return err
+	if err := r.currentCluster.Deploy(r); err != nil {
+		// Ignore "Operation cannot be fulfilled" error. It happens when the
+		// actual state of object is different from what is known to the operator.
+		// Operator would resync and retry the failed operation on its own.
+		if !strings.HasPrefix(err.Error(), "Operation cannot be fulfilled") {
+			r.recorder.Event(m, corev1.EventTypeWarning, "FailedCreation", err.Error())
 		}
-	} else {
-		// Delete the deployment once the finalizers are set on the cluster
-		// resource.
-		r.recorder.Event(m, corev1.EventTypeNormal, "Terminating", "Deleting all the resources...")
 
-		if err := r.currentCluster.DeleteDeployment(); err != nil {
+		// Set the status to pending.
+		r.currentCluster.cluster.Status.Phase = storageosv1.ClusterPhasePending
+		if err := r.client.Status().Update(context.Background(), r.currentCluster.cluster); err != nil {
 			return err
 		}
 
-		r.ResetCurrentCluster()
-		// Reset finalizers and let k8s delete the object.
-		// When finalizers are set on an object, metadata.deletionTimestamp is
-		// also set. deletionTimestamp helps the garbage collector identify
-		// when to delete an object. k8s deletes the object only once the
-		// list of finalizers is empty.
-		m.SetFinalizers([]string{})
-		return r.client.Update(context.Background(), m)
+		return err
 	}
 
 	return nil
@@ -414,4 +478,24 @@ func getMatchingTolerations(taints []corev1.Taint, tolerations []corev1.Tolerati
 		}
 	}
 	return true, result
+}
+
+// contains checks if an item exists in a given list.
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// remove removes an item from a given list.
+func remove(list []string, s string) []string {
+	for i, v := range list {
+		if v == s {
+			list = append(list[:i], list[i+1:]...)
+		}
+	}
+	return list
 }

--- a/pkg/storageos/update_status.go
+++ b/pkg/storageos/update_status.go
@@ -75,7 +75,7 @@ func (s *Deployment) getStorageOSStatus() (*storageosv1.StorageOSClusterStatus, 
 		}
 	}
 
-	phase := storageosv1.ClusterPhaseInitial
+	phase := storageosv1.ClusterPhaseCreating
 	if readyNodes == totalNodes {
 		phase = storageosv1.ClusterPhaseRunning
 	}


### PR DESCRIPTION
- Add pending cluster status when the requirements are unmet
- Add creating cluster status when the provisioning has started
- Add terminating cluster status when cluster delete is initiated
- Immediate retry for clusters that can't be provisioned because of
existing main cluster.
- Add finalizer to simplify deployment cleanup.

Previously, the phase used to be empty/unset. This resulted in the CR status to remain empty until the resource is ready. OLM scorecard test expects the CR status to not be empty. CR status will be set to pending immediately with this change.

```
$ kubectl get stos --all-namespaces 
NAMESPACE   NAME                        READY   STATUS    AGE
default     example-storageoscluster            Pending   3s

$ kubectl get stos --all-namespaces 
NAMESPACE   NAME                        READY   STATUS     AGE
default     example-storageoscluster    0/1     Creating   34s

$ kubectl get stos --all-namespaces 
NAMESPACE   NAME                        READY   STATUS    AGE
default     example-storageoscluster    1/1     Running   70s
```

Multiple instances of cluster:
```
$ kubectl get stos --all-namespaces 
NAMESPACE   NAME                        READY   STATUS    AGE
default     example-storageoscluster2           Pending   21s
olm         example                     1/1     Running   2m48s
```