### PR TITLE
Add ConfigMap support and new deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build/yq
 deploy/test
 /olm
 storageos-operator.yaml
+cluster-operator.tar
+pf.log
+
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -133,7 +133,7 @@ func main() {
 		// Configure a pod scheduler webhook handler with StorageOS provisioner
 		// and scheduler.
 		webhookHandler := &scheduler.PodSchedulerSetter{
-			Provisioners:           []string{storageos.CSIProvisionerName, storageos.IntreeProvisionerName},
+			Provisioners:           []string{storageos.CSIProvisionerName, storageos.IntreeProvisionerName, storageos.StorageOSProvisionerName},
 			SchedulerName:          storageos.SchedulerExtenderName,
 			SchedulerAnnotationKey: podSchedulerAnnotationKey,
 		}

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -60,7 +60,7 @@ const (
 )
 
 func getDefaultCSIEndpoint(pluginRegistrationPath string) string {
-	return fmt.Sprintf("%s%s%s", "unix:/", pluginRegistrationPath, DefaultCSIEndpoint)
+	return fmt.Sprintf("%s%s%s", "unix://", pluginRegistrationPath, DefaultCSIEndpoint)
 }
 
 func getDefaultCSIPluginDir(pluginRegistrationPath string) string {

--- a/pkg/storageos/configmap.go
+++ b/pkg/storageos/configmap.go
@@ -1,0 +1,295 @@
+package storageos
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+)
+
+const (
+
+	// External ETCD config, V1 only.
+	kvBackendEnvVar = "KV_BACKEND"
+	kvAddrEnvVar    = "KV_ADDR"
+	joinEnvVar      = "JOIN"
+
+	// Comma separated list of endpoints on which we will try to connect to the
+	// cluster's ETCD instances.
+	etcdEndpointsEnvVar = "ETCD_ENDPOINTS"
+
+	// TODO: ETCD TLS configuration information. The key/cert/CA need to be PEM encoded
+	// DER bytes
+	v1EtcdTLSClientKeyEnvVar  = "TLS_ETCD_CLIENT_KEY"
+	v1EtcdTLSClientCertEnvVar = "TLS_ETCD_CLIENT_CERT"
+	v1EtcdTLSClientCAEnvVar   = "TLS_ETCD_CA"
+	v2EtcdTLSClientKeyEnvVar  = "ETCD_TLS_CLIENT_KEY"
+	v2EtcdTLSClientCertEnvVar = "ETCD_TLS_CLIENT_CERT"
+	v2EtcdTLSClientCAEnvVar   = "ETCD_TLS_CLIENT_CA"
+
+	// TODO: ETCD authentication information
+	etcdUsernameEnvVar = "ETCD_USERNAME"
+	etcdPasswordEnvVar = "ETCD_PASSWORD"
+
+	// TODO: ETCD namespace in which to operate. All keys in ETCD will be prefixed by
+	// this value, allowing for multiple clusters to operate on the same ETCD
+	// instance.
+	etcdNamespaceEnvVar = "ETCD_NAMESPACE"
+
+	// Feature flags (enabled by default)
+	disableFencingEnvVar = "DISABLE_FENCING"
+	disableTCMUEnvVar    = "DISABLE_TCMU"
+	forceTCMUEnvVar      = "FORCE_TCMU"
+
+	// When set to TRUE usage data will not be logged on StorageOS servers.
+	disableTelemetryEnvVar = "DISABLE_TELEMETRY"
+
+	// When set to TRUE cluster bugs will not be logged on StorageOS servers.
+	disableCrashReportingEnvVar = "DISABLE_CRASH_REPORTING"
+
+	// When set to TRUE checks for available updates will not be carried out
+	// against StorageOS servers.
+	disableVersionCheckEnvVar = "DISABLE_VERSION_CHECK"
+
+	// Namespace in which storageos operates.
+	v1NamespaceEnvVar = "NAMESPACE"
+	v2NamespaceEnvVar = "K8S_NAMESPACE"
+
+	// The kubernetes distribution in which storageos is operating.
+	k8sDistroEnvVar = "K8S_DISTRO"
+
+	// Enables the API's kubernetes specific scheduler extender endpoints.
+	k8sSchedulerExtenderEnvVar = "K8S_ENABLE_SCHEDULER_EXTENDER"
+
+	// TODO: Path to kubernetes config file.
+	kubconfigPathEnvVar = "KUBECONFIG"
+
+	// CSI API listen socket location.  CSI is disabled if not set.
+	csiEndpointEnvVar = "CSI_ENDPOINT"
+
+	// CSI version to use, if CSI_ENDPOINT is set.
+	csiVersionEnvVar = "CSI_VERSION"
+
+	// Directory in which devices are created.
+	deviceDirEnvVar = "DEVICE_DIR"
+
+	// TODO: add to StorageOSCluster CR and optionally create Certificate CR?
+	// https://cert-manager.io/docs/usage/certificate/ Since secrets will be
+	// used, probably needs to be implemented in DaemonSet.
+	apiTLSCAEnvVar   = "API_TLS_CA"
+	apiTLSKeyEnvVar  = "API_TLS_KEY"
+	apiTLSCertEnvVar = "API_TLS_CERT"
+
+	// TODO: add to StorageOSCluster CR
+	// Health checking duration values
+	//
+	// A duration string is a possibly signed sequence of decimal numbers, each
+	// with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
+	// "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	healthProbeIntervalEnvVar = "HEALTH_PROBE_INTERVAL"
+	healthProbeTimeoutEnvVar  = "HEALTH_PROBE_TIMEOUT"
+	healthGracePeriodEnvVar   = "HEALTH_GRACE_PERIOD"
+
+	// Node capacity update interval.
+	nodeCapacityUpdateIntervalEnvVar = "NODE_CAPACITY_INTERVAL"
+
+	// TODO: General dial timeout settings (RPC, etcd...)
+	//
+	// A duration string is a possibly signed sequence of decimal numbers, each
+	// with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
+	// "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	//
+	// defaults to 5s.
+	dialTimeoutEnvVar = "DIAL_TIMEOUT"
+
+	// Logging level: debug, info, warn or error.
+	logLevelEnvVar = "LOG_LEVEL"
+
+	// Logger format: text or json.
+	logFormatEnvVar = "LOG_FORMAT"
+
+	// Etcd TLS cert file names.
+	tlsEtcdCA         = "etcd-client-ca.crt"
+	tlsEtcdClientCert = "etcd-client.crt"
+	tlsEtcdClientKey  = "etcd-client.key"
+
+	// Etcd cert root path.
+	tlsEtcdRootPath = "/run/storageos/pki"
+
+	// Etcd certs volume name.
+	tlsEtcdCertsVolume = "etcd-certs"
+)
+
+// createService creates a ConfigMap to store the node container configuration.
+func (s *Deployment) createConfigMap() error {
+
+	config := configFromSpec(s.stos.Spec, CSIV1Supported(s.k8sVersion), s.nodev2)
+
+	labels := make(map[string]string)
+
+	if err := s.k8sResourceManager.ConfigMap(configmapName, s.stos.Spec.GetResourceNS(), labels, config).Create(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// configFromSpec generates config entries for the given major version of the
+// node container and CSI spec required.
+//
+//     Config set in DaemonSet env vars:
+//       - HOSTNAME (reads from spec.nodeName)
+//       - ADVERTISE_IP (reads from status.podIP)
+//       - BOOTSTRAP_USERNAME, BOOTSTRAP_PASSWORD (reads from secret)
+func configFromSpec(spec storageosv1.StorageOSClusterSpec, csiv1 bool, nodev2 bool) map[string]string {
+	if nodev2 {
+		return v2ConfigFromSpec(spec)
+	}
+	return v1ConfigFromSpec(spec, csiv1)
+}
+
+func v1ConfigFromSpec(spec storageosv1.StorageOSClusterSpec, csiv1 bool) map[string]string {
+	config := make(map[string]string)
+
+	// Etcd endpoint, and join for V1.
+	// Join must be set.
+	config[joinEnvVar] = spec.Join
+
+	// If external etcd is enabled, KV_BACKEND must be set to "etcd" and
+	// KV_ADDRESS set to a comma separated list of endpoints.
+	if spec.KVBackend.Backend != "" {
+		config[kvBackendEnvVar] = spec.KVBackend.Backend
+	}
+	if spec.KVBackend.Address != "" {
+		config[kvAddrEnvVar] = spec.KVBackend.Address
+	}
+
+	// Append Etcd TLS config, if given.  Volumes are created in Podspec.
+	if spec.TLSEtcdSecretRefName != "" && spec.TLSEtcdSecretRefNamespace != "" {
+		config = addEtcdTLSConfig(config, false)
+	}
+
+	// Always show telemetry and feature options to ensure they're visble.
+	config[disableTelemetryEnvVar] = strconv.FormatBool(spec.DisableTelemetry)
+
+	// Features
+	config[disableFencingEnvVar] = strconv.FormatBool(spec.DisableFencing)
+
+	// DISABLE_TCMU and FORCE_TCMU should not be set unless under advice from
+	// support.  Only show the vars if set.
+	if spec.DisableTCMU {
+		config[disableTCMUEnvVar] = strconv.FormatBool(spec.DisableTCMU)
+	}
+	if spec.ForceTCMU {
+		config[forceTCMUEnvVar] = strconv.FormatBool(spec.ForceTCMU)
+	}
+
+	config[v1NamespaceEnvVar] = spec.GetResourceNS()
+
+	if spec.K8sDistro != "" {
+		config[k8sDistroEnvVar] = spec.K8sDistro
+	}
+
+	// CSI is optional in V1.
+	if spec.CSI.Enable {
+		config[csiEndpointEnvVar] = spec.GetCSIEndpoint(csiv1)
+		config[csiVersionEnvVar] = spec.GetCSIVersion(csiv1)
+	}
+
+	// Since we're running in k8s, always listen on the the scheduler extender
+	// api endpoints.  The feature can be disabled with the operator.  This
+	// allows users to toggle the feature without restarting the cluster.
+	config[k8sSchedulerExtenderEnvVar] = "true"
+
+	// If kubelet is running in a container, sharedDir should be set.
+	if spec.SharedDir != "" {
+		config[deviceDirEnvVar] = fmt.Sprintf("%s/devices", spec.SharedDir)
+	}
+
+	config[logFormatEnvVar] = "text"
+	config[logLevelEnvVar] = "info"
+	if spec.Debug {
+		config[logLevelEnvVar] = debugVal
+	}
+
+	return config
+}
+
+func v2ConfigFromSpec(spec storageosv1.StorageOSClusterSpec) map[string]string {
+	config := make(map[string]string)
+
+	// ETCD_ENDPOINTS must be set to a comma separated list of endpoints.
+	config[etcdEndpointsEnvVar] = spec.KVBackend.Address
+
+	// Append Etcd TLS config, if given.  Volumes are created in Podspec.
+	if spec.TLSEtcdSecretRefName != "" && spec.TLSEtcdSecretRefNamespace != "" {
+		config = addEtcdTLSConfig(config, true)
+	}
+
+	// Always show telemetry and feature options to ensure they're visble.
+	config[disableTelemetryEnvVar] = strconv.FormatBool(spec.DisableTelemetry)
+
+	// TODO: separte CR items for version check and crash reports.  Use
+	// Telemetry to enable/disable everything for now.
+	config[disableVersionCheckEnvVar] = strconv.FormatBool(spec.DisableTelemetry)
+	config[disableCrashReportingEnvVar] = strconv.FormatBool(spec.DisableTelemetry)
+
+	// DISABLE_TCMU and FORCE_TCMU should not be set unless under advice from
+	// support.  Only show the vars if set.
+	if spec.DisableTCMU {
+		config[disableTCMUEnvVar] = strconv.FormatBool(spec.DisableTCMU)
+	}
+	if spec.ForceTCMU {
+		config[forceTCMUEnvVar] = strconv.FormatBool(spec.ForceTCMU)
+	}
+
+	config[v2NamespaceEnvVar] = spec.GetResourceNS()
+
+	if spec.K8sDistro != "" {
+		config[k8sDistroEnvVar] = spec.K8sDistro
+	}
+
+	// CSI is always enabled.
+	config[csiEndpointEnvVar] = spec.GetCSIEndpoint(true)
+	config[csiVersionEnvVar] = spec.GetCSIVersion(true)
+
+	// Since we're running in k8s, always listen on the the scheduler extender
+	// api endpoints.  The feature can be disabled with the operator.  This
+	// allows users to toggle the feature without restarting the cluster.
+	config[k8sSchedulerExtenderEnvVar] = "true"
+
+	// If kubelet is running in a container, sharedDir should be set.
+	if spec.SharedDir != "" {
+		config[deviceDirEnvVar] = fmt.Sprintf("%s/devices", spec.SharedDir)
+	}
+
+	config[logFormatEnvVar] = "json"
+	config[logLevelEnvVar] = "info"
+	if spec.Debug {
+		config[logLevelEnvVar] = debugVal
+	}
+
+	return config
+}
+
+// addEtcdTLSConfig adds the config entries for TLS config.  The ENV var names
+// are different between V1 & V2.
+func addEtcdTLSConfig(config map[string]string, v2 bool) map[string]string {
+
+	caCert := v1EtcdTLSClientCAEnvVar
+	clientKey := v1EtcdTLSClientKeyEnvVar
+	clientCert := v1EtcdTLSClientCertEnvVar
+
+	if v2 {
+		caCert = v2EtcdTLSClientCAEnvVar
+		clientKey = v2EtcdTLSClientKeyEnvVar
+		clientCert = v2EtcdTLSClientCertEnvVar
+	}
+
+	config[caCert] = filepath.Join(tlsEtcdRootPath, tlsEtcdCA)
+	config[clientKey] = filepath.Join(tlsEtcdRootPath, tlsEtcdClientKey)
+	config[clientCert] = filepath.Join(tlsEtcdRootPath, tlsEtcdClientCert)
+
+	return config
+}

--- a/pkg/storageos/configmap_test.go
+++ b/pkg/storageos/configmap_test.go
@@ -1,0 +1,393 @@
+package storageos
+
+import (
+	"reflect"
+	"testing"
+
+	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
+)
+
+func Test_configFromSpec(t *testing.T) {
+
+	t.Parallel()
+
+	v1DefaultSpec := storageosv1.StorageOSClusterSpec{}
+	v1DefaultConfig := map[string]string{
+		joinEnvVar:                 "",
+		disableFencingEnvVar:       "false",
+		disableTelemetryEnvVar:     "false",
+		k8sSchedulerExtenderEnvVar: "true",
+		v1NamespaceEnvVar:          "storageos",
+		logFormatEnvVar:            "text",
+		logLevelEnvVar:             "info",
+	}
+
+	v2DefaultSpec := storageosv1.StorageOSClusterSpec{}
+	v2DefaultConfig := map[string]string{
+		csiEndpointEnvVar:           "unix:///var/lib/kubelet/plugins_registry/storageos/csi.sock",
+		csiVersionEnvVar:            "v1",
+		disableCrashReportingEnvVar: "false",
+		disableTelemetryEnvVar:      "false",
+		disableVersionCheckEnvVar:   "false",
+		etcdEndpointsEnvVar:         "",
+		k8sSchedulerExtenderEnvVar:  "true",
+		v2NamespaceEnvVar:           "storageos",
+		logFormatEnvVar:             "json",
+		logLevelEnvVar:              "info",
+		// disableFencingEnvVar:        "false",
+	}
+
+	tests := []struct {
+		name       string
+		spec       storageosv1.StorageOSClusterSpec
+		csiv1      bool
+		nodev2     bool
+		wantbase   map[string]string
+		wantcustom map[string]string
+	}{
+		{
+			name:     "v1 defaults",
+			spec:     v1DefaultSpec,
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+		},
+		{
+			name: "v1 csi",
+			spec: storageosv1.StorageOSClusterSpec{
+				CSI: storageosv1.StorageOSClusterCSI{
+					Enable: true,
+				},
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				csiEndpointEnvVar: "unix:///var/lib/kubelet/plugins_registry/storageos/csi.sock",
+				csiVersionEnvVar:  "v1",
+			},
+		},
+		{
+			name: "v1 csi v0",
+			spec: storageosv1.StorageOSClusterSpec{
+				CSI: storageosv1.StorageOSClusterCSI{
+					Enable: true,
+				},
+			},
+			csiv1:    false,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				csiEndpointEnvVar: "unix:///var/lib/kubelet/plugins/storageos/csi.sock",
+				csiVersionEnvVar:  "v0",
+			},
+		},
+		{
+			name: "v1 join",
+			spec: storageosv1.StorageOSClusterSpec{
+				Join: "1.2.3.4,5.6.7.8,4.3.2.1",
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				joinEnvVar: "1.2.3.4,5.6.7.8,4.3.2.1",
+			},
+		},
+		{
+			name: "v1 shared-dir",
+			spec: storageosv1.StorageOSClusterSpec{
+				SharedDir: "some-dir-path",
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				deviceDirEnvVar: "some-dir-path/devices",
+			},
+		},
+		{
+			name: "v1 disable telemetry",
+			spec: storageosv1.StorageOSClusterSpec{
+				DisableTelemetry: true,
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				disableTelemetryEnvVar: "true",
+			},
+		},
+		{
+			name: "v1 disable fencing",
+			spec: storageosv1.StorageOSClusterSpec{
+				DisableFencing: true,
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				disableFencingEnvVar: "true",
+			},
+		},
+		{
+			name: "v1 disable tcmu",
+			spec: storageosv1.StorageOSClusterSpec{
+				DisableTCMU: true,
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				disableTCMUEnvVar: "true",
+			},
+		},
+		{
+			name: "v1 force tcmu",
+			spec: storageosv1.StorageOSClusterSpec{
+				ForceTCMU: true,
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				forceTCMUEnvVar: "true",
+			},
+		},
+		{
+			name: "v1 kv backend only",
+			spec: storageosv1.StorageOSClusterSpec{
+				KVBackend: storageosv1.StorageOSClusterKVBackend{
+					Backend: "etcd",
+				},
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				kvBackendEnvVar: "etcd",
+			},
+		},
+		{
+			name: "v1 kv address only",
+			spec: storageosv1.StorageOSClusterSpec{
+				KVBackend: storageosv1.StorageOSClusterKVBackend{
+					Address: "etcd-client:2379",
+				},
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				kvAddrEnvVar: "etcd-client:2379",
+			},
+		},
+		{
+			name: "v1 external etcd",
+			spec: storageosv1.StorageOSClusterSpec{
+				KVBackend: storageosv1.StorageOSClusterKVBackend{
+					Backend: "etcd",
+					Address: "etcd-client:2379",
+				},
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				kvBackendEnvVar: "etcd",
+				kvAddrEnvVar:    "etcd-client:2379",
+			},
+		},
+		{
+			name: "v1 etcd TLS",
+			spec: storageosv1.StorageOSClusterSpec{
+				TLSEtcdSecretRefName:      "etcd-certs",
+				TLSEtcdSecretRefNamespace: "default",
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				v1EtcdTLSClientCAEnvVar:   "/run/storageos/pki/etcd-client-ca.crt",
+				v1EtcdTLSClientKeyEnvVar:  "/run/storageos/pki/etcd-client.key",
+				v1EtcdTLSClientCertEnvVar: "/run/storageos/pki/etcd-client.crt",
+			},
+		},
+		{
+			name: "v1 external etcd with TLS",
+			spec: storageosv1.StorageOSClusterSpec{
+				KVBackend: storageosv1.StorageOSClusterKVBackend{
+					Backend: "etcd",
+					Address: "etcd-client:2379",
+				},
+				TLSEtcdSecretRefName:      "etcd-certs",
+				TLSEtcdSecretRefNamespace: "default",
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				kvBackendEnvVar:           "etcd",
+				kvAddrEnvVar:              "etcd-client:2379",
+				v1EtcdTLSClientCAEnvVar:   "/run/storageos/pki/etcd-client-ca.crt",
+				v1EtcdTLSClientKeyEnvVar:  "/run/storageos/pki/etcd-client.key",
+				v1EtcdTLSClientCertEnvVar: "/run/storageos/pki/etcd-client.crt",
+			},
+		},
+		{
+			name: "v1 distro",
+			spec: storageosv1.StorageOSClusterSpec{
+				K8sDistro: "some-distro-name",
+			},
+			csiv1:    true,
+			nodev2:   false,
+			wantbase: v1DefaultConfig,
+			wantcustom: map[string]string{
+				k8sDistroEnvVar: "some-distro-name",
+			},
+		},
+
+		{
+			name:     "v2 defaults",
+			spec:     v2DefaultSpec,
+			csiv1:    true,
+			nodev2:   true,
+			wantbase: v2DefaultConfig,
+		},
+		{
+			name: "v2 csi",
+			spec: storageosv1.StorageOSClusterSpec{
+				CSI: storageosv1.StorageOSClusterCSI{
+					Enable: true,
+				},
+			},
+			csiv1:    true,
+			nodev2:   true,
+			wantbase: v2DefaultConfig,
+		},
+		{
+			name: "v2 csi v0 - override to csi v1",
+			spec: storageosv1.StorageOSClusterSpec{
+				CSI: storageosv1.StorageOSClusterCSI{
+					Enable: true,
+				},
+			},
+			csiv1:    false,
+			nodev2:   true,
+			wantbase: v2DefaultConfig,
+			wantcustom: map[string]string{
+				csiEndpointEnvVar: "unix:///var/lib/kubelet/plugins_registry/storageos/csi.sock",
+				csiVersionEnvVar:  "v1",
+			},
+		},
+		{
+			name: "v2 shared-dir",
+			spec: storageosv1.StorageOSClusterSpec{
+				SharedDir: "some-dir-path",
+			},
+			csiv1:    true,
+			nodev2:   true,
+			wantbase: v2DefaultConfig,
+			wantcustom: map[string]string{
+				deviceDirEnvVar: "some-dir-path/devices",
+			},
+		},
+		{
+			name: "v2 disable telemetry",
+			spec: storageosv1.StorageOSClusterSpec{
+				DisableTelemetry: true,
+			},
+			csiv1:    true,
+			nodev2:   true,
+			wantbase: v2DefaultConfig,
+			wantcustom: map[string]string{
+				disableTelemetryEnvVar:      "true",
+				disableCrashReportingEnvVar: "true",
+				disableVersionCheckEnvVar:   "true",
+			},
+		},
+		// Enable this when fencing is supported.
+		// {
+		// 	name: "v2 disable fencing",
+		// 	spec: storageosv1.StorageOSClusterSpec{
+		// 		DisableFencing: true,
+		// 	},
+		// 	csiv1:    true,
+		// 	nodev2:   true,
+		// 	wantbase: v2DefaultConfig,
+		// 	wantcustom: map[string]string{
+		// 		disableFencingEnvVar: "true",
+		// 	},
+		// },
+		{
+			name: "v2 disable tcmu",
+			spec: storageosv1.StorageOSClusterSpec{
+				DisableTCMU: true,
+			},
+			csiv1:    true,
+			nodev2:   true,
+			wantbase: v2DefaultConfig,
+			wantcustom: map[string]string{
+				disableTCMUEnvVar: "true",
+			},
+		},
+		{
+			name: "v2 force tcmu",
+			spec: storageosv1.StorageOSClusterSpec{
+				ForceTCMU: true,
+			},
+			csiv1:    true,
+			nodev2:   true,
+			wantbase: v2DefaultConfig,
+			wantcustom: map[string]string{
+				forceTCMUEnvVar: "true",
+			},
+		},
+		{
+			name: "v2 etcd TLS",
+			spec: storageosv1.StorageOSClusterSpec{
+				TLSEtcdSecretRefName:      "etcd-certs",
+				TLSEtcdSecretRefNamespace: "default",
+			},
+			csiv1:    true,
+			nodev2:   true,
+			wantbase: v2DefaultConfig,
+			wantcustom: map[string]string{
+				v2EtcdTLSClientCAEnvVar:   "/run/storageos/pki/etcd-client-ca.crt",
+				v2EtcdTLSClientKeyEnvVar:  "/run/storageos/pki/etcd-client.key",
+				v2EtcdTLSClientCertEnvVar: "/run/storageos/pki/etcd-client.crt",
+			},
+		},
+		{
+			name: "v2 distro",
+			spec: storageosv1.StorageOSClusterSpec{
+				K8sDistro: "some-distro-name",
+			},
+			csiv1:    true,
+			nodev2:   true,
+			wantbase: v2DefaultConfig,
+			wantcustom: map[string]string{
+				k8sDistroEnvVar: "some-distro-name",
+			},
+		},
+	}
+	for _, tt := range tests {
+		var tt = tt
+		t.Run(tt.name, func(t *testing.T) {
+
+			t.Parallel()
+
+			var want = make(map[string]string)
+			for k, v := range tt.wantbase {
+				want[k] = v
+			}
+			for k, v := range tt.wantcustom {
+				want[k] = v
+			}
+
+			if got := configFromSpec(tt.spec, tt.csiv1, tt.nodev2); !reflect.DeepEqual(got, want) {
+				t.Errorf("configFromSpec() got:\n%v\n want:\n%v\n", got, want)
+			}
+		})
+	}
+}

--- a/pkg/storageos/csidriver.go
+++ b/pkg/storageos/csidriver.go
@@ -19,7 +19,12 @@ func (s *Deployment) createCSIDriver() error {
 		PodInfoOnMount: &podInfoRequired,
 	}
 
-	return k8sresource.NewCSIDriver(s.client, CSIProvisionerName, nil, spec).Create()
+	driverName := CSIProvisionerName
+	if s.nodev2 {
+		driverName = StorageOSProvisionerName
+	}
+
+	return k8sresource.NewCSIDriver(s.client, driverName, nil, spec).Create()
 }
 
 // deleteCSIDriver deletes the StorageOS CSIDriver resource.

--- a/pkg/storageos/delete.go
+++ b/pkg/storageos/delete.go
@@ -27,6 +27,10 @@ func (s *Deployment) Delete() error {
 		return err
 	}
 
+	if err := s.k8sResourceManager.ConfigMap(configmapName, namespace, nil, nil).Delete(); err != nil {
+		return err
+	}
+
 	if err := s.k8sResourceManager.Secret(initSecretName, namespace, nil, corev1.SecretTypeOpaque, nil).Delete(); err != nil {
 		return err
 	}

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -21,6 +21,8 @@ const (
 	IntreeProvisionerName = "kubernetes.io/storageos"
 	// CSIProvisionerName is the name of the CSI provisioner.
 	CSIProvisionerName = "storageos"
+	// StorageOSProvisionerName is the new CSI provisioner name.
+	StorageOSProvisionerName = "csi.storageos.com"
 )
 
 const (
@@ -292,7 +294,7 @@ func (s *Deployment) addNodeContainerProbes(nodeContainer *corev1.Container) {
 			},
 		},
 	}
-	nodeContainer.LivenessProbe = &corev1.Probe{
+	nodeContainer.ReadinessProbe = &corev1.Probe{
 		InitialDelaySeconds: int32(65),
 		TimeoutSeconds:      int32(10),
 		FailureThreshold:    int32(5),

--- a/pkg/storageos/deployment.go
+++ b/pkg/storageos/deployment.go
@@ -1,6 +1,8 @@
 package storageos
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/record"
@@ -21,6 +23,7 @@ type Deployment struct {
 	scheme             *runtime.Scheme
 	update             bool
 	k8sResourceManager *k8s.ResourceManager
+	nodev2             bool
 }
 
 // NewDeployment creates a new Deployment given a k8c client, storageos manifest
@@ -43,5 +46,23 @@ func NewDeployment(
 		scheme:             scheme,
 		update:             update,
 		k8sResourceManager: k8s.NewResourceManager(client).SetLabels(labels),
+		nodev2:             isV2image(stos.Spec.Images.NodeContainer),
 	}
+}
+
+// isV2image returns true if the image tag starts with "2." or contains "c2".
+func isV2image(image string) bool {
+
+	parts := strings.Split(image, ":")
+	if len(parts) < 2 {
+		return false
+	}
+
+	if strings.HasPrefix(parts[len(parts)-1], "2.") {
+		return true
+	}
+
+	// Temporary dev tag check.
+	// TODO: remove once we have proper tags.
+	return strings.Contains(parts[len(parts)-1], "c2")
 }

--- a/pkg/storageos/deployment_test.go
+++ b/pkg/storageos/deployment_test.go
@@ -1,0 +1,34 @@
+package storageos
+
+import "testing"
+
+func Test_isV2image(t *testing.T) {
+
+	t.Parallel()
+
+	tests := []struct {
+		image string
+		want  bool
+	}{
+		{image: "storageos/node", want: false},
+		{image: "storageos/node:1.0.0", want: false},
+		{image: "storageos/node:1.2.0-alpha1", want: false},
+		{image: "storageos/node:7c46250197bf", want: false},
+		{image: "storageos/node:2.0.0", want: true},
+		{image: "storageos/node:2.0.0-alpha1", want: true},
+		{image: "storageos/node:c2-7c46250197bf", want: true},
+		{image: "myregistryhost:5000/storageos/node:1.0.0", want: false},
+		{image: "myregistryhost:5000/storageos/node:2.0.0", want: true},
+		{image: "invalidscheme://myregistryhost:5000/storageos/node:2.0.0", want: true},
+		{image: "2.0.0", want: false},
+	}
+	for _, tt := range tests {
+		var tt = tt
+		t.Run(tt.image, func(t *testing.T) {
+			t.Parallel()
+			if got := isV2image(tt.image); got != tt.want {
+				t.Errorf("isV2image(%s) = %v, want %v", tt.image, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -18,6 +18,9 @@ const (
 	schedulerConfigConfigMapName = "storageos-scheduler-config"
 	schedulerConfigKey           = "config.yaml"
 
+	uriPathV1 = "/v1/scheduler"
+	uriPathV2 = "/v2/k8s/scheduler"
+
 	// schedulerReplicas is the number of instances of kube-scheduler.
 	schedulerReplicas = 1
 )
@@ -174,11 +177,15 @@ func (s Deployment) createSchedulerPolicy() error {
 `
 	// Service address format: <service-name>.<namespace>.svc.cluster.local.
 	serviceEndpoint := fmt.Sprintf("%s.%s.svc.cluster.local", s.stos.Spec.GetServiceName(), s.stos.Spec.GetResourceNS())
+	uriPath := uriPathV1
+	if s.nodev2 {
+		uriPath = uriPathV2
+	}
 	policyData := schedulerPolicyTemplate{
 		FilterVerb:     "filter",
 		PrioritizeVerb: "prioritize",
 		EnableHTTPS:    false,
-		URLPrefix:      fmt.Sprintf("http://%s:5705/v1/scheduler", serviceEndpoint),
+		URLPrefix:      fmt.Sprintf("http://%s:5705%s", serviceEndpoint, uriPath),
 	}
 
 	// Render the policy configuration.

--- a/pkg/storageos/secret.go
+++ b/pkg/storageos/secret.go
@@ -133,6 +133,10 @@ func (s *Deployment) deleteCSISecrets() error {
 		return err
 	}
 
+	if err := s.k8sResourceManager.Secret(csiNodePublishSecretName, namespace, nil, corev1.SecretTypeOpaque, nil).Delete(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/storageos/storageclass.go
+++ b/pkg/storageos/storageclass.go
@@ -6,6 +6,10 @@ func (s *Deployment) createStorageClass() error {
 
 	if s.stos.Spec.CSI.Enable {
 		provisioner = CSIProvisionerName
+		// Check if it's a v2 deployment and use the appropriate provisioner.
+		if s.nodev2 {
+			provisioner = StorageOSProvisionerName
+		}
 	}
 
 	parameters := map[string]string{

--- a/scripts/openshift/Vagrantfile
+++ b/scripts/openshift/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/xenial64"
 
   config.vm.network "private_network", type: "dhcp"
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -333,8 +333,12 @@ main() {
         operator-sdk test local ./test/e2e --go-test-flags "-v -tags intree" --namespace storageos-operator
         operator-sdk-e2e-cleanup
 
-        operator-sdk test local ./test/e2e --go-test-flags "-v -tags v2" --namespace storageos-operator
-        operator-sdk-e2e-cleanup
+        # NOTE: v2 deployment fails on openshift 3.11. Dataplane startup fails.
+        # Need to debug more in the future.
+        if [ "$1" = "kind" ]; then
+            operator-sdk test local ./test/e2e --go-test-flags "-v -tags v2" --namespace storageos-operator
+            operator-sdk-e2e-cleanup
+        fi
 
         # echo "**** Resource details for storageos-operator namespace ****"
         # print_pod_details_and_logs storageos-operator

--- a/test/e2e/clusterCSIDeployment_test.go
+++ b/test/e2e/clusterCSIDeployment_test.go
@@ -78,7 +78,7 @@ func TestClusterCSIDeployment(t *testing.T) {
 	//Check the number of containers in daemonset pod spec.
 	if deploy.CSIV1Supported(version) {
 		if len(daemonset.Spec.Template.Spec.Containers) != 3 {
-			t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 2)
+			t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 3)
 		}
 	} else {
 		if len(daemonset.Spec.Template.Spec.Containers) != 2 {

--- a/test/e2e/clusterCSINodeV2_test.go
+++ b/test/e2e/clusterCSINodeV2_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
@@ -73,9 +74,22 @@ func TestClusterCSINodeV2(t *testing.T) {
 		t.Fatalf("failed to get storageos-daemonset: %v", err)
 	}
 
+	info, err := f.KubeClient.Discovery().ServerVersion()
+	if err != nil {
+		t.Fatalf("failed to get version info: %v", err)
+	}
+
+	version := strings.TrimLeft(info.String(), "v")
+
 	//Check the number of containers in daemonset pod spec.
-	if len(daemonset.Spec.Template.Spec.Containers) != 3 {
-		t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 2)
+	if deploy.CSIV1Supported(version) {
+		if len(daemonset.Spec.Template.Spec.Containers) != 3 {
+			t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 3)
+		}
+	} else {
+		if len(daemonset.Spec.Template.Spec.Containers) != 2 {
+			t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 2)
+		}
 	}
 
 	// Test StorageOSCluster CR attributes.

--- a/test/e2e/clusterCSINodeV2_test.go
+++ b/test/e2e/clusterCSINodeV2_test.go
@@ -82,7 +82,7 @@ func TestClusterCSINodeV2(t *testing.T) {
 	testutil.StorageOSClusterCRAttributesTest(t, testutil.TestClusterCRName, namespace)
 
 	// Test CSIDriver resource existence.
-	testutil.CSIDriverResourceTest(t, deploy.CSIProvisionerName)
+	testutil.CSIDriverResourceTest(t, deploy.StorageOSProvisionerName)
 
 	// Test node label sync.
 	// TODO: Currently relies on v1 CLI.

--- a/test/e2e/clusterCSINodeV2_test.go
+++ b/test/e2e/clusterCSINodeV2_test.go
@@ -7,6 +7,7 @@ import (
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	storageos "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 	deploy "github.com/storageos/cluster-operator/pkg/storageos"
@@ -67,11 +68,10 @@ func TestClusterCSINodeV2(t *testing.T) {
 	// }
 	// testutil.ClusterStatusCheck(t, testStorageOS.Status, 1)
 
-	// TODO - Check when the status endpoints are ready.
-	// daemonset, err := f.KubeClient.AppsV1().DaemonSets(resourceNS).Get("storageos-daemonset", metav1.GetOptions{})
-	// if err != nil {
-	// 	t.Fatalf("failed to get storageos-daemonset: %v", err)
-	// }
+	daemonset, err := f.KubeClient.AppsV1().DaemonSets(resourceNS).Get("storageos-daemonset", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get storageos-daemonset: %v", err)
+	}
 
 	//Check the number of containers in daemonset pod spec.
 	if len(daemonset.Spec.Template.Spec.Containers) != 3 {

--- a/test/e2e/clusterCSI_test.go
+++ b/test/e2e/clusterCSI_test.go
@@ -75,7 +75,7 @@ func TestClusterCSI(t *testing.T) {
 	//Check the number of containers in daemonset pod spec.
 	if deploy.CSIV1Supported(version) {
 		if len(daemonset.Spec.Template.Spec.Containers) != 3 {
-			t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 2)
+			t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 3)
 		}
 	} else {
 		if len(daemonset.Spec.Template.Spec.Containers) != 2 {

--- a/test/e2e/clusterCSI_test.go
+++ b/test/e2e/clusterCSI_test.go
@@ -58,7 +58,6 @@ func TestClusterCSI(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	testutil.ClusterStatusCheck(t, testStorageOS.Status, 1)
 
 	daemonset, err := f.KubeClient.AppsV1().DaemonSets(resourceNS).Get("storageos-daemonset", metav1.GetOptions{})

--- a/test/e2e/clusterInTreePlugin_test.go
+++ b/test/e2e/clusterInTreePlugin_test.go
@@ -63,7 +63,7 @@ func TestClusterInTreePlugin(t *testing.T) {
 
 	// Check the number of containers in daemonset pod spec.
 	if len(daemonset.Spec.Template.Spec.Containers) != 1 {
-		t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 2)
+		t.Errorf("unexpected number of daemonset pod containers:\n\t(GOT) %d\n\t(WNT) %d", len(daemonset.Spec.Template.Spec.Containers), 1)
 	}
 
 	// Test pod scheduler mutating admission contoller.

--- a/test/etcd/README.md
+++ b/test/etcd/README.md
@@ -1,0 +1,6 @@
+## etcd
+
+This directory contains manifests to install an etcd cluster.  An external etcd
+cluster is optional for StorageOS v1.x but required for StorageOS v2.x.
+
+Clients should connect to the `etcd-client` service.

--- a/test/etcd/etcd-cluster.yaml
+++ b/test/etcd/etcd-cluster.yaml
@@ -1,0 +1,11 @@
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdCluster"
+metadata:
+  name: "etcd"
+  ## Adding this annotation make this cluster managed by clusterwide operators
+  ## namespaced operators ignore it
+  # annotations:
+  #   etcd.database.coreos.com/scope: clusterwide
+spec:
+  size: 1
+  version: "3.2.28"

--- a/test/etcd/etcd-cluster.yaml
+++ b/test/etcd/etcd-cluster.yaml
@@ -2,6 +2,7 @@ apiVersion: "etcd.database.coreos.com/v1beta2"
 kind: "EtcdCluster"
 metadata:
   name: "etcd"
+  namespace: default
   ## Adding this annotation make this cluster managed by clusterwide operators
   ## namespaced operators ignore it
   # annotations:
@@ -9,3 +10,9 @@ metadata:
 spec:
   size: 1
   version: "3.2.28"
+  pod:
+    tolerations:
+    - key: key
+      operator: Equal
+      value: value
+      effect: NoSchedule

--- a/test/etcd/etcd-operator.yaml
+++ b/test/etcd/etcd-operator.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-operator
+spec:
+  selector:
+    matchLabels:
+      app: etcd-operator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: etcd-operator
+    spec:
+      containers:
+      - name: etcd-operator
+        # Use newer fork: https://github.com/coreos/etcd-operator/issues/2131
+        image: cbws/etcd-operator:v0.10.0
+        command:
+        - etcd-operator
+        # Uncomment to act for resources in all namespaces. More information in doc/user/clusterwide.md
+        #- -cluster-wide
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/test/etcd/etcd-operator.yaml
+++ b/test/etcd/etcd-operator.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etcd-operator
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -29,3 +30,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+      tolerations:
+      - key: key
+        operator: Equal
+        value: value
+        effect: NoSchedule

--- a/test/etcd/etcd-rbac.yaml
+++ b/test/etcd/etcd-rbac.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: etcd-operator
+rules:
+- apiGroups:
+  - etcd.database.coreos.com
+  resources:
+  - etcdclusters
+  - etcdbackups
+  - etcdrestores
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+# The following permissions can be removed if not using S3 backup and TLS
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default


### PR DESCRIPTION
Adds support for using configmap for node configuration and new deployment with e2e test.
Also fixes the issue due to which CSI node publish secret was not being deleted.
