### PR TITLE
e2e: run full tests when platform supports it

### DIFF
--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -70,6 +70,9 @@ func (s Deployment) createSchedulerDeployment(replicas int32) error {
 		},
 	}
 
+	// Add cluster config tolerations.
+	s.addTolerations(&spec.Template.Spec)
+
 	// Add pod toleration for quick recovery on node failure.
 	addPodTolerationForRecovery(&spec.Template.Spec)
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -132,7 +132,7 @@ install_operatorsdk() {
 print_pod_details_and_logs() {
     local namespace="${1?Namespace is required}"
 
-    kubectl get pods --show-all --no-headers --namespace "$namespace" | awk '{ print $1 }' | while read -r pod; do
+    kubectl get pods --no-headers --namespace "$namespace" | awk '{ print $1 }' | while read -r pod; do
         if [[ -n "$pod" ]]; then
             printf '\n================================================================================\n'
             printf ' Details from pod %s\n' "$pod"
@@ -149,7 +149,7 @@ print_pod_details_and_logs() {
             printf '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n'
 
             local init_containers
-            init_containers=$(kubectl get pods --show-all --output jsonpath="{.spec.initContainers[*].name}" --namespace "$namespace" "$pod")
+            init_containers=$(kubectl get pods --output jsonpath="{.spec.initContainers[*].name}" --namespace "$namespace" "$pod")
             for container in $init_containers; do
                 printf -- '\n--------------------------------------------------------------------------------\n'
                 printf ' Logs of init container %s in pod %s\n' "$container" "$pod"
@@ -163,7 +163,7 @@ print_pod_details_and_logs() {
             done
 
             local containers
-            containers=$(kubectl get pods --show-all --output jsonpath="{.spec.containers[*].name}" --namespace "$namespace" "$pod")
+            containers=$(kubectl get pods --output jsonpath="{.spec.containers[*].name}" --namespace "$namespace" "$pod")
             for container in $containers; do
                 printf '\n--------------------------------------------------------------------------------\n'
                 printf -- ' Logs of container %s in pod %s\n' "$container" "$pod"

--- a/test/e2e/util/cluster.go
+++ b/test/e2e/util/cluster.go
@@ -7,18 +7,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-	"github.com/storageos/cluster-operator/pkg/apis"
-	storageos "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/storageos/cluster-operator/pkg/apis"
+	storageos "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+	"github.com/storageos/cluster-operator/pkg/util/k8sutil"
 )
 
 // Time constants.
@@ -302,4 +305,29 @@ func StorageOSClusterCRAttributesTest(t *testing.T, crName string, crNamespace s
 	if testStorageOS.Spec.Service.Name == "" {
 		t.Errorf("spec.service.name must not be empty")
 	}
+}
+
+// featureSupportAvailable can be used by tests to check if the platform
+// supports the test by passing a minimum version of k8s required to run the
+// test.
+func featureSupportAvailable(minVersion semver.Version) (bool, error) {
+	log := logf.Log.WithName("test.featureSupportAvailability")
+	k := k8sutil.NewK8SOps(framework.Global.KubeClient, log)
+	version, err := k.GetK8SVersion()
+	if err != nil {
+		return false, fmt.Errorf("failed to get k8s version: %v", err)
+	}
+
+	currentVersion, err := semver.Parse(version)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse k8s version: %v", err)
+	}
+
+	if currentVersion.Compare(minVersion) >= 0 {
+		// This test is supported in this version of k8s.
+		return true, nil
+	}
+
+	// Test is not supported in this version of k8s. Skip the test.
+	return false, nil
 }

--- a/test/e2e/util/nfs_cluster.go
+++ b/test/e2e/util/nfs_cluster.go
@@ -6,14 +6,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	storageos "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+
+	storageos "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 )
 
 // Constants used in NFS server test utils.
@@ -49,27 +52,49 @@ func DeployNFSServer(t *testing.T, ctx *framework.TestCtx, nfsServer *storageos.
 		return err
 	}
 
-	// // NOTE: This is disabled for now, because NFS server pod fails to mount
-	// // volume on OpenShift 3.11 because of limited CSI support, resulting in
-	// // test failure. When an OpenShift 3.11 CSI support workaround is added, or
-	// // when OpenShift 4 is added in the CI, this can be enabled again.
-	// err = WaitForStatefulSet(t, f.KubeClient, nfsServer.Namespace, nfsServer.Name, RetryInterval, Timeout*2)
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-
-	// NOTE: Temporary resource creation check only. Remove once the above check
-	// is added.
-	// Wait for 10 seconds here because there's no wait for the StatefulSet to be
-	// ready. This will provide time for the PVC to be provisioned.
-	time.Sleep(10 * time.Second)
-	statefulset := &appsv1.StatefulSet{}
-	namespacedName := types.NamespacedName{
-		Name:      nfsServer.Name,
-		Namespace: nfsServer.Namespace,
+	// Minimum version for running the complete test.
+	minVersion := semver.Version{
+		Major: 1, Minor: 13, Patch: 0,
 	}
-	if f.Client.Get(goctx.TODO(), namespacedName, statefulset); err != nil {
-		return err
+
+	featureSupported, err := featureSupportAvailable(minVersion)
+	if err != nil {
+		return fmt.Errorf("failed to check platform support for NFS Server test: %v", err)
+	}
+
+	if featureSupported {
+		// Wait for NFS Server StatefulSet to be ready.
+		err = WaitForStatefulSet(t, f.KubeClient, nfsServer.Namespace, nfsServer.Name, RetryInterval, Timeout*2)
+		if err != nil {
+			return err
+		}
+
+		// Check the Service endpoints to be selected properly.
+		nfsServiceEndpoints := &corev1.Endpoints{}
+		namespacedName := types.NamespacedName{
+			Name:      nfsServer.Name,
+			Namespace: nfsServer.Namespace,
+		}
+		if err := f.Client.Get(goctx.TODO(), namespacedName, nfsServiceEndpoints); err != nil {
+			return err
+		}
+		if len(nfsServiceEndpoints.Subsets) < 1 {
+			return fmt.Errorf("NFS Server Service has no selected endpoints")
+		}
+	} else {
+		// Wait for 10 seconds here because there's no wait for the StatefulSet
+		// to be ready. This will provide time for the PVC to be provisioned.
+		time.Sleep(10 * time.Second)
+		// Since the feature is not supported, only check if the StatefulSet
+		// is created.
+		statefulset := &appsv1.StatefulSet{}
+		namespacedName := types.NamespacedName{
+			Name:      nfsServer.Name,
+			Namespace: nfsServer.Namespace,
+		}
+		if f.Client.Get(goctx.TODO(), namespacedName, statefulset); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -108,13 +133,19 @@ func NFSServerTest(t *testing.T, ctx *framework.TestCtx) {
 	// Check if a ServiceMonitor was created.
 	// ServiceMonitor is only created when the ServiceMonitor CRD is known in
 	// the cluster.
-	serviceMonitor := &monitoringv1.ServiceMonitor{}
-	smNSName := types.NamespacedName{
-		Name:      fmt.Sprintf("%s-%s", testNFSServer.Name, "metrics"),
-		Namespace: defaultNS,
+	serviceMonitorExists, err := hasServiceMonitor()
+	if err != nil {
+		t.Error("failed to check if ServiceMonitor exists", err)
 	}
-	if err := f.Client.Get(goctx.TODO(), smNSName, serviceMonitor); err != nil {
-		t.Error("failed to get NFS metrics ServiceMonitor", err)
+	if serviceMonitorExists {
+		serviceMonitor := &monitoringv1.ServiceMonitor{}
+		smNSName := types.NamespacedName{
+			Name:      fmt.Sprintf("%s-%s", testNFSServer.Name, "metrics"),
+			Namespace: defaultNS,
+		}
+		if err := f.Client.Get(goctx.TODO(), smNSName, serviceMonitor); err != nil {
+			t.Error("failed to get NFS metrics ServiceMonitor", err)
+		}
 	}
 
 	// Delete the NFS server.
@@ -122,17 +153,29 @@ func NFSServerTest(t *testing.T, ctx *framework.TestCtx) {
 		t.Error("failed to delete NFS Server", err)
 	}
 
-	// Delete the PVC used by NFS server because it's not cleaned up when the
-	// server is deleted.
-	pvc := &corev1.PersistentVolumeClaim{}
-	pvcNSName := types.NamespacedName{
-		Name:      testNFSServer.Name,
-		Namespace: defaultNS,
+	// Wait for NFS resources to be deleted automatically.
+	time.Sleep(5 * time.Second)
+}
+
+// hasServiceMonitor checks is Prometheus Service Monitor CRD is registered in
+// the cluster.
+func hasServiceMonitor() (bool, error) {
+	dc := discovery.NewDiscoveryClientForConfigOrDie(framework.Global.KubeConfig)
+	apiVersion := "monitoring.coreos.com/v1"
+	kind := "ServiceMonitor"
+
+	apiLists, err := dc.ServerResources()
+	if err != nil {
+		return false, err
 	}
-	if err := f.Client.Get(goctx.TODO(), pvcNSName, pvc); err != nil {
-		t.Error("failed to get PVC", err)
+	for _, apiList := range apiLists {
+		if apiList.GroupVersion == apiVersion {
+			for _, r := range apiList.APIResources {
+				if r.Kind == kind {
+					return true, nil
+				}
+			}
+		}
 	}
-	if err := f.Client.Delete(goctx.TODO(), pvc); err != nil {
-		t.Error("failed to delete PVC", err)
-	}
+	return false, nil
 }


### PR DESCRIPTION
This change adds platform version checks in the e2e tests. Admission
controller and NFS Server tests will be run completely on the supported
platforms and partially or skipped for unsupported platform versions.