### PR TITLE
scheduler: replace hyperkube with kube-scheduler

### DIFF
--- a/deploy/crds/storageos_v1_storageoscluster_crd.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_crd.yaml
@@ -137,6 +137,8 @@ spec:
                   type: string
                 initContainer:
                   type: string
+                kubeSchedulerContainer:
+                  type: string
                 nfsContainer:
                   type: string
                 nodeContainer:

--- a/deploy/olm/storageos/storageoscluster.crd.yaml
+++ b/deploy/olm/storageos/storageoscluster.crd.yaml
@@ -137,6 +137,8 @@ spec:
                   type: string
                 initContainer:
                   type: string
+                kubeSchedulerContainer:
+                  type: string
                 nfsContainer:
                   type: string
                 nodeContainer:

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -146,6 +146,8 @@ data:
                         type: string
                       initContainer:
                         type: string
+                      kubeSchedulerContainer:
+                        type: string
                       nfsContainer:
                         type: string
                       nodeContainer:

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -57,6 +57,8 @@ const (
 
 	DefaultHyperkubeContainerRegistry = "gcr.io/google_containers/hyperkube"
 
+	DefaultKubeSchedulerContainerRegistry = "gcr.io/google-containers/kube-scheduler"
+
 	DefaultPluginRegistrationPath = "/var/lib/kubelet/plugins_registry"
 	OldPluginRegistrationPath     = "/var/lib/kubelet/plugins"
 
@@ -366,6 +368,17 @@ func (s StorageOSClusterSpec) GetHyperkubeImage(k8sVersion string) string {
 	return fmt.Sprintf("%s:v%s", DefaultHyperkubeContainerRegistry, k8sVersion)
 }
 
+// GetKubeSchedulerImage returns kube-scheduler container image for a given k8s
+// version. If an image is set explicitly in the cluster configuration, that
+// image is returned.
+func (s StorageOSClusterSpec) GetKubeSchedulerImage(k8sVersion string) string {
+	if s.Images.KubeSchedulerContainer != "" {
+		return s.Images.KubeSchedulerContainer
+	}
+	// Add version prefix "v" in the tag.
+	return fmt.Sprintf("%s:v%s", DefaultKubeSchedulerContainerRegistry, k8sVersion)
+}
+
 // GetNFSServerImage returns NFS server container image used as the default
 // image in the cluster.
 func (s StorageOSClusterSpec) GetNFSServerImage() string {
@@ -529,6 +542,7 @@ type ContainerImages struct {
 	CSIExternalAttacherContainer       string `json:"csiExternalAttacherContainer,omitempty"`
 	CSILivenessProbeContainer          string `json:"csiLivenessProbeContainer,omitempty"`
 	HyperkubeContainer                 string `json:"hyperkubeContainer,omitempty"`
+	KubeSchedulerContainer             string `json:"kubeSchedulerContainer,omitempty"`
 	NFSContainer                       string `json:"nfsContainer,omitempty"`
 }
 

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -323,7 +323,7 @@ func (r *ReconcileStorageOSCluster) updateSpec(m *storageosv1.StorageOSCluster) 
 	}
 
 	if !m.Spec.DisableScheduler {
-		properties[&m.Spec.Images.HyperkubeContainer] = m.Spec.GetHyperkubeImage(r.k8sVersion)
+		properties[&m.Spec.Images.KubeSchedulerContainer] = m.Spec.GetKubeSchedulerImage(r.k8sVersion)
 	}
 
 	if m.Spec.CSI.Enable {

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -84,7 +84,7 @@ func (s Deployment) createSchedulerDeployment(replicas int32) error {
 func (s Deployment) schedulerContainers() []corev1.Container {
 	return []corev1.Container{
 		{
-			Image:           s.stos.Spec.GetHyperkubeImage(s.k8sVersion),
+			Image:           s.stos.Spec.GetKubeSchedulerImage(s.k8sVersion),
 			Name:            "storageos-scheduler",
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Args: []string{


### PR DESCRIPTION
Replace the hyperkube container image for deploying scheduler with
kube-scheduler container image. It's very small in size compared to a
hyperkube image.

```
REPOSITORY                                TAG                 IMAGE ID            CREATED             SIZE
gcr.io/google_containers/hyperkube        v1.17.0             06fad8e48222        3 weeks ago         855MB
gcr.io/google-containers/kube-scheduler   v1.17.0             78c190f736b1        3 weeks ago         94.4MB
```