### PR TITLE
Add container image env vars in deployment manifest

### DIFF
--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -383,6 +383,32 @@ spec:
                 - cluster-operator
                 image: registry.connect.redhat.com/storageos/cluster-operator:1.5.2
                 env:
+                - name: RELATED_IMAGE_STORAGEOS_NODE
+                  value: ""
+                - name: RELATED_IMAGE_STORAGEOS_INIT
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_CLUSTER_DRIVER_REGISTRAR
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_NODE_DRIVER_REGISTRAR
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_PROVISIONER
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_LIVENESS_PROBE
+                  value: ""
+                - name: RELATED_IMAGE_CSIV0_DRIVER_REGISTRAR
+                  value: ""
+                - name: RELATED_IMAGE_CSIV0_EXTERNAL_PROVISIONER
+                  value: ""
+                - name: RELATED_IMAGE_CSIV0_EXTERNAL_ATTACHER
+                  value: ""
+                - name: RELATED_IMAGE_NFS
+                  value: ""
+                - name: RELATED_IMAGE_KUBE_SCHEDULER
+                  value: ""
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -382,6 +382,32 @@ spec:
                 - cluster-operator
                 image: storageos/cluster-operator:1.5.2
                 env:
+                - name: RELATED_IMAGE_STORAGEOS_NODE
+                  value: ""
+                - name: RELATED_IMAGE_STORAGEOS_INIT
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_CLUSTER_DRIVER_REGISTRAR
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_NODE_DRIVER_REGISTRAR
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_PROVISIONER
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_LIVENESS_PROBE
+                  value: ""
+                - name: RELATED_IMAGE_CSIV0_DRIVER_REGISTRAR
+                  value: ""
+                - name: RELATED_IMAGE_CSIV0_EXTERNAL_PROVISIONER
+                  value: ""
+                - name: RELATED_IMAGE_CSIV0_EXTERNAL_ATTACHER
+                  value: ""
+                - name: RELATED_IMAGE_NFS
+                  value: ""
+                - name: RELATED_IMAGE_KUBE_SCHEDULER
+                  value: ""
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -33,6 +33,32 @@ spec:
           - cluster-operator
           imagePullPolicy: IfNotPresent
           env:
+            - name: RELATED_IMAGE_STORAGEOS_NODE
+              value: ""
+            - name: RELATED_IMAGE_STORAGEOS_INIT
+              value: ""
+            - name: RELATED_IMAGE_CSIV1_CLUSTER_DRIVER_REGISTRAR
+              value: ""
+            - name: RELATED_IMAGE_CSIV1_NODE_DRIVER_REGISTRAR
+              value: ""
+            - name: RELATED_IMAGE_CSIV1_EXTERNAL_PROVISIONER
+              value: ""
+            - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER
+              value: ""
+            - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2
+              value: ""
+            - name: RELATED_IMAGE_CSIV1_LIVENESS_PROBE
+              value: ""
+            - name: RELATED_IMAGE_CSIV0_DRIVER_REGISTRAR
+              value: ""
+            - name: RELATED_IMAGE_CSIV0_EXTERNAL_PROVISIONER
+              value: ""
+            - name: RELATED_IMAGE_CSIV0_EXTERNAL_ATTACHER
+              value: ""
+            - name: RELATED_IMAGE_NFS
+              value: ""
+            - name: RELATED_IMAGE_KUBE_SCHEDULER
+              value: ""
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -994,6 +994,32 @@ data:
                       - cluster-operator
                       image: storageos/cluster-operator:test
                       env:
+                      - name: RELATED_IMAGE_STORAGEOS_NODE
+                        value: ""
+                      - name: RELATED_IMAGE_STORAGEOS_INIT
+                        value: ""
+                      - name: RELATED_IMAGE_CSIV1_CLUSTER_DRIVER_REGISTRAR
+                        value: ""
+                      - name: RELATED_IMAGE_CSIV1_NODE_DRIVER_REGISTRAR
+                        value: ""
+                      - name: RELATED_IMAGE_CSIV1_EXTERNAL_PROVISIONER
+                        value: ""
+                      - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER
+                        value: ""
+                      - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2
+                        value: ""
+                      - name: RELATED_IMAGE_CSIV1_LIVENESS_PROBE
+                        value: ""
+                      - name: RELATED_IMAGE_CSIV0_DRIVER_REGISTRAR
+                        value: ""
+                      - name: RELATED_IMAGE_CSIV0_EXTERNAL_PROVISIONER
+                        value: ""
+                      - name: RELATED_IMAGE_CSIV0_EXTERNAL_ATTACHER
+                        value: ""
+                      - name: RELATED_IMAGE_NFS
+                        value: ""
+                      - name: RELATED_IMAGE_KUBE_SCHEDULER
+                        value: ""
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -16,6 +16,13 @@ The release requires
 checked-in before `version` is tagged. These files should have the container
 image set to tag `version`.
 
+NOTE: The CSV must have related images in the operator deployment as environment
+variables. Unlike before, the default version of StorageOS node container image
+must be set in the CSV file. When there's a new version of node container, or
+any other container images, update release-gen.sh with the new node container
+tag in the operator changes template, before running the following release
+generator command. Image update should apply to both operatorhub and rhel CSVs.
+
 To create the CSV files and update all the associated files with the new release
 version, run `NEW_VERSION=<version> make release`. This will run
 `release-gen.sh`, updating all the intermediate files(`*-changes.yaml`) that are

--- a/internal/pkg/image/doc.go
+++ b/internal/pkg/image/doc.go
@@ -1,0 +1,4 @@
+// Package image contains the default container images, environment
+// variables for the default images and helper functions to select the
+// appropriate image.
+package image

--- a/internal/pkg/image/image.go
+++ b/internal/pkg/image/image.go
@@ -1,0 +1,53 @@
+package image
+
+import "os"
+
+// Default image constant variables.
+const (
+	DefaultNodeContainerImage                 = "storageos/node:1.5.2"
+	DefaultInitContainerImage                 = "storageos/init:1.0.0"
+	CSIv1ClusterDriverRegistrarContainerImage = "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1"
+	CSIv1NodeDriverRegistrarContainerImage    = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+	CSIv1ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v1.4.0"
+	CSIv1ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v1.2.1"
+	CSIv1ExternalAttacherv2ContainerImage     = "quay.io/k8scsi/csi-attacher:v2.0.0"
+	CSIv1LivenessProbeContainerImage          = "quay.io/k8scsi/livenessprobe:v1.1.0"
+	CSIv0DriverRegistrarContainerImage        = "quay.io/k8scsi/driver-registrar:v0.4.2"
+	CSIv0ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v0.4.3"
+	CSIv0ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v0.4.2"
+	DefaultNFSContainerImage                  = "storageos/nfs:1.0.0"
+
+	DefaultHyperkubeContainerRegistry = "gcr.io/google_containers/hyperkube"
+
+	DefaultKubeSchedulerContainerRegistry = "gcr.io/google-containers/kube-scheduler"
+)
+
+// Environment variables for setting default images.
+const (
+	StorageOSNodeImageEnvVar = "RELATED_IMAGE_STORAGEOS_NODE"
+	StorageOSInitImageEnvVar = "RELATED_IMAGE_STORAGEOS_INIT"
+
+	CSIv1ClusterDriverRegistrarImageEnvVar = "RELATED_IMAGE_CSIV1_CLUSTER_DRIVER_REGISTRAR"
+	CSIv1NodeDriverRegistrarImageEnvVar    = "RELATED_IMAGE_CSIV1_NODE_DRIVER_REGISTRAR"
+	CSIv1ExternalProvisionerImageEnvVar    = "RELATED_IMAGE_CSIV1_EXTERNAL_PROVISIONER"
+	CSIv1ExternalAttacherImageEnvVar       = "RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER"
+	CSIv1ExternalAttacherv2ImageEnvVar     = "RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2"
+	CSIv1LivenessProbeImageEnvVar          = "RELATED_IMAGE_CSIV1_LIVENESS_PROBE"
+
+	CSIv0DriverRegistrarImageEnvVar     = "RELATED_IMAGE_CSIV0_DRIVER_REGISTRAR"
+	CSIv0ExternalProvisionerImageEnvVar = "RELATED_IMAGE_CSIV0_EXTERNAL_PROVISIONER"
+	CSIv0ExternalAttacherImageEnvVar    = "RELATED_IMAGE_CSIV0_EXTERNAL_ATTACHER"
+
+	NFSImageEnvVar           = "RELATED_IMAGE_NFS"
+	KubeSchedulerImageEnvVar = "RELATED_IMAGE_KUBE_SCHEDULER"
+)
+
+// GetDefaultImage checks the environment variable for an image. If not found,
+// it returns a default image.
+func GetDefaultImage(imageEnvVar, defaultImage string) string {
+	img := os.Getenv(imageEnvVar)
+	if img != "" {
+		return img
+	}
+	return defaultImage
+}

--- a/internal/pkg/image/image_test.go
+++ b/internal/pkg/image/image_test.go
@@ -1,0 +1,88 @@
+package image
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetDefaultImage(t *testing.T) {
+	fakeNFSDefaultImage := "nfs/foo:1"
+	fakeStorageOSNodeImage := "stos/foo:1"
+
+	testcases := []struct {
+		name          string
+		envVars       map[string]string
+		defaultImages map[string]string
+		wantImages    map[string]string
+	}{
+		{
+			name: "images from env vars",
+			envVars: map[string]string{
+				NFSImageEnvVar:           fakeNFSDefaultImage,
+				StorageOSNodeImageEnvVar: fakeStorageOSNodeImage,
+			},
+			defaultImages: map[string]string{
+				NFSImageEnvVar:           DefaultNFSContainerImage,
+				StorageOSNodeImageEnvVar: DefaultNodeContainerImage,
+			},
+			wantImages: map[string]string{
+				NFSImageEnvVar:           fakeNFSDefaultImage,
+				StorageOSNodeImageEnvVar: fakeStorageOSNodeImage,
+			},
+		},
+		{
+			name:    "images not in env var",
+			envVars: map[string]string{},
+			defaultImages: map[string]string{
+				NFSImageEnvVar:           DefaultNFSContainerImage,
+				StorageOSNodeImageEnvVar: DefaultNodeContainerImage,
+			},
+			wantImages: map[string]string{
+				NFSImageEnvVar:           DefaultNFSContainerImage,
+				StorageOSNodeImageEnvVar: DefaultNodeContainerImage,
+			},
+		},
+		{
+			name: "some images in env var and some defaults",
+			envVars: map[string]string{
+				NFSImageEnvVar:           fakeNFSDefaultImage,
+				StorageOSNodeImageEnvVar: fakeStorageOSNodeImage,
+			},
+			defaultImages: map[string]string{
+				NFSImageEnvVar:                DefaultNFSContainerImage,
+				StorageOSNodeImageEnvVar:      DefaultNodeContainerImage,
+				CSIv1LivenessProbeImageEnvVar: CSIv1LivenessProbeContainerImage,
+			},
+			wantImages: map[string]string{
+				NFSImageEnvVar:                fakeNFSDefaultImage,
+				StorageOSNodeImageEnvVar:      fakeStorageOSNodeImage,
+				CSIv1LivenessProbeImageEnvVar: CSIv1LivenessProbeContainerImage,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Set the env vars.
+			for k, v := range tc.envVars {
+				os.Setenv(k, v)
+			}
+
+			// Unset the env vars at the end.
+			defer func() {
+				for k := range tc.envVars {
+					os.Unsetenv(k)
+				}
+			}()
+
+			// Get the default images and check.
+			for k, v := range tc.wantImages {
+				got := GetDefaultImage(k, tc.defaultImages[k])
+				if v != got {
+					t.Errorf("unexpected default images for %s:\n\t(WNT) %s\n\t(GOT) %s", k, v, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -6,6 +6,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/storageos/cluster-operator/internal/pkg/image"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -41,23 +43,6 @@ const (
 	DefaultServiceInternalPort = 5705
 
 	DefaultIngressHostname = "storageos.local"
-
-	DefaultNodeContainerImage                 = "storageos/node:1.5.2"
-	DefaultInitContainerImage                 = "storageos/init:1.0.0"
-	CSIv1ClusterDriverRegistrarContainerImage = "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1"
-	CSIv1NodeDriverRegistrarContainerImage    = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
-	CSIv1ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v1.4.0"
-	CSIv1ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v1.2.1"
-	CSIv1ExternalAttacherv2ContainerImage     = "quay.io/k8scsi/csi-attacher:v2.0.0"
-	CSIv1LivenessProbeContainerImage          = "quay.io/k8scsi/livenessprobe:v1.1.0"
-	CSIv0DriverRegistrarContainerImage        = "quay.io/k8scsi/driver-registrar:v0.4.2"
-	CSIv0ExternalProvisionerContainerImage    = "storageos/csi-provisioner:v0.4.3"
-	CSIv0ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v0.4.2"
-	DefaultNFSContainerImage                  = "storageos/nfs:1.0.0"
-
-	DefaultHyperkubeContainerRegistry = "gcr.io/google_containers/hyperkube"
-
-	DefaultKubeSchedulerContainerRegistry = "gcr.io/google-containers/kube-scheduler"
 
 	DefaultPluginRegistrationPath = "/var/lib/kubelet/plugins_registry"
 	OldPluginRegistrationPath     = "/var/lib/kubelet/plugins"
@@ -291,7 +276,7 @@ func (s StorageOSClusterSpec) GetNodeContainerImage() string {
 	if s.Images.NodeContainer != "" {
 		return s.Images.NodeContainer
 	}
-	return DefaultNodeContainerImage
+	return image.GetDefaultImage(image.StorageOSNodeImageEnvVar, image.DefaultNodeContainerImage)
 }
 
 // GetInitContainerImage returns init container image.
@@ -299,7 +284,7 @@ func (s StorageOSClusterSpec) GetInitContainerImage() string {
 	if s.Images.InitContainer != "" {
 		return s.Images.InitContainer
 	}
-	return DefaultInitContainerImage
+	return image.GetDefaultImage(image.StorageOSInitImageEnvVar, image.DefaultInitContainerImage)
 }
 
 // GetCSINodeDriverRegistrarImage returns CSI node driver registrar container image.
@@ -308,9 +293,9 @@ func (s StorageOSClusterSpec) GetCSINodeDriverRegistrarImage(csiv1 bool) string 
 		return s.Images.CSINodeDriverRegistrarContainer
 	}
 	if csiv1 {
-		return CSIv1NodeDriverRegistrarContainerImage
+		return image.GetDefaultImage(image.CSIv1NodeDriverRegistrarImageEnvVar, image.CSIv1NodeDriverRegistrarContainerImage)
 	}
-	return CSIv0DriverRegistrarContainerImage
+	return image.GetDefaultImage(image.CSIv0DriverRegistrarImageEnvVar, image.CSIv0DriverRegistrarContainerImage)
 }
 
 // GetCSIClusterDriverRegistrarImage returns CSI cluster driver registrar
@@ -319,7 +304,7 @@ func (s StorageOSClusterSpec) GetCSIClusterDriverRegistrarImage() string {
 	if s.Images.CSIClusterDriverRegistrarContainer != "" {
 		return s.Images.CSIClusterDriverRegistrarContainer
 	}
-	return CSIv1ClusterDriverRegistrarContainerImage
+	return image.GetDefaultImage(image.CSIv1ClusterDriverRegistrarImageEnvVar, image.CSIv1ClusterDriverRegistrarContainerImage)
 }
 
 // GetCSIExternalProvisionerImage returns CSI external provisioner container image.
@@ -328,9 +313,9 @@ func (s StorageOSClusterSpec) GetCSIExternalProvisionerImage(csiv1 bool) string 
 		return s.Images.CSIExternalProvisionerContainer
 	}
 	if csiv1 {
-		return CSIv1ExternalProvisionerContainerImage
+		return image.GetDefaultImage(image.CSIv1ExternalProvisionerImageEnvVar, image.CSIv1ExternalProvisionerContainerImage)
 	}
-	return CSIv0ExternalProvisionerContainerImage
+	return image.GetDefaultImage(image.CSIv0ExternalProvisionerImageEnvVar, image.CSIv0ExternalProvisionerContainerImage)
 }
 
 // GetCSIExternalAttacherImage returns CSI external attacher container image.
@@ -342,11 +327,11 @@ func (s StorageOSClusterSpec) GetCSIExternalAttacherImage(csiv1 bool, attacherv2
 	}
 	if csiv1 {
 		if attacherv2Supported {
-			return CSIv1ExternalAttacherv2ContainerImage
+			return image.GetDefaultImage(image.CSIv1ExternalAttacherv2ImageEnvVar, image.CSIv1ExternalAttacherv2ContainerImage)
 		}
-		return CSIv1ExternalAttacherContainerImage
+		return image.GetDefaultImage(image.CSIv1ExternalAttacherImageEnvVar, image.CSIv1ExternalAttacherContainerImage)
 	}
-	return CSIv0ExternalAttacherContainerImage
+	return image.GetDefaultImage(image.CSIv0ExternalAttacherImageEnvVar, image.CSIv0ExternalAttacherContainerImage)
 }
 
 // GetCSILivenessProbeImage returns CSI liveness probe container image.
@@ -354,7 +339,7 @@ func (s StorageOSClusterSpec) GetCSILivenessProbeImage() string {
 	if s.Images.CSILivenessProbeContainer != "" {
 		return s.Images.CSILivenessProbeContainer
 	}
-	return CSIv1LivenessProbeContainerImage
+	return image.GetDefaultImage(image.CSIv1LivenessProbeImageEnvVar, image.CSIv1LivenessProbeContainerImage)
 }
 
 // GetHyperkubeImage returns hyperkube container image for a given k8s version.
@@ -364,8 +349,11 @@ func (s StorageOSClusterSpec) GetHyperkubeImage(k8sVersion string) string {
 	if s.Images.HyperkubeContainer != "" {
 		return s.Images.HyperkubeContainer
 	}
+
+	// NOTE: Hyperkube is not being used anywhere for now. Hyperkube image is
+	// not available to be set via environment variable.
 	// Add version prefix "v" in the tag.
-	return fmt.Sprintf("%s:v%s", DefaultHyperkubeContainerRegistry, k8sVersion)
+	return fmt.Sprintf("%s:v%s", image.DefaultHyperkubeContainerRegistry, k8sVersion)
 }
 
 // GetKubeSchedulerImage returns kube-scheduler container image for a given k8s
@@ -375,8 +363,16 @@ func (s StorageOSClusterSpec) GetKubeSchedulerImage(k8sVersion string) string {
 	if s.Images.KubeSchedulerContainer != "" {
 		return s.Images.KubeSchedulerContainer
 	}
+
+	// Kube-scheduler image is dynamically selected based on the k8s version.
+	// We create an image name for a fallback image based on the k8s version.
+	// If kube-scheduler image is not specified in the environment variable, the
+	// fallback image is used.
+
 	// Add version prefix "v" in the tag.
-	return fmt.Sprintf("%s:v%s", DefaultKubeSchedulerContainerRegistry, k8sVersion)
+	fallbackImage := fmt.Sprintf("%s:v%s", image.DefaultKubeSchedulerContainerRegistry, k8sVersion)
+
+	return image.GetDefaultImage(image.KubeSchedulerImageEnvVar, fallbackImage)
 }
 
 // GetNFSServerImage returns NFS server container image used as the default
@@ -385,7 +381,7 @@ func (s StorageOSClusterSpec) GetNFSServerImage() string {
 	if s.Images.NFSContainer != "" {
 		return s.Images.NFSContainer
 	}
-	return DefaultNFSContainerImage
+	return image.GetDefaultImage(image.NFSImageEnvVar, image.DefaultNFSContainerImage)
 }
 
 // GetServiceName returns the service name.

--- a/pkg/controller/nfsserver/nfsserver_controller_test.go
+++ b/pkg/controller/nfsserver/nfsserver_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/storageos/cluster-operator/internal/pkg/image"
 	storageosapis "github.com/storageos/cluster-operator/pkg/apis"
 	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 )
@@ -67,7 +68,7 @@ func TestUpdateSpec(t *testing.T) {
 			wantNFSServer: getTestNFSServer("nfs1", "default",
 				storageosv1.NFSServerSpec{
 					StorageClassName: "fast",
-					NFSContainer:     storageosv1.DefaultNFSContainerImage,
+					NFSContainer:     image.DefaultNFSContainerImage,
 				},
 				emptyNFSStatus,
 			),
@@ -101,7 +102,7 @@ func TestUpdateSpec(t *testing.T) {
 				"nfs1", "default",
 				storageosv1.NFSServerSpec{
 					StorageClassName: "fast",
-					NFSContainer:     storageosv1.DefaultNFSContainerImage,
+					NFSContainer:     image.DefaultNFSContainerImage,
 				}, emptyNFSStatus),
 			wantUpdate: false,
 		},

--- a/scripts/release-helpers/release-gen.sh
+++ b/scripts/release-helpers/release-gen.sh
@@ -58,6 +58,18 @@ metadata.namespace: placeholder
 metadata.annotations.containerImage: storageos/cluster-operator:$NEW_VERSION
 spec.version: $NEW_VERSION
 spec.install.spec.deployments[0].spec.template.spec.containers[0].image: storageos/cluster-operator:$NEW_VERSION
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[0].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[1].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[2].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[3].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[4].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[5].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[6].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[7].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[8].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[9].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[10].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[11].value:
 spec.replaces: storageosoperator.v$PREV_VERSION
 EOF
 echo
@@ -139,6 +151,18 @@ metadata.annotations.alm-examples: |-
 
 spec.version: $NEW_VERSION
 spec.install.spec.deployments[0].spec.template.spec.containers[0].image: registry.connect.redhat.com/storageos/cluster-operator:$NEW_VERSION
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[0].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[1].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[2].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[3].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[4].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[5].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[6].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[7].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[8].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[9].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[10].value:
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[11].value:
 spec.customresourcedefinitions.owned[2].specDescriptors[0].description: The StorageOS Node image to upgrade to. e.g. \`registry.connect.redhat.com/storageos/node:latest\`
 spec.replaces: storageosoperator.v$PREV_VERSION
 EOF


### PR DESCRIPTION
Operator marketplaces require providing a way to set the related image used by the operator in the operator's deployment manifest as per https://github.com/zachncst/om-env-example/blob/master/README.md . In the [examples](https://github.com/zachncst/om-env-example/blob/master/ubi-noop-go/pkg/controller/ubinoop/ubinoop_controller.go#L142-L145), default fallback image is still kept and not removed from the operator.

This change creates a new package `internal/pkg/image` and moves all the default container image constants to this packages. It also defines env vars for the default container images. The default image constants will now be used as a fallback when the env var image defaults are not set.

With this, the container images used in StorageOS deployment can be set in two different places. The operator's deployment manifest can be used to set the default images. But these defaults can be overridden by StorageOSCluster CR `spec.images` property. When none of these are set, the default fallback images are used.

Since kube-scheduler image is dynamically selected, if it is set in the env var or StorageOSCluster CR, that will be used, else, a dynamic image will be used based on the k8s version.

The latest CSV files have empty values for those image env vars at the moment. When the release-gen.sh script is run for the next release generation, they will be filled with the appropriate image env var values.
