### PR TITLE
NFS: fix service label selectors

### DIFF
--- a/docs/nfs-prometheus-metrics/README.md
+++ b/docs/nfs-prometheus-metrics/README.md
@@ -98,8 +98,9 @@ The ServiceMonitor inherits labels from the respective NFS Server metrics
 service.
 
 To collect the NFS Server metrics in prometheus, create a Prometheus instance
-with `serviceMonitorSelector` matching labels `app=storageos` and 
-`app.kubernetes.io/component=metrics`. The prometheus server needs permissions
+with `serviceMonitorSelector` matching labels
+`app.kubernetes.io/service-for=nfs-metrics` and
+`app.kubernetes.io/component=nfs-server`. The prometheus server needs permissions
 to be able to collect the metrics from the metrics endpoints. Create a
 ServiceAccount with all the necessary RBAC permission by applying
 [prometheus-rbac.yaml](prometheus-rbac.yaml) and create a prometheus server
@@ -116,6 +117,10 @@ pvc-527a4462-50a4-490e-90a7-d2dd1224cf63-0   1/1     Running   0          118m
 In the above, `prometheus-prometheus-nfs-0` is the prometheus server pod.
 Once created, port-forward to the prometheus server pod and view the collected
 metrics in the prometheus dashboard at `localhost:8080`.
+
+__NOTE__: If there are multiple NFS Servers and metrics for a specific NFS
+Server is required, NFS PVC name can be included in the
+`serviceMonitorSelector`, `nfsserver=<rwx-pvc-name>`.
 
 ```
 $ kubectl port-forward prometheus-prometheus-nfs-0 8080:9090

--- a/docs/nfs-prometheus-metrics/prometheus-nfs.yaml
+++ b/docs/nfs-prometheus-metrics/prometheus-nfs.yaml
@@ -7,6 +7,8 @@ spec:
   serviceAccountName: prometheus-nfs
   serviceMonitorSelector:
     matchLabels:
-      app: storageos
-      app.kubernetes.io/component: metrics
+      app.kubernetes.io/name: storageos
+      app.kubernetes.io/component: nfs-server
+      app.kubernetes.io/service-for: nfs-metrics
+      # nfsserver: some-pvc-name
   enableAdminAPI: false

--- a/pkg/nfs/service.go
+++ b/pkg/nfs/service.go
@@ -5,6 +5,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/storageos/cluster-operator/pkg/util/k8s"
 )
 
 func (d *Deployment) ensureService(nfsPort int) error {
@@ -15,7 +17,7 @@ func (d *Deployment) ensureService(nfsPort int) error {
 	}
 
 	labels := map[string]string{
-		componentLabel: "server",
+		k8s.ServiceFor: "nfs-server",
 	}
 
 	// Couldn't get any existing service. Create a new service.
@@ -28,7 +30,7 @@ func (d *Deployment) ensureService(nfsPort int) error {
 // createMetricsService creates a Service for metrics at the given port number.
 func (d *Deployment) createMetricsService(metricsPort int) error {
 	labels := map[string]string{
-		componentLabel: "metrics",
+		k8s.ServiceFor: "nfs-metrics",
 	}
 	if err := d.createService(d.getMetricsServiceName(), MetricsPortName, metricsPort, labels); err != nil {
 		return err
@@ -38,7 +40,7 @@ func (d *Deployment) createMetricsService(metricsPort int) error {
 
 func (d *Deployment) createService(name string, portName string, port int, labels map[string]string) error {
 	spec := &corev1.ServiceSpec{
-		Selector: d.labelsForStatefulSet(d.nfsServer.Name, map[string]string{}),
+		Selector: d.labelsForStatefulSet(),
 		Type:     corev1.ServiceTypeClusterIP,
 		Ports: []corev1.ServicePort{
 			{

--- a/pkg/nfs/statefulset.go
+++ b/pkg/nfs/statefulset.go
@@ -21,7 +21,7 @@ func (d *Deployment) createStatefulSet(pvcVS *corev1.PersistentVolumeClaimVolume
 		ServiceName: d.nfsServer.Name,
 		Replicas:    &replicas,
 		Selector: &metav1.LabelSelector{
-			MatchLabels: d.labelsForStatefulSet(d.nfsServer.Name, d.nfsServer.Labels),
+			MatchLabels: d.labelsForStatefulSet(),
 		},
 		Template: d.createPodTemplateSpec(nfsPort, httpPort),
 	}
@@ -44,7 +44,7 @@ func (d *Deployment) createStatefulSet(pvcVS *corev1.PersistentVolumeClaimVolume
 func (d *Deployment) createPodTemplateSpec(nfsPort int, httpPort int) corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: d.labelsForStatefulSet(d.nfsServer.Name, d.nfsServer.Labels),
+			Labels: d.labelsForStatefulSet(),
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: d.getServiceAccountName(),

--- a/pkg/storageos/service.go
+++ b/pkg/storageos/service.go
@@ -6,6 +6,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/storageos/cluster-operator/pkg/util/k8s"
 )
 
 // createService creates a service for storageos app with a label selector
@@ -29,7 +31,12 @@ func (s *Deployment) createService() error {
 		},
 	}
 
-	if err := s.k8sResourceManager.Service(s.stos.Spec.GetServiceName(), s.stos.Spec.GetResourceNS(), nil, s.stos.Spec.Service.Annotations, spec).Create(); err != nil {
+	// Add ServiceFor labels for the Service.
+	labels := map[string]string{
+		k8s.ServiceFor: "storageos-api-server",
+	}
+
+	if err := s.k8sResourceManager.Service(s.stos.Spec.GetServiceName(), s.stos.Spec.GetResourceNS(), labels, s.stos.Spec.Service.Annotations, spec).Create(); err != nil {
 		return err
 	}
 

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -3,12 +3,13 @@
 package k8s
 
 import (
-	"github.com/storageos/cluster-operator/pkg/util/k8s/resource"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/storageos/cluster-operator/pkg/util/k8s/resource"
 )
 
 // Resource is an interface for k8s resources. All the k8s resources supported
@@ -46,6 +47,11 @@ func (r *ResourceManager) SetLabels(labels map[string]string) *ResourceManager {
 	}
 	r.labels = labels
 	return r
+}
+
+// GetLabels returns labels of the resource manager.
+func (r *ResourceManager) GetLabels() map[string]string {
+	return r.labels
 }
 
 // ConfigMap returns a ConfigMap object.

--- a/pkg/util/k8s/labels.go
+++ b/pkg/util/k8s/labels.go
@@ -1,6 +1,13 @@
 package k8s
 
 // k8s recommended labels from https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/ .
+//
+// Custom labels:
+//  - app.kubernetes.io/service-for: This label should be used to differentiate
+// between services by specifying what type of endpoint a service provides, like
+// nfs-server or metrics endpoint. This can be used along with component label
+// to uniquely select services by service label selectors, e.g. prometheus
+// service monitor selector.
 const (
 	AppName      = "app.kubernetes.io/name"
 	AppInstance  = "app.kubernetes.io/instance"
@@ -8,6 +15,7 @@ const (
 	AppComponent = "app.kubernetes.io/component"
 	AppPartOf    = "app.kubernetes.io/part-of"
 	AppManagedBy = "app.kubernetes.io/managed-by"
+	ServiceFor   = "app.kubernetes.io/service-for"
 )
 
 // GetDefaultAppLabels returns the default k8s app labels for resources created


### PR DESCRIPTION
The new k8s labels that were added to all the resources introduced a bug
due to which the Service labels selector for NFS wasn't able to select
any pod, resulting in no endpoints in the service. Due to this, NFS
mounts were resulting in connection timeout.
This change fixes the labels by correcting label selectors used in the
Service and introducing a new label `app.kubernetes.io/service-for` to
define what a service is for. The NFS Server service has service-for value
"nfs-server" and the metrics service has the value "nfs-metrics". This
helps easily distinguish between the NFS Server service and the NFS
metrics service. The prometheus service monitor selectors have been
updated to use the new labels.