### PR TITLE
Bump csi-provisioner for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ Parameter | Description | Default
 `namespace` | Namespace where storageos cluster resources are created | `storageos`
 `images.nodeContainer` | StorageOS node container image | `storageos/node:1.5.3`
 `images.initContainer` | StorageOS init container image | `storageos/init:1.0.0`
-`images.csiNodeDriverRegistrarContainer` | CSI Node Driver Registrar Container image | `quay.io/k8scsi/csi-node-driver-registrar:v1.0.1`
-`images.csiClusterDriverRegistrarContainer` | CSI Cluster Driver Registrar Container image | `quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1`
-`images.csiExternalProvisionerContainer` | CSI External Provisioner Container image | `storageos/csi-provisioner:v1.0.1`
-`images.csiExternalAttacherContainer` | CSI External Attacher Container image | `quay.io/k8scsi/csi-attacher:v1.0.1`
-`ìmages.csiLivenessProbeContainer` | CSI Liveness Probe Container Image | `quay.io/k8scsi/livenessprobe:v1.0.1`
+`images.csiNodeDriverRegistrarContainer` | CSI Node Driver Registrar Container image | Varies depending on Kubernetes version
+`images.csiClusterDriverRegistrarContainer` | CSI Cluster Driver Registrar Container image |  Varies depending on Kubernetes version
+`images.csiExternalProvisionerContainer` | CSI External Provisioner Container image |  Varies depending on Kubernetes version
+`images.csiExternalAttacherContainer` | CSI External Attacher Container image |  Varies depending on Kubernetes version
+`ìmages.csiLivenessProbeContainer` | CSI Liveness Probe Container Image |  Varies depending on Kubernetes version
 `csi.enable` | Enable CSI setup | `false`
 `csi.enableProvisionCreds` | Enable CSI provision credentials | `false`
 `csi.enableControllerPublishCreds` | Enable CSI controller publish credentials | `false`

--- a/README.md
+++ b/README.md
@@ -418,3 +418,4 @@ data:
   csiNodePublishUsername:
   csiNodePublishPassword:
 ```
+

--- a/internal/pkg/image/image.go
+++ b/internal/pkg/image/image.go
@@ -9,7 +9,7 @@ const (
 	CSIv1ClusterDriverRegistrarContainerImage = "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1"
 	CSIv1NodeDriverRegistrarContainerImage    = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
 	CSIv1ExternalProvisionerContainerImageV1  = "storageos/csi-provisioner:v1.4.0"
-	CSIv1ExternalProvisionerContainerImageV2  = "storageos/csi-provisioner:1.5.4aa560e"
+	CSIv1ExternalProvisionerContainerImageV2  = "storageos/csi-provisioner:53f0949-patched"
 	CSIv1ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v1.2.1"
 	CSIv1ExternalAttacherv2ContainerImage     = "quay.io/k8scsi/csi-attacher:v2.0.0"
 	CSIv1LivenessProbeContainerImage          = "quay.io/k8scsi/livenessprobe:v1.1.0"


### PR DESCRIPTION
Bumps external-provisioner to upstream commit https://github.com/kubernetes-csi/external-provisioner/commit/53f0949f60eda07d2df3d4fbe37e95ff51ba7408

With patch: https://github.com/storageos/external-provisioner/commit/fd3540386579ecafea49a1188b2f6ebd6b2a4336