### PR TITLE
Pass specific operator env vars via the ConfigMap

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -75,8 +75,12 @@ spec:
               value: "storageos-cluster-operator"
             - name: DISABLE_SCHEDULER_WEBHOOK
               value: "false"
+            - name: JAEGER_ENDPOINT
+              value: ""
+            - name: JAEGER_SERVICE_NAME
+              value: ""
       tolerations:
       - key: "key"
         operator: "Equal"
         value: "value"
-        effect: "NoSchedule" 
+        effect: "NoSchedule"

--- a/pkg/storageos/configmap.go
+++ b/pkg/storageos/configmap.go
@@ -2,6 +2,7 @@ package storageos
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -108,6 +109,11 @@ const (
 
 	// Logger format: text or json.
 	logFormatEnvVar = "LOG_FORMAT"
+
+	// Tracing configuration.  Intended for internal development use only and
+	// should not be documented externally.
+	jaegerEndpointEnvVar    = "JAEGER_ENDPOINT"
+	jaegerServiceNameEnvVar = "JAEGER_SERVICE_NAME"
 
 	// Etcd TLS cert file names.
 	tlsEtcdCA         = "etcd-client-ca.crt"
@@ -268,6 +274,16 @@ func v2ConfigFromSpec(spec storageosv1.StorageOSClusterSpec) map[string]string {
 	config[logLevelEnvVar] = "info"
 	if spec.Debug {
 		config[logLevelEnvVar] = debugVal
+	}
+
+	// Set Jaeger configuration, only if set as an env var in the operator. We
+	// do this because we don't want to publish configuration options in the CRD
+	// that are intended for developer use only.
+	if val := os.Getenv(jaegerEndpointEnvVar); val != "" {
+		config[jaegerEndpointEnvVar] = val
+	}
+	if val := os.Getenv(jaegerServiceNameEnvVar); val != "" {
+		config[jaegerServiceNameEnvVar] = val
 	}
 
 	return config

--- a/scripts/create-manifest.sh
+++ b/scripts/create-manifest.sh
@@ -33,7 +33,23 @@ do
     cat $i >> $INSTALL_MANIFEST
 done
 
+# Set operator install env vars. Be careful of the ordering if they change!
+OPERATOR_MANIFEST=deploy/operator-generated.yaml
+cp deploy/operator.yaml $OPERATOR_MANIFEST
+
+if [ -n "$JAEGER_ENDPOINT" ]; then
+    build/yq w -i $OPERATOR_MANIFEST spec.template.spec.containers[0].env[18].value $JAEGER_ENDPOINT
+fi
+if [ -n "$JAEGER_SERVICE_NAME" ]; then
+    build/yq w -i $OPERATOR_MANIFEST spec.template.spec.containers[0].env[19].value $JAEGER_SERVICE_NAME
+fi
+
 # Write the operator manifest with the proper container image tag.
 echo "---" >> $INSTALL_MANIFEST
-echo "Copying deploy/operator.yaml with image $OPERATOR_IMAGE"
-build/yq w deploy/operator.yaml spec.template.spec.containers[0].image $OPERATOR_IMAGE >> $INSTALL_MANIFEST
+echo "Copying $OPERATOR_MANIFEST with image $OPERATOR_IMAGE"
+build/yq w $OPERATOR_MANIFEST spec.template.spec.containers[0].image $OPERATOR_IMAGE >> $INSTALL_MANIFEST
+
+if [ -f "$OPERATOR_MANIFEST" ]; then
+    rm -f "$OPERATOR_MANIFEST"
+fi
+

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -228,6 +228,10 @@ operator-sdk-e2e-cleanup() {
 
     # Delete webhook config.
     kubectl delete mutatingwebhookconfigurations storageos-scheduler-webhook --ignore-not-found=true
+
+    # Clean up StorageOS devices
+    sudo umount storageos || true
+    sudo rm -rf /var/lib/storageos/* || true
 }
 
 main() {


### PR DESCRIPTION
This allows us to pass some specific debug variables though the operator environment to the node container.  They're intended for internal-use-only and may be removed, so we don't want to add them to the StorageOSCluster CRD.