### PR TITLE
Pass cluster node selector to NFS pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Parameter | Description | Default
 `disableTCMU` | Disable TCMU to allow co-existence with other storage systems but degrades performance | `false`
 `forceTCMU` | Forces TCMU to be enabled or causes StorageOS to abort startup | `false`
 `disableScheduler` | Disable StorageOS scheduler for data locality | `false`
-`nodeSelectorTerms` | Set node selector for storageos pod placement, including NFS pods. |
+`nodeSelectorTerms` | Set node selector for storageos pod placement, including NFS pods |
 `tolerations` | Set pod tolerations for storageos pod placement |
 `resources` | Set resource requirements for the containers |
 `k8sDistro` | The name of the Kubernetes distribution is use, e.g. `rancher` or `eks` |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Parameter | Description | Default
 `disableTCMU` | Disable TCMU to allow co-existence with other storage systems but degrades performance | `false`
 `forceTCMU` | Forces TCMU to be enabled or causes StorageOS to abort startup | `false`
 `disableScheduler` | Disable StorageOS scheduler for data locality | `false`
-`nodeSelectorTerms` | Set node selector for storageos pod placement |
+`nodeSelectorTerms` | Set node selector for storageos pod placement, including NFS pods. |
 `tolerations` | Set pod tolerations for storageos pod placement |
 `resources` | Set resource requirements for the containers |
 `k8sDistro` | The name of the Kubernetes distribution is use, e.g. `rancher` or `eks` |

--- a/pkg/nfs/statefulset.go
+++ b/pkg/nfs/statefulset.go
@@ -35,8 +35,13 @@ func (d *Deployment) createStatefulSet(pvcVS *corev1.PersistentVolumeClaimVolume
 	}
 	spec.Template.Spec.Volumes = append(spec.Template.Spec.Volumes, vol)
 
-	// TODO: Add node affinity support for NFS server pods.
 	util.AddTolerations(&spec.Template.Spec, d.nfsServer.Spec.Tolerations)
+
+	// If the cluster was configured with node selectors to only run on certain
+	// nodes, use the same selectors to selct the nodes that the NFS pods can
+	// run on.  NFSServer does not currently allow setting node selectors or
+	// affinity directly.
+	util.AddRequiredNodeAffinity(&spec.Template.Spec, d.cluster.Spec.NodeSelectorTerms)
 
 	return d.k8sResourceManager.StatefulSet(d.nfsServer.Name, d.nfsServer.Namespace, nil, spec).Create()
 }

--- a/pkg/util/podspec.go
+++ b/pkg/util/podspec.go
@@ -18,3 +18,17 @@ func AddTolerations(podSpec *corev1.PodSpec, tolerations []corev1.Toleration) er
 	}
 	return nil
 }
+
+// AddRequiredNodeAffinity adds required node affinity to the given pod spec.
+func AddRequiredNodeAffinity(podSpec *corev1.PodSpec, terms []corev1.NodeSelectorTerm) {
+	if len(terms) == 0 {
+		return
+	}
+	podSpec.Affinity = &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: terms,
+			},
+		},
+	}
+}


### PR DESCRIPTION
If node selectors are set on StorageOSCluster, any NFS pods will inherit the selectors as required node affinity selectors.

This ensures that NFS pods will only be scheduled to nodes where StorageOS is running.