### PR TITLE
Add status to all crds

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Parameter | Description | Default
 `secretRefName` | Reference name of storageos secret |
 `secretRefNamespace` | Namespace of storageos secret |
 `namespace` | Namespace where storageos cluster resources are created | `storageos`
-`images.nodeContainer` | StorageOS node container image | `storageos/node:1.5.0`
+`images.nodeContainer` | StorageOS node container image | `storageos/node:1.5.1`
 `images.initContainer` | StorageOS init container image | `storageos/init:1.0.0`
 `images.csiNodeDriverRegistrarContainer` | CSI Node Driver Registrar Container image | `quay.io/k8scsi/csi-node-driver-registrar:v1.0.1`
 `images.csiClusterDriverRegistrarContainer` | CSI Cluster Driver Registrar Container image | `quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1`


### PR DESCRIPTION
This adds default status to upgrade and job CRs.
With this the scorecard test for all the CRDs would not wait for the
resources to have a status, increasing the scorecard score and reducing
the CI time.

Scorecard test results:
```
Running operator-sdk scorecard with example Job
DEBU[0000] Debug logging is set                         
WARN[0000] Could not load config file; using flags      
WARN[0000] Plugin directory not found; skipping external plugins: stat scorecard: no such file or directory 
Basic Tests:
	Spec Block Exists: 1/1
	Status Block Exists: 1/1
	Writing into CRs has an effect: 0/1
OLM Tests:
	Spec fields with descriptors: 6/6
	Status fields with descriptors: 0/0
	Provided APIs have validation: 1/1
	Owned CRDs have resources listed: 1/1
	CRs have at least 1 example: 1/1

Total Score: 76%
SUGGESTION: The operator should write into objects to update state. No PUT or POST requests from the operator were recorded by the scorecard.
```
```
Running operator-sdk scorecard with example StorageOSUpgrade
DEBU[0000] Debug logging is set                         
WARN[0000] Could not load config file; using flags      
WARN[0000] Plugin directory not found; skipping external plugins: stat scorecard: no such file or directory 
Basic Tests:
	Status Block Exists: 1/1
	Writing into CRs has an effect: 0/1
	Spec Block Exists: 1/1
OLM Tests:
	Provided APIs have validation: 1/1
	Owned CRDs have resources listed: 1/1
	CRs have at least 1 example: 1/1
	Spec fields with descriptors: 1/1
	Status fields with descriptors: 0/0

Total Score: 76%
SUGGESTION: The operator should write into objects to update state. No PUT or POST requests from the operator were recorded by the scorecard.
```
We don't actively maintain these CRDs at the moment but since they are part of the operator, they are considered in the third-party scorecard tests.
This change will help with the basic requirement that CRs must have spec and status.