### PR TITLE
Add k8s api resource discovery package

### DIFF
--- a/internal/pkg/discovery/discovery.go
+++ b/internal/pkg/discovery/discovery.go
@@ -1,0 +1,30 @@
+package discovery
+
+import (
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// HasResource takes an api version and a kind of a resource and checks if the resource
+// is supported by the k8s api server.
+func HasResource(kubeconfig *rest.Config, apiVersion, kind string) (bool, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(kubeconfig)
+	if err != nil {
+		return false, err
+	}
+	apiLists, err := dc.ServerResources()
+	if err != nil {
+		return false, err
+	}
+	// Compare the resource api version and kind and find the resource.
+	for _, apiList := range apiLists {
+		if apiList.GroupVersion == apiVersion {
+			for _, r := range apiList.APIResources {
+				if r.Kind == kind {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}

--- a/internal/pkg/discovery/doc.go
+++ b/internal/pkg/discovery/doc.go
@@ -1,0 +1,4 @@
+// Package discovery contains functions to help discovery of resources in a
+// cluster. It can be used to check if cluster (api server) supports a given
+// resource.
+package discovery

--- a/test/e2e/util/nfs_cluster.go
+++ b/test/e2e/util/nfs_cluster.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/discovery"
 
+	"github.com/storageos/cluster-operator/internal/pkg/discovery"
 	storageos "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 )
 
@@ -157,25 +157,10 @@ func NFSServerTest(t *testing.T, ctx *framework.TestCtx) {
 	time.Sleep(5 * time.Second)
 }
 
-// hasServiceMonitor checks is Prometheus Service Monitor CRD is registered in
+// hasServiceMonitor checks if Prometheus Service Monitor CRD is registered in
 // the cluster.
 func hasServiceMonitor() (bool, error) {
-	dc := discovery.NewDiscoveryClientForConfigOrDie(framework.Global.KubeConfig)
 	apiVersion := "monitoring.coreos.com/v1"
 	kind := "ServiceMonitor"
-
-	apiLists, err := dc.ServerResources()
-	if err != nil {
-		return false, err
-	}
-	for _, apiList := range apiLists {
-		if apiList.GroupVersion == apiVersion {
-			for _, r := range apiList.APIResources {
-				if r.Kind == kind {
-					return true, nil
-				}
-			}
-		}
-	}
-	return false, nil
+	return discovery.HasResource(framework.Global.KubeConfig, apiVersion, kind)
 }


### PR DESCRIPTION
This adds a new package internal/pkg/discovery, containing helpers to
check if a resource is supported by the k8s api server. This can be used
in tests to check if the test cluster supports some features before
running the tests. This will also be helpful for CSI deployments in
checking if CSIDriver and CSINode built-in resources are supported in
the cluster and use the built-in resources instead of CSI CRDs for
driver deployment.