### PR TITLE
Run CSI helpers as privileged

### DIFF
--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -103,6 +103,7 @@ func (s Deployment) addCommonPodProperties(podSpec *corev1.PodSpec) error {
 // csiHelperContainers returns a list of containers that should be part of the
 // CSI helper pods.
 func (s Deployment) csiHelperContainers() ([]corev1.Container, error) {
+	privileged := true
 	containers := []corev1.Container{
 		{
 			Image:           s.stos.Spec.GetCSIExternalProvisionerImage(CSIV1Supported(s.k8sVersion), s.nodev2),
@@ -118,6 +119,9 @@ func (s Deployment) csiHelperContainers() ([]corev1.Container, error) {
 					Name:  addressEnvVar,
 					Value: "/csi/csi.sock",
 				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: &privileged,
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
@@ -139,6 +143,9 @@ func (s Deployment) csiHelperContainers() ([]corev1.Container, error) {
 					Name:  addressEnvVar,
 					Value: "/csi/csi.sock",
 				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: &privileged,
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
@@ -198,6 +205,9 @@ func (s Deployment) csiHelperContainers() ([]corev1.Container, error) {
 						},
 					},
 				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: &privileged,
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{

--- a/pkg/storageos/podspec.go
+++ b/pkg/storageos/podspec.go
@@ -51,6 +51,7 @@ func (s *Deployment) addSharedDir(podSpec *corev1.PodSpec) {
 
 // addCSI adds the CSI env vars, volumes and containers to the provided podSpec.
 func (s *Deployment) addCSI(podSpec *corev1.PodSpec) {
+	privileged := true
 	hostpathDirOrCreate := corev1.HostPathDirectoryOrCreate
 	hostpathDir := corev1.HostPathDirectory
 	mountPropagationBidirectional := corev1.MountPropagationBidirectional
@@ -207,6 +208,9 @@ func (s *Deployment) addCSI(podSpec *corev1.PodSpec) {
 					},
 				},
 			},
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: &privileged,
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "plugin-dir",
@@ -246,6 +250,9 @@ func (s *Deployment) addCSI(podSpec *corev1.PodSpec) {
 						Name:  addressEnvVar,
 						Value: "/csi/csi.sock",
 					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					Privileged: &privileged,
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{


### PR DESCRIPTION
This is required for systems that run SELinux where non-privileged containers can't access unix domain sockets created by a privileged container.

This is common with other CSI drivers, for example github.com/kubernetes-csi/csi-driver-hostpath, github.com/kubernetes-csi/csi-driver-nfs, github.com/kubernetes-csi/csi-driver-iscsi, etc.

We've chosen not to make this configurable as we've seen that it can be difficult to diagnose problems arising from this being required but not set in different environments.

