### PR TITLE
Add new permissions for kube-scheduler

### DIFF
--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -286,6 +286,7 @@ spec:
           - storageclasses
           - volumeattachments
           - csinodeinfos
+          - csinodes
           verbs:
           - create
           - delete
@@ -346,6 +347,12 @@ spec:
           - storageos-cluster-operator
           verbs:
           - update
+        - apiGroups:
+          - events.k8s.io
+          resources:
+          - events
+          verbs:
+          - create
       deployments:
       - name: storageos-operator
         spec:

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -285,6 +285,7 @@ spec:
           - storageclasses
           - volumeattachments
           - csinodeinfos
+          - csinodes
           verbs:
           - create
           - delete
@@ -345,6 +346,12 @@ spec:
           - storageos-cluster-operator
           verbs:
           - update
+        - apiGroups:
+          - events.k8s.io
+          resources:
+          - events
+          verbs:
+          - create
       deployments:
       - name: storageos-operator
         spec:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -88,6 +88,7 @@ rules:
   - storageclasses
   - volumeattachments
   - csinodeinfos
+  - csinodes
   verbs:
   - create
   - delete
@@ -148,3 +149,9 @@ rules:
   - storageos-cluster-operator
   verbs:
   - update
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -895,6 +895,7 @@ data:
                 - storageclasses
                 - volumeattachments
                 - csinodeinfos
+                - csinodes
                 verbs:
                 - create
                 - delete
@@ -955,6 +956,12 @@ data:
                 - storageos-cluster-operator
                 verbs:
                 - update
+              - apiGroups:
+                - events.k8s.io
+                resources:
+                - events
+                verbs:
+                - create
             deployments:
             - name: storageos-operator
               spec:

--- a/pkg/storageos/rbac.go
+++ b/pkg/storageos/rbac.go
@@ -248,13 +248,18 @@ func (s *Deployment) createClusterRoleForScheduler() error {
 		},
 		{
 			APIGroups: []string{"storage.k8s.io"},
-			Resources: []string{"storageclasses"},
+			Resources: []string{"storageclasses", "csinodes"},
 			Verbs:     []string{"list", "watch"},
 		},
 		{
 			APIGroups: []string{"policy"},
 			Resources: []string{"poddisruptionbudgets"},
 			Verbs:     []string{"list", "watch"},
+		},
+		{
+			APIGroups: []string{"events.k8s.io"},
+			Resources: []string{"events"},
+			Verbs:     []string{"create"},
 		},
 	}
 	return s.k8sResourceManager.ClusterRole(SchedulerClusterRoleName, nil, rules).Create()


### PR DESCRIPTION
In k8s 1.16, kube-scheduler requires permissions to list csinodes and
create events.

Without these permissions, scheduling fails and the pods remain in pending state.

kube-scheduler logs:
```
Failed to list *v1beta1.CSINode: csinodes.storage.k8s.io is forbidden: User "system:serviceaccount:storageos:storageos-scheduler-sa" cannot list resource "csinodes" in API group "storage.k8s.io" at the cluster scope
...
'events.events.k8s.io is forbidden: User "system:serviceaccount:storageos:storageos-scheduler-sa" cannot create resource "events" in API group "events.k8s.io" in the namespace "default"'
```
