### PR TITLE
StorageOS containers should run in kube-system by default

### DIFF
--- a/deploy/crds/storageos_v1_storageoscluster_cr.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretRefName: "storageos-api"
   secretRefNamespace: "default"
-  namespace: "storageos"
+  namespace: "kube-system"
   # k8sDistro: openshift
   # storageClassName: fast
   # tlsEtcdSecretRefName:

--- a/deploy/crds/storageos_v1_storageoscluster_cr.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_cr.yaml
@@ -38,7 +38,7 @@ spec:
   #   DriverRequiresAttachment: "true"
   #   deploymentStrategy: "deployment"
   # service:
-  #   name: "kube-system"
+  #   name: "storageos"
   #   type: "ClusterIP"
   #   externalPort: 5705
   #   internalPort: 5705

--- a/deploy/crds/storageos_v1_storageoscluster_cr.yaml
+++ b/deploy/crds/storageos_v1_storageoscluster_cr.yaml
@@ -38,7 +38,7 @@ spec:
   #   DriverRequiresAttachment: "true"
   #   deploymentStrategy: "deployment"
   # service:
-  #   name: "storageos"
+  #   name: "kube-system"
   #   type: "ClusterIP"
   #   externalPort: 5705
   #   internalPort: 5705

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -33,7 +33,10 @@ const (
 	// The cluster object is waiting for the finalizers to be executed.
 	ClusterPhaseTerminating ClusterPhase = "Terminating"
 
-	DefaultNamespace = "storageos"
+	// Use kube-system as the default namespace as so that our containers won't
+	// get evicted when there is resource contention.  Works with
+	// "system-node-critical" priority class.
+	DefaultNamespace = "kube-system"
 
 	DefaultStorageClassName = "fast"
 

--- a/pkg/storageos/configmap_test.go
+++ b/pkg/storageos/configmap_test.go
@@ -16,7 +16,7 @@ func Test_configFromSpec(t *testing.T) {
 		disableFencingEnvVar:       "false",
 		disableTelemetryEnvVar:     "false",
 		k8sSchedulerExtenderEnvVar: "true",
-		v1NamespaceEnvVar:          "storageos",
+		v1NamespaceEnvVar:          "kube-system",
 		logFormatEnvVar:            "text",
 		logLevelEnvVar:             "info",
 	}
@@ -30,7 +30,7 @@ func Test_configFromSpec(t *testing.T) {
 		disableVersionCheckEnvVar:   "false",
 		etcdEndpointsEnvVar:         "",
 		k8sSchedulerExtenderEnvVar:  "true",
-		v2NamespaceEnvVar:           "storageos",
+		v2NamespaceEnvVar:           "kube-system",
 		logFormatEnvVar:             "json",
 		logLevelEnvVar:              "info",
 		// disableFencingEnvVar:        "false",

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -36,7 +36,7 @@ var gvk = schema.GroupVersionKind{
 
 var testScheme = runtime.NewScheme()
 
-const defaultNS = "storageos"
+const defaultNS = "kube-system"
 
 // getFakeDiscoveryClient returns a discovery client with pre-defined resource
 // list.

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -1278,7 +1278,7 @@ func TestDeployTLSEtcdCerts(t *testing.T) {
 	}
 	nsName := types.NamespacedName{
 		Name:      TLSEtcdSecretName,
-		Namespace: "storageos",
+		Namespace: "kube-system",
 	}
 	if err := c.Get(context.Background(), nsName, stosEtcdSecret); err != nil {
 		t.Fatalf("expected %q secret to exist, but not found", stosEtcdSecret)

--- a/test/e2e/clusterCSIDeployment_test.go
+++ b/test/e2e/clusterCSIDeployment_test.go
@@ -21,7 +21,7 @@ import (
 func TestClusterCSIDeployment(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	resourceNS := "storageos"
+	resourceNS := "kube-system"
 
 	namespace, err := ctx.GetNamespace()
 	if err != nil {

--- a/test/e2e/clusterCSINodeV2_test.go
+++ b/test/e2e/clusterCSINodeV2_test.go
@@ -19,7 +19,7 @@ import (
 func TestClusterCSINodeV2(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	resourceNS := "storageos"
+	resourceNS := "kube-system"
 
 	namespace, err := ctx.GetNamespace()
 	if err != nil {

--- a/test/e2e/clusterCSI_test.go
+++ b/test/e2e/clusterCSI_test.go
@@ -19,7 +19,7 @@ import (
 func TestClusterCSI(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	resourceNS := "storageos"
+	resourceNS := "kube-system"
 
 	namespace, err := ctx.GetNamespace()
 	if err != nil {

--- a/test/e2e/clusterInTreePlugin_test.go
+++ b/test/e2e/clusterInTreePlugin_test.go
@@ -17,7 +17,7 @@ import (
 func TestClusterInTreePlugin(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	resourceNS := "storageos"
+	resourceNS := "kube-system"
 
 	namespace, err := ctx.GetNamespace()
 	if err != nil {

--- a/test/port-forward.sh
+++ b/test/port-forward.sh
@@ -10,8 +10,8 @@
 # host runs k8s directly, 5705 will already be in use by the storageos running
 # on the host. In case of KinD, the host port remains free. In order to test
 # this on both the environment, the host port is changed.
-podname=$(kubectl -n storageos get pods -o=name | grep daemonset)
-kubectl -n storageos port-forward $podname 5709:5705 >> pf.log 2>&1 &
+podname=$(kubectl -n kube-system get pods -o=name | grep daemonset)
+kubectl -n kube-system port-forward $podname 5709:5705 >> pf.log 2>&1 &
 pid=$!
 
 sleep 7


### PR DESCRIPTION
Previously we advised customers to install the StorageOS containers into the `kube-system` namespace so that we can set the `system-node-critical` priority-class, which instructs Kubernetes to evict our pods last if there is resource contention.

This PR changes the default so that users don't have to manually set this.

The CRs for Openshift via the Marketplace have not changed and still use `openshift-operators`.

We are not intending to merge this into the v1 branch, so new clusters created by a v1 operator will not be affected.