### PR TITLE
Update CSI Deployment

### DIFF
--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -287,6 +287,7 @@ spec:
           - volumeattachments
           - csinodeinfos
           - csinodes
+          - csidrivers
           verbs:
           - create
           - delete
@@ -294,6 +295,7 @@ spec:
           - list
           - get
           - update
+          - patch
         - apiGroups:
           - apiextensions.k8s.io
           resources:

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -286,6 +286,7 @@ spec:
           - volumeattachments
           - csinodeinfos
           - csinodes
+          - csidrivers
           verbs:
           - create
           - delete
@@ -293,6 +294,7 @@ spec:
           - list
           - get
           - update
+          - patch
         - apiGroups:
           - apiextensions.k8s.io
           resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -94,6 +94,7 @@ rules:
   - volumeattachments
   - csinodeinfos
   - csinodes
+  - csidrivers
   verbs:
   - create
   - delete
@@ -101,6 +102,7 @@ rules:
   - list
   - get
   - update
+  - patch
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -896,6 +896,7 @@ data:
                 - volumeattachments
                 - csinodeinfos
                 - csinodes
+                - csidrivers
                 verbs:
                 - create
                 - delete
@@ -903,6 +904,7 @@ data:
                 - list
                 - get
                 - update
+                - patch
               - apiGroups:
                 - apiextensions.k8s.io
                 resources:

--- a/internal/pkg/discovery/discovery.go
+++ b/internal/pkg/discovery/discovery.go
@@ -2,17 +2,12 @@ package discovery
 
 import (
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
 )
 
 // HasResource takes an api version and a kind of a resource and checks if the resource
 // is supported by the k8s api server.
-func HasResource(kubeconfig *rest.Config, apiVersion, kind string) (bool, error) {
-	dc, err := discovery.NewDiscoveryClientForConfig(kubeconfig)
-	if err != nil {
-		return false, err
-	}
-	apiLists, err := dc.ServerResources()
+func HasResource(dc discovery.DiscoveryInterface, apiVersion, kind string) (bool, error) {
+	_, apiLists, err := dc.ServerGroupsAndResources()
 	if err != nil {
 		return false, err
 	}

--- a/internal/pkg/discovery/discovery_test.go
+++ b/internal/pkg/discovery/discovery_test.go
@@ -1,0 +1,80 @@
+package discovery
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestHasResource(t *testing.T) {
+	testKind := "Foo"
+	testKindGroupVersion := "v1"
+
+	testcases := []struct {
+		name            string
+		apiResourceList []*metav1.APIResourceList
+		wantResult      bool
+	}{
+		{
+			name:            "empty api resource list",
+			apiResourceList: []*metav1.APIResourceList{},
+			wantResult:      false,
+		},
+		{
+			name: "have resource",
+			apiResourceList: []*metav1.APIResourceList{
+				{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{
+							Kind: "Foo",
+						},
+						{
+							Kind: "Bar",
+						},
+					},
+				},
+			},
+			wantResult: true,
+		},
+		{
+			name: "have resource but different version",
+			apiResourceList: []*metav1.APIResourceList{
+				{
+					GroupVersion: "v2",
+					APIResources: []metav1.APIResource{
+						{
+							Kind: "Foo",
+						},
+						{
+							Kind: "Bar",
+						},
+					},
+				},
+			},
+			wantResult: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			client := fakeclientset.NewSimpleClientset()
+			fakeDiscovery, ok := client.Discovery().(*fakediscovery.FakeDiscovery)
+			if !ok {
+				t.Fatalf("could not convert Discovery() to *FakeDiscovery")
+			}
+			fakeDiscovery.Resources = tc.apiResourceList
+
+			exists, err := HasResource(fakeDiscovery, testKindGroupVersion, testKind)
+			if err != nil {
+				t.Fatalf("failed to check if resource exists: %v", err)
+			}
+			if exists != tc.wantResult {
+				t.Errorf("unexpected result for HasResource:\n\t(WNT) %t\n\t(GOT) %t", tc.wantResult, exists)
+			}
+		})
+	}
+}

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -45,12 +45,13 @@ const (
 	DefaultNodeContainerImage                 = "storageos/node:1.5.1"
 	DefaultInitContainerImage                 = "storageos/init:1.0.0"
 	CSIv1ClusterDriverRegistrarContainerImage = "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1"
-	CSIv1NodeDriverRegistrarContainerImage    = "quay.io/k8scsi/csi-node-driver-registrar:v1.0.1"
-	CSIv1ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v1.0.1"
-	CSIv1ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v1.0.1"
-	CSIv1LivenessProbeContainerImage          = "quay.io/k8scsi/livenessprobe:v1.0.1"
+	CSIv1NodeDriverRegistrarContainerImage    = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+	CSIv1ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v1.4.0"
+	CSIv1ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v1.2.1"
+	CSIv1ExternalAttacherv2ContainerImage     = "quay.io/k8scsi/csi-attacher:v2.0.0"
+	CSIv1LivenessProbeContainerImage          = "quay.io/k8scsi/livenessprobe:v1.1.0"
 	CSIv0DriverRegistrarContainerImage        = "quay.io/k8scsi/driver-registrar:v0.4.2"
-	CSIv0ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v0.4.2"
+	CSIv0ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v0.4.3"
 	CSIv0ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v0.4.2"
 	DefaultNFSContainerImage                  = "storageos/nfs:1.0.0"
 
@@ -331,11 +332,16 @@ func (s StorageOSClusterSpec) GetCSIExternalProvisionerImage(csiv1 bool) string 
 }
 
 // GetCSIExternalAttacherImage returns CSI external attacher container image.
-func (s StorageOSClusterSpec) GetCSIExternalAttacherImage(csiv1 bool) string {
+// CSI v0, CSI v1 on k8s 1.13 and CSI v1 on k8s 1.14+ require different versions
+// of external attacher.
+func (s StorageOSClusterSpec) GetCSIExternalAttacherImage(csiv1 bool, attacherv2Supported bool) string {
 	if s.Images.CSIExternalAttacherContainer != "" {
 		return s.Images.CSIExternalAttacherContainer
 	}
 	if csiv1 {
+		if attacherv2Supported {
+			return CSIv1ExternalAttacherv2ContainerImage
+		}
 		return CSIv1ExternalAttacherContainerImage
 	}
 	return CSIv0ExternalAttacherContainerImage

--- a/pkg/controller/storageoscluster/cluster.go
+++ b/pkg/controller/storageoscluster/cluster.go
@@ -45,7 +45,7 @@ func (c *StorageOSCluster) SetDeployment(r *ReconcileStorageOSCluster) {
 	// Add default resource app labels.
 	labels = k8s.AddDefaultAppLabels(c.cluster.Name, labels)
 
-	c.deployment = storageos.NewDeployment(r.client, c.cluster, labels, r.recorder, r.scheme, r.k8sVersion, updateIfExists)
+	c.deployment = storageos.NewDeployment(r.client, r.discoveryClient, c.cluster, labels, r.recorder, r.scheme, r.k8sVersion, updateIfExists)
 }
 
 // IsCurrentCluster compares the cluster attributes to check if the given

--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -32,6 +32,10 @@ func (s *Deployment) createCSIHelper() error {
 // csiHelperStatefulSet returns a CSI helper StatefulSet object.
 func (s Deployment) createCSIHelperStatefulSet(replicas int32) error {
 	podLabels := podLabelsForCSIHelpers(s.stos.Name, statefulsetKind)
+	containers, err := s.csiHelperContainers()
+	if err != nil {
+		return err
+	}
 	spec := &appsv1.StatefulSetSpec{
 		Replicas: &replicas,
 		Selector: &metav1.LabelSelector{
@@ -43,7 +47,7 @@ func (s Deployment) createCSIHelperStatefulSet(replicas int32) error {
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: StatefulsetSA,
-				Containers:         s.csiHelperContainers(),
+				Containers:         containers,
 				Volumes:            s.csiHelperVolumes(),
 			},
 		},
@@ -57,6 +61,10 @@ func (s Deployment) createCSIHelperStatefulSet(replicas int32) error {
 // csiHelperDeployment returns a CSI helper Deployment object.
 func (s Deployment) createCSIHelperDeployment(replicas int32) error {
 	podLabels := podLabelsForCSIHelpers(s.stos.Name, deploymentKind)
+	containers, err := s.csiHelperContainers()
+	if err != nil {
+		return err
+	}
 	spec := &appsv1.DeploymentSpec{
 		Replicas: &replicas,
 		Selector: &metav1.LabelSelector{
@@ -68,7 +76,7 @@ func (s Deployment) createCSIHelperDeployment(replicas int32) error {
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: CSIHelperSA,
-				Containers:         s.csiHelperContainers(),
+				Containers:         containers,
 				Volumes:            s.csiHelperVolumes(),
 			},
 		},
@@ -94,7 +102,7 @@ func (s Deployment) addCommonPodProperties(podSpec *corev1.PodSpec) error {
 
 // csiHelperContainers returns a list of containers that should be part of the
 // CSI helper pods.
-func (s Deployment) csiHelperContainers() []corev1.Container {
+func (s Deployment) csiHelperContainers() ([]corev1.Container, error) {
 	containers := []corev1.Container{
 		{
 			Image:           s.stos.Spec.GetCSIExternalProvisionerImage(CSIV1Supported(s.k8sVersion)),
@@ -119,7 +127,7 @@ func (s Deployment) csiHelperContainers() []corev1.Container {
 			},
 		},
 		{
-			Image:           s.stos.Spec.GetCSIExternalAttacherImage(CSIV1Supported(s.k8sVersion)),
+			Image:           s.stos.Spec.GetCSIExternalAttacherImage(CSIV1Supported(s.k8sVersion), CSIExternalAttacherV2Supported(s.k8sVersion)),
 			Name:            "csi-external-attacher",
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Args: []string{
@@ -145,7 +153,23 @@ func (s Deployment) csiHelperContainers() []corev1.Container {
 	// with the other CSI helpers.
 	// CSI v0 requires the driver registrar to be run with the driver instances
 	// only.
-	if CSIV1Supported(s.k8sVersion) {
+	// In k8s 1.13, csi-cluster-driver-registrar was required to be run along
+	// with the CSI helpers. This was responsible for the creation of CSIDriver
+	// resource belonging to the CRD csidrivers.csi.storage.k8s.io. In k8s
+	// 1.14+ this was replaced by a CSIDriver built-in resource belonging to
+	// API group csidrivers.storage.k8s.io. This is no longer automatically
+	// created. The deployment tools should create this resource.
+	//
+	// Add csi-cluster-driver-registrar if the built-in csidrivers resource is
+	// not supported by the k8s api server.
+	supportsCSIDriver, err := HasCSIDriverKind(s.discoveryClient)
+	if err != nil {
+		return containers, err
+	}
+
+	// If CSIDriver is not supported but CSI v1 is supported, run
+	// cluster-driver-registrar.
+	if !supportsCSIDriver && CSIV1Supported(s.k8sVersion) {
 		driverReg := corev1.Container{
 			Image:           s.stos.Spec.GetCSIClusterDriverRegistrarImage(),
 			Name:            "csi-driver-k8s-registrar",
@@ -180,7 +204,7 @@ func (s Deployment) csiHelperContainers() []corev1.Container {
 		containers = append(containers, driverReg)
 	}
 
-	return containers
+	return containers, nil
 }
 
 // csiHelperVolumes returns a list of volumes that should be part of the CSI

--- a/pkg/storageos/csidriver.go
+++ b/pkg/storageos/csidriver.go
@@ -1,0 +1,34 @@
+package storageos
+
+import (
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	kdiscovery "k8s.io/client-go/discovery"
+
+	"github.com/storageos/cluster-operator/internal/pkg/discovery"
+	k8sresource "github.com/storageos/cluster-operator/pkg/util/k8s/resource"
+)
+
+// createCSIDriver creates a StorageOS CSIDriver resource with the required
+// attributes.
+func (s *Deployment) createCSIDriver() error {
+	attachRequired := true
+	podInfoRequired := true
+
+	spec := &storagev1beta1.CSIDriverSpec{
+		AttachRequired: &attachRequired,
+		PodInfoOnMount: &podInfoRequired,
+	}
+
+	return k8sresource.NewCSIDriver(s.client, CSIProvisionerName, nil, spec).Create()
+}
+
+// deleteCSIDriver deletes the StorageOS CSIDriver resource.
+func (s Deployment) deleteCSIDriver() error {
+	return s.k8sResourceManager.CSIDriver(CSIProvisionerName, nil, nil).Delete()
+}
+
+// HasCSIDriverKind checks if CSIDriver built-in resource is supported in the
+// k8s cluster.
+func HasCSIDriverKind(dc kdiscovery.DiscoveryInterface) (bool, error) {
+	return discovery.HasResource(dc, k8sresource.APIstoragev1beta1, k8sresource.CSIDriverKind)
+}

--- a/pkg/storageos/delete.go
+++ b/pkg/storageos/delete.go
@@ -60,6 +60,17 @@ func (s *Deployment) Delete() error {
 	}
 
 	if s.stos.Spec.CSI.Enable {
+		// Delete CSIDriver if supported.
+		supportsCSIDriver, err := HasCSIDriverKind(s.discoveryClient)
+		if err != nil {
+			return err
+		}
+		if supportsCSIDriver {
+			if err := s.deleteCSIDriver(); err != nil {
+				return err
+			}
+		}
+
 		if err := s.deleteCSIHelper(); err != nil {
 			return err
 		}

--- a/pkg/storageos/deployment.go
+++ b/pkg/storageos/deployment.go
@@ -1,17 +1,20 @@
 package storageos
 
 import (
-	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
-	"github.com/storageos/cluster-operator/pkg/util/k8s"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+	"github.com/storageos/cluster-operator/pkg/util/k8s"
 )
 
 // Deployment stores all the resource configuration and performs
 // resource creation and update.
 type Deployment struct {
 	client             client.Client
+	discoveryClient    discovery.DiscoveryInterface
 	stos               *storageosv1.StorageOSCluster
 	recorder           record.EventRecorder
 	k8sVersion         string
@@ -24,6 +27,7 @@ type Deployment struct {
 // and an event broadcast recorder.
 func NewDeployment(
 	client client.Client,
+	discoveryClient discovery.DiscoveryInterface,
 	stos *storageosv1.StorageOSCluster,
 	labels map[string]string,
 	recorder record.EventRecorder,
@@ -32,6 +36,7 @@ func NewDeployment(
 	update bool) *Deployment {
 	return &Deployment{
 		client:             client,
+		discoveryClient:    discoveryClient,
 		stos:               stos,
 		recorder:           recorder,
 		k8sVersion:         version,

--- a/pkg/storageos/rbac.go
+++ b/pkg/storageos/rbac.go
@@ -159,7 +159,7 @@ func (s *Deployment) createClusterRoleForProvisioner() error {
 		{
 			APIGroups: []string{""},
 			Resources: []string{"persistentvolumes"},
-			Verbs:     []string{"list", "watch", "create", "delete"},
+			Verbs:     []string{"get", "list", "watch", "create", "delete"},
 		},
 		{
 			APIGroups: []string{""},
@@ -168,7 +168,7 @@ func (s *Deployment) createClusterRoleForProvisioner() error {
 		},
 		{
 			APIGroups: []string{"storage.k8s.io"},
-			Resources: []string{"storageclasses"},
+			Resources: []string{"storageclasses", "csinodes"},
 			Verbs:     []string{"list", "watch", "get"},
 		},
 		{
@@ -181,6 +181,11 @@ func (s *Deployment) createClusterRoleForProvisioner() error {
 			Resources: []string{"events"},
 			Verbs:     []string{"list", "watch", "create", "update", "patch"},
 		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"nodes"},
+			Verbs:     []string{"list", "watch", "get"},
+		},
 	}
 	return s.k8sResourceManager.ClusterRole(CSIProvisionerClusterRoleName, nil, rules).Create()
 }
@@ -190,7 +195,7 @@ func (s *Deployment) createClusterRoleForAttacher() error {
 		{
 			APIGroups: []string{""},
 			Resources: []string{"persistentvolumes"},
-			Verbs:     []string{"get", "list", "watch", "update"},
+			Verbs:     []string{"get", "list", "watch", "update", "patch"},
 		},
 		{
 			APIGroups: []string{""},
@@ -205,11 +210,11 @@ func (s *Deployment) createClusterRoleForAttacher() error {
 		{
 			APIGroups: []string{"storage.k8s.io"},
 			Resources: []string{"volumeattachments"},
-			Verbs:     []string{"get", "list", "watch", "update"},
+			Verbs:     []string{"get", "list", "watch", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"storage.k8s.io"},
-			Resources: []string{"csinodeinfos"},
+			Resources: []string{"csinodeinfos", "csinodes"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
 		{

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/storageos/cluster-operator/pkg/util/k8s/resource"
@@ -125,6 +126,11 @@ func (r ResourceManager) StorageClass(name string, labels map[string]string, pro
 // PersistentVolumeClaim returns a PersistentVolumeClaim object.
 func (r ResourceManager) PersistentVolumeClaim(name, namespace string, labels map[string]string, spec *corev1.PersistentVolumeClaimSpec) *resource.PVC {
 	return resource.NewPVC(r.client, name, namespace, r.combineLabels(labels), spec)
+}
+
+// CSIDriver returns a CSIDriver object.
+func (r ResourceManager) CSIDriver(name string, labels map[string]string, spec *storagev1beta1.CSIDriverSpec) *resource.CSIDriver {
+	return resource.NewCSIDriver(r.client, name, r.combineLabels(labels), spec)
 }
 
 func (r ResourceManager) combineLabels(labels map[string]string) map[string]string {

--- a/pkg/util/k8s/k8s_test.go
+++ b/pkg/util/k8s/k8s_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/storageos/cluster-operator/pkg/util/k8s/resource"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -14,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/storageos/cluster-operator/pkg/util/k8s/resource"
 )
 
 // TestResourceManager tests ResourceManager and the resources in the
@@ -173,6 +174,18 @@ func TestResourceManager(t *testing.T) {
 			},
 			wantResource: &corev1.PersistentVolumeClaim{},
 		},
+		// Testing this results in invalid kind even when a custom scheme is
+		// passed to the fake client. The default client-go scheme doesn't
+		// include CSIDriver.
+		// {
+		// 	name: resource.CSIDriverKind,
+		// 	create: func(rm *ResourceManager, nsName types.NamespacedName) error {
+		// 		return rm.CSIDriver(nsName.Name, nil, &storagev1beta1.CSIDriverSpec{}).Create()
+		// 	},
+		// 	delete: func(rm *ResourceManager, nsName types.NamespacedName) error {
+		// 		return rm.CSIDriver(nsName.Name, nil, nil).Delete()
+		// 	},
+		// },
 	}
 
 	for _, tc := range testcases {

--- a/pkg/util/k8s/resource/csidriver.go
+++ b/pkg/util/k8s/resource/csidriver.go
@@ -1,0 +1,70 @@
+package resource
+
+import (
+	"context"
+
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CSIDriverKind is the name of the k8s CSIDriver resource kind.
+const CSIDriverKind = "CSIDriver"
+
+// CSIDriver implements k8s.Resource interface for k8s CSIDriver resource.
+type CSIDriver struct {
+	types.NamespacedName
+	labels map[string]string
+	client client.Client
+	spec   *storagev1beta1.CSIDriverSpec
+}
+
+// NewCSIDriver returns an initialized CSIDriver.
+func NewCSIDriver(
+	c client.Client,
+	name string,
+	labels map[string]string,
+	spec *storagev1beta1.CSIDriverSpec) *CSIDriver {
+
+	return &CSIDriver{
+		NamespacedName: types.NamespacedName{
+			Name: name,
+		},
+		labels: labels,
+		client: c,
+		spec:   spec,
+	}
+}
+
+// Get returns an existing CSIDriver and an error if any.
+func (c CSIDriver) Get() (*storagev1beta1.CSIDriver, error) {
+	csiDriver := &storagev1beta1.CSIDriver{}
+	err := c.client.Get(context.TODO(), c.NamespacedName, csiDriver)
+	return csiDriver, err
+}
+
+// Create creates a CSIDriver.
+func (c CSIDriver) Create() error {
+	csiDriver := getCSIDriver(c.Name, c.labels)
+	csiDriver.Spec = *c.spec
+	return CreateOrUpdate(c.client, csiDriver)
+}
+
+// Delete deletes a CSIDriver.
+func (c CSIDriver) Delete() error {
+	return Delete(c.client, getCSIDriver(c.Name, c.labels))
+}
+
+// getCSIDriver returns a generic CSIDriver object.
+func getCSIDriver(name string, labels map[string]string) *storagev1beta1.CSIDriver {
+	return &storagev1beta1.CSIDriver{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: APIstoragev1beta1,
+			Kind:       CSIDriverKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}

--- a/pkg/util/k8s/resource/resource.go
+++ b/pkg/util/k8s/resource/resource.go
@@ -13,11 +13,12 @@ import (
 
 // k8s APIVersion constants.
 const (
-	APIv1         = "v1"
-	APIappsv1     = "apps/v1"
-	APIextv1beta1 = "extensions/v1beta1"
-	APIrbacv1     = "rbac.authorization.k8s.io/v1"
-	APIstoragev1  = "storage.k8s.io/v1"
+	APIv1             = "v1"
+	APIappsv1         = "apps/v1"
+	APIextv1beta1     = "extensions/v1beta1"
+	APIrbacv1         = "rbac.authorization.k8s.io/v1"
+	APIstoragev1      = "storage.k8s.io/v1"
+	APIstoragev1beta1 = "storage.k8s.io/v1beta1"
 )
 
 // CreateOrUpdate creates or updates an existing k8s resource.

--- a/test/e2e/clusterCSIDeployment_test.go
+++ b/test/e2e/clusterCSIDeployment_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	storageos "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
-	deploy "github.com/storageos/cluster-operator/pkg/storageos"
-	testutil "github.com/storageos/cluster-operator/test/e2e/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	storageos "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+	deploy "github.com/storageos/cluster-operator/pkg/storageos"
+	testutil "github.com/storageos/cluster-operator/test/e2e/util"
 )
 
 // TestClusterCSIDeployment test the CSI helper deployment as Deployment.
@@ -88,6 +89,9 @@ func TestClusterCSIDeployment(t *testing.T) {
 
 	// Test StorageOSCluster CR attributes.
 	testutil.StorageOSClusterCRAttributesTest(t, testutil.TestClusterCRName, namespace)
+
+	// Test CSIDriver resource existence.
+	testutil.CSIDriverResourceTest(t, deploy.CSIProvisionerName)
 
 	// Test NFSServer deployment.
 	testutil.NFSServerTest(t, ctx)

--- a/test/e2e/clusterCSI_test.go
+++ b/test/e2e/clusterCSI_test.go
@@ -84,5 +84,8 @@ func TestClusterCSI(t *testing.T) {
 		}
 	}
 
+	// Test CSIDriver resource existence.
+	testutil.CSIDriverResourceTest(t, deploy.CSIProvisionerName)
+
 	testutil.NodeLabelSyncTest(t, f.KubeClient)
 }

--- a/test/e2e/util/cluster.go
+++ b/test/e2e/util/cluster.go
@@ -12,6 +12,7 @@ import (
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	corev1 "k8s.io/api/core/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -330,4 +331,15 @@ func featureSupportAvailable(minVersion semver.Version) (bool, error) {
 
 	// Test is not supported in this version of k8s. Skip the test.
 	return false, nil
+}
+
+// CSIDriverResourceTest checks if the CSIDriver resource is created. In k8s
+// 1.14+, CSIDriver is created as part of the cluster deployment.
+func CSIDriverResourceTest(t *testing.T, driverName string) {
+	f := framework.Global
+	csiDriver := &storagev1beta1.CSIDriver{}
+	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: driverName}, csiDriver)
+	if err != nil {
+		t.Errorf("CSIDriver not found: %v", err)
+	}
 }

--- a/test/e2e/util/nfs_cluster.go
+++ b/test/e2e/util/nfs_cluster.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	kdiscovery "k8s.io/client-go/discovery"
 
 	"github.com/storageos/cluster-operator/internal/pkg/discovery"
 	storageos "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
@@ -162,5 +163,10 @@ func NFSServerTest(t *testing.T, ctx *framework.TestCtx) {
 func hasServiceMonitor() (bool, error) {
 	apiVersion := "monitoring.coreos.com/v1"
 	kind := "ServiceMonitor"
-	return discovery.HasResource(framework.Global.KubeConfig, apiVersion, kind)
+
+	dc, err := kdiscovery.NewDiscoveryClientForConfig(framework.Global.KubeConfig)
+	if err != nil {
+		return false, err
+	}
+	return discovery.HasResource(dc, apiVersion, kind)
 }


### PR DESCRIPTION
This change updates the CSI deployment to be compatible with the latest version of CSI and CSI-sidecars.

- Add CSIDriver to k8s resource manager 
- Update discovery package to use a discovery client interface instead of kube
config
- Update storageos cluster Deployment to store a discovery client. This
is used for any API resource discovery and if useful in passing a fake
discovery client for testing.
- On k8s 1.14+, CSIDriver resource is created by the operator during deployment
and csi-cluster-driver-registrar is no longer deployed with the csi-helpers.
- Update all the cluster deployment tests to use a fake discovery client
with CSIDriver resource defined in it.
- Update csi attacher and provisioner versions. Optionally use
csi-attacher v2 on k8s 1.14+.
- Add new permissions for csi-attacher and csi-provisioner.
- Add e2e test for checking CSIDriver creation.

Created new branches for the fork of external-provisioner [release-0.4-patched](https://github.com/storageos/external-provisioner/tree/release-0.4-patched) and [release-1.4-patched](https://github.com/storageos/external-provisioner/tree/release-1.4-patched) which contain all the updates. New container images for the same are `storageos/csi-provisioner:v0.4.3` and `storageos/csi-provisioner:v1.4.0`.