### PR TITLE
Update to latest v2 nightly image

### DIFF
--- a/test/e2e/clusterCSINodeV2_test.go
+++ b/test/e2e/clusterCSINodeV2_test.go
@@ -44,7 +44,7 @@ func TestClusterCSINodeV2(t *testing.T) {
 		},
 		K8sDistro: "openshift",
 		Images: storageos.ContainerImages{
-			NodeContainer: "rotsesgao/node:c2",
+			NodeContainer: "rotsesgao/node:v2",
 		},
 		KVBackend: storageos.StorageOSClusterKVBackend{
 			Address: "etcd-client.default.svc.cluster.local:2379",


### PR DESCRIPTION
Update to use new image naming format.  Affects the e2e test only.