### PR TITLE
Re-add provisioner flag for CSI v0 compatibility

### DIFF
--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -110,6 +110,7 @@ func (s Deployment) csiHelperContainers() ([]corev1.Container, error) {
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Args: []string{
 				"--v=5",
+				"--provisioner=storageos", // deprecated in v1.1.0, but required for v1.0.0 (CSI v0).
 				"--csi-address=$(ADDRESS)",
 			},
 			Env: []corev1.EnvVar{


### PR DESCRIPTION
The flag is ignored in csi-provisioner v.1.1.0 and above, but required for v1.0.0, which we use for k8s < 1.13.