### PR TITLE
Use golangci-lint and cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,5 +13,5 @@ jobs:
       - checkout
 
       # specify any bash command here prefixed with `run: `
-      - run: go get golang.org/x/lint/golint
+      - run: make lint
       - run: make all

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/_output
 build/_test
 build/operator-sdk
 build/yq
+build/golangci-lint
 deploy/test
 /olm
 storageos-operator.yaml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+run:
+  skip-dirs:
+    - pkg/client
+    - internal/pkg/cert
+    - internal/pkg/crv01
+
+linters:
+  enable:
+    - gofmt
+    - goimports
+    - unconvert
+    - nakedret
+    - scopelint
+    - whitespace
+    # - gomnd
+    # - gocyclo

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -67,7 +67,6 @@ var (
 )
 
 func main() {
-
 	logf.SetLogger(zap.Logger(true))
 
 	log.WithValues(

--- a/cmd/upgrader/main.go
+++ b/cmd/upgrader/main.go
@@ -13,7 +13,6 @@ import (
 var log = logf.Log.WithName("storageos.upgrader")
 
 func main() {
-
 	cfg, err := restclient.InClusterConfig()
 	if err != nil {
 		fatal(err)

--- a/internal/pkg/admission/scheduler/handler_test.go
+++ b/internal/pkg/admission/scheduler/handler_test.go
@@ -27,9 +27,15 @@ func TestMutatePodFn(t *testing.T) {
 
 	// Create a new scheme and add all the types from different clientsets.
 	scheme := runtime.NewScheme()
-	kscheme.AddToScheme(scheme)
-	apiextensionsv1beta1.AddToScheme(scheme)
-	storageosapis.AddToScheme(scheme)
+	if err := kscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := apiextensionsv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := storageosapis.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
 
 	// StorageOS StorageClass.
 	stosSC := &storagev1.StorageClass{
@@ -140,6 +146,7 @@ func TestMutatePodFn(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// StorageOS Cluster with scheduler configured.
 			stosCluster := &storageosv1.StorageOSCluster{

--- a/internal/pkg/admission/scheduler/helper_test.go
+++ b/internal/pkg/admission/scheduler/helper_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestPodSchedulerSetter_IsManagedVolume(t *testing.T) {
-
 	// Test values only.
 	storageosSchedulerName := "storageos-scheduler"
 	storageosCSIProvisioner := "storageos"
@@ -23,9 +22,15 @@ func TestPodSchedulerSetter_IsManagedVolume(t *testing.T) {
 
 	// Create a new scheme and add all the types from different clientsets.
 	scheme := runtime.NewScheme()
-	kscheme.AddToScheme(scheme)
-	apiextensionsv1beta1.AddToScheme(scheme)
-	storageosapis.AddToScheme(scheme)
+	if err := kscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := apiextensionsv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := storageosapis.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
 
 	// StorageOS StorageClass.
 	stosSC := &storagev1.StorageClass{
@@ -98,8 +103,8 @@ func TestPodSchedulerSetter_IsManagedVolume(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-
 			// Create all the above resources and get a k8s client.
 			client := fake.NewFakeClientWithScheme(scheme, stosSC, stosNativeSC, fooSC, tt.pvc)
 

--- a/internal/pkg/storageoscluster/cluster.go
+++ b/internal/pkg/storageoscluster/cluster.go
@@ -31,6 +31,7 @@ func GetCurrentStorageOSCluster(kclient client.Client) (*storageosv1.StorageOSCl
 
 	// If there are multiple clusters, consider the status of the cluster.
 	for _, cluster := range clusterList.Items {
+		cluster := cluster
 		// Only one cluster can be in running phase at a time.
 		if cluster.Status.Phase == storageosv1.ClusterPhaseRunning {
 			currentCluster = &cluster

--- a/internal/pkg/storageoscluster/cluster_test.go
+++ b/internal/pkg/storageoscluster/cluster_test.go
@@ -19,7 +19,6 @@ func getTestCluster(
 	name string, namespace string,
 	spec storageosv1.StorageOSClusterSpec,
 	status storageosv1.StorageOSClusterStatus) *storageosv1.StorageOSCluster {
-
 	return &storageosv1.StorageOSCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -36,8 +35,12 @@ func TestGetCurrentStorageOSCluster(t *testing.T) {
 
 	// Create a new scheme and add the required schemes to it.
 	scheme := runtime.NewScheme()
-	kscheme.AddToScheme(scheme)
-	storageosapis.AddToScheme(scheme)
+	if err := kscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := storageosapis.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
 
 	testcases := []struct {
 		name            string

--- a/pkg/apis/storageos/v1/nfsserver_types.go
+++ b/pkg/apis/storageos/v1/nfsserver_types.go
@@ -81,7 +81,7 @@ func (s NFSServerSpec) GetContainerImage(clusterNFSImage string) string {
 // GetRequestedCapacity returns the requested capacity for the NFS volume.
 func (s NFSServerSpec) GetRequestedCapacity() resource.Quantity {
 	if s.Resources.Requests != nil {
-		if capacity, exists := s.Resources.Requests[corev1.ResourceName(corev1.ResourceStorage)]; exists {
+		if capacity, exists := s.Resources.Requests[corev1.ResourceStorage]; exists {
 			return capacity
 		}
 	}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -90,7 +90,6 @@ type ReconcileJob struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileJob) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-
 	log := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	// log.Info("Reconciling Job")
 

--- a/pkg/controller/nfsserver/nfsserver_controller.go
+++ b/pkg/controller/nfsserver/nfsserver_controller.go
@@ -36,6 +36,8 @@ var log = logf.Log.WithName("controller_nfsserver")
 const (
 	finalizer    = "finalizer.nfsserver.storageos.com"
 	appComponent = "nfs-server"
+
+	reconcilePeriodSeconds = 15
 )
 
 // Add creates a new NFSServer Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -122,7 +124,7 @@ func (r *ReconcileNFSServer) Reconcile(request reconcile.Request) (reconcile.Res
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	// reqLogger.Info("Reconciling NFSServer")
 
-	reconcilePeriod := 15 * time.Second
+	reconcilePeriod := reconcilePeriodSeconds * time.Second
 	reconcileResult := reconcile.Result{RequeueAfter: reconcilePeriod}
 
 	// Fetch the NFSServer instance
@@ -151,7 +153,6 @@ func (r *ReconcileNFSServer) reconcile(instance *storageosv1.NFSServer) error {
 	// Add our finalizer immediately so we can cleanup a partial deployment.  If
 	// this is not set, the CR can simply be deleted.
 	if len(instance.GetFinalizers()) == 0 {
-
 		// Add our finalizer so that we control deletion.
 		if err := r.addFinalizer(instance); err != nil {
 			return err
@@ -234,7 +235,6 @@ func (r *ReconcileNFSServer) reconcile(instance *storageosv1.NFSServer) error {
 }
 
 func (r *ReconcileNFSServer) addFinalizer(instance *storageosv1.NFSServer) error {
-
 	instance.SetFinalizers(append(instance.GetFinalizers(), finalizer))
 
 	// Update CR
@@ -275,22 +275,4 @@ func (r *ReconcileNFSServer) updateSpec(instance *storageosv1.NFSServer, cluster
 		return true, nil
 	}
 	return false, nil
-}
-
-func contains(list []string, s string) bool {
-	for _, v := range list {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-
-func remove(list []string, s string) []string {
-	for i, v := range list {
-		if v == s {
-			list = append(list[:i], list[i+1:]...)
-		}
-	}
-	return list
 }

--- a/pkg/controller/nfsserver/nfsserver_controller_test.go
+++ b/pkg/controller/nfsserver/nfsserver_controller_test.go
@@ -20,7 +20,6 @@ func getTestCluster(
 	name string, namespace string,
 	spec storageosv1.StorageOSClusterSpec,
 	status storageosv1.StorageOSClusterStatus) *storageosv1.StorageOSCluster {
-
 	return &storageosv1.StorageOSCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -36,7 +35,6 @@ func getTestNFSServer(
 	name string, namespace string,
 	spec storageosv1.NFSServerSpec,
 	status storageosv1.NFSServerStatus) *storageosv1.NFSServer {
-
 	return &storageosv1.NFSServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -125,7 +123,9 @@ func TestUpdateSpec(t *testing.T) {
 			// Create a new scheme and add StorageOS APIs to it. Pass this to the
 			// k8s client so that it can create StorageOS resources.
 			testScheme := runtime.NewScheme()
-			storageosapis.AddToScheme(testScheme)
+			if err := storageosapis.AddToScheme(testScheme); err != nil {
+				t.Fatal(err)
+			}
 
 			client := fake.NewFakeClientWithScheme(testScheme, tc.cluster, tc.nfsServer)
 

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -45,6 +45,7 @@ func TestUpdateLabels(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ret := updateLabels(tt.arg1, tt.arg2)
 			if tt.ret != ret {

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -30,7 +30,11 @@ import (
 
 var log = logf.Log.WithName("storageos.cluster")
 
-const clusterFinalizer = "finalizer.storageoscluster.storageos.com"
+const (
+	clusterFinalizer = "finalizer.storageoscluster.storageos.com"
+
+	reconcilePeriodSeconds = 15
+)
 
 // Add creates a new StorageOSCluster Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -123,13 +127,12 @@ func (r *ReconcileStorageOSCluster) ResetCurrentCluster() {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileStorageOSCluster) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-
 	log := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	// log.Info("Reconciling Cluster")
 
 	// Return this for a retry of the reconciliation loop after a period of
 	// time.
-	reconcilePeriod := 15 * time.Second
+	reconcilePeriod := reconcilePeriodSeconds * time.Second
 	reconcileResult := reconcile.Result{RequeueAfter: reconcilePeriod}
 
 	// Return this for a immediate retry of the reconciliation loop with the

--- a/pkg/controller/storageoscluster/storageoscluster_controller_test.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller_test.go
@@ -26,7 +26,6 @@ var gvk = schema.GroupVersionKind{
 }
 
 func TestGenerateJoinToken(t *testing.T) {
-
 	testcases := []struct {
 		name      string
 		nodes     []*corev1.Node
@@ -37,17 +36,17 @@ func TestGenerateJoinToken(t *testing.T) {
 		{
 			name: "three-node no selector",
 			nodes: []*corev1.Node{
-				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "fake-node1"},
+				{ObjectMeta: metav1.ObjectMeta{Name: "fake-node1"},
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "0.0.0.0"}},
 					},
 				},
-				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "fake-node2"},
+				{ObjectMeta: metav1.ObjectMeta{Name: "fake-node2"},
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "0.0.0.1"}},
 					},
 				},
-				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "fake-node3"},
+				{ObjectMeta: metav1.ObjectMeta{Name: "fake-node3"},
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "0.0.0.2"}},
 					},
@@ -60,7 +59,7 @@ func TestGenerateJoinToken(t *testing.T) {
 		{
 			name: "three-node with node selector",
 			nodes: []*corev1.Node{
-				&corev1.Node{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "fake-node1",
 						Labels: map[string]string{"foo": "baz"},
@@ -69,7 +68,7 @@ func TestGenerateJoinToken(t *testing.T) {
 						Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "0.0.0.0"}},
 					},
 				},
-				&corev1.Node{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "fake-node2",
 						Labels: map[string]string{"foo4": "baz4"},
@@ -78,7 +77,7 @@ func TestGenerateJoinToken(t *testing.T) {
 						Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "0.0.0.1"}},
 					},
 				},
-				&corev1.Node{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "fake-node3",
 						Labels: map[string]string{"foo0": "baz0", "foo": "baz"},
@@ -109,7 +108,7 @@ func TestGenerateJoinToken(t *testing.T) {
 			name: "unsupported node selector operator",
 			// Need at least one node to run the node selector operator block.
 			nodes: []*corev1.Node{
-				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "fake-node1"},
+				{ObjectMeta: metav1.ObjectMeta{Name: "fake-node1"},
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "0.0.0.0"}},
 					},
@@ -134,14 +133,22 @@ func TestGenerateJoinToken(t *testing.T) {
 
 		// Create fake node objects.
 		for _, node := range tc.nodes {
-			controllerClient.Create(context.Background(), node)
+			if err := controllerClient.Create(context.Background(), node); err != nil {
+				t.Fatal(err)
+			}
 		}
 		testScheme := runtime.NewScheme()
 
 		// Register all the schemes.
-		kscheme.AddToScheme(testScheme)
-		apiextensionsv1beta1.AddToScheme(testScheme)
-		storageosapis.AddToScheme(testScheme)
+		if err := kscheme.AddToScheme(testScheme); err != nil {
+			t.Fatal(err)
+		}
+		if err := apiextensionsv1beta1.AddToScheme(testScheme); err != nil {
+			t.Fatal(err)
+		}
+		if err := storageosapis.AddToScheme(testScheme); err != nil {
+			t.Fatal(err)
+		}
 
 		// Create kubernetes client for event recorder.
 		kubeClient := clientgofake.NewSimpleClientset()

--- a/pkg/nfs/configmap.go
+++ b/pkg/nfs/configmap.go
@@ -22,7 +22,6 @@ const (
 )
 
 func createConfig(instance *storageosv1.NFSServer) (string, error) {
-
 	// id needs to be unique for each export on the server node.
 	id := 57
 

--- a/pkg/nfs/configmap_test.go
+++ b/pkg/nfs/configmap_test.go
@@ -259,6 +259,7 @@ func TestGetExportSpec(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			nfsServer := &storageosv1.NFSServer{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/nfs/delete_test.go
+++ b/pkg/nfs/delete_test.go
@@ -65,6 +65,7 @@ func TestDelete(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewFakeClient(existingPVC)
 			kConfig := &rest.Config{}

--- a/pkg/nfs/deploy.go
+++ b/pkg/nfs/deploy.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	appName         = "storageos"
-	statefulsetKind = "statefulset"
+	appName = "storageos"
 
 	serviceAccountPrefix = "storageos-nfs"
 
@@ -157,7 +156,6 @@ func (d *Deployment) createServiceAccountForNFSServer() error {
 }
 
 func (d *Deployment) createServiceMonitor() error {
-
 	metricsService, err := d.getMetricsService()
 	if err != nil {
 		return err

--- a/pkg/nfs/deploy_test.go
+++ b/pkg/nfs/deploy_test.go
@@ -40,6 +40,7 @@ func TestDeploy(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewFakeClient()
 			kConfig := &rest.Config{}

--- a/pkg/nfs/deployment.go
+++ b/pkg/nfs/deployment.go
@@ -29,7 +29,6 @@ func NewDeployment(
 	labels map[string]string,
 	recorder record.EventRecorder,
 	scheme *runtime.Scheme) *Deployment {
-
 	return &Deployment{
 		client:             client,
 		kConfig:            kConfig,

--- a/pkg/nfs/pvc.go
+++ b/pkg/nfs/pvc.go
@@ -13,7 +13,7 @@ func (d *Deployment) createPVC(size *resource.Quantity) error {
 		StorageClassName: &scName,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceName(corev1.ResourceStorage): *size,
+				corev1.ResourceStorage: *size,
 			},
 		},
 	}

--- a/pkg/nfs/service.go
+++ b/pkg/nfs/service.go
@@ -10,7 +10,6 @@ import (
 )
 
 func (d *Deployment) ensureService(nfsPort int) error {
-
 	// If no error in getting the service, service already exists, do nothing.
 	if _, err := d.getServerService(); err == nil {
 		return nil
@@ -46,7 +45,7 @@ func (d *Deployment) createService(name string, portName string, port int, label
 			{
 				Name:       portName,
 				Port:       int32(port),
-				TargetPort: intstr.FromInt(int(port)),
+				TargetPort: intstr.FromInt(port),
 			},
 		},
 	}

--- a/pkg/nfs/statefulset.go
+++ b/pkg/nfs/statefulset.go
@@ -14,7 +14,6 @@ const (
 )
 
 func (d *Deployment) createStatefulSet(pvcVS *corev1.PersistentVolumeClaimVolumeSource, nfsPort int, httpPort int) error {
-
 	replicas := int32(1)
 
 	spec := &appsv1.StatefulSetSpec{
@@ -35,7 +34,9 @@ func (d *Deployment) createStatefulSet(pvcVS *corev1.PersistentVolumeClaimVolume
 	}
 	spec.Template.Spec.Volumes = append(spec.Template.Spec.Volumes, vol)
 
-	util.AddTolerations(&spec.Template.Spec, d.nfsServer.Spec.Tolerations)
+	if err := util.AddTolerations(&spec.Template.Spec, d.nfsServer.Spec.Tolerations); err != nil {
+		return err
+	}
 
 	// If the cluster was configured with node selectors to only run on certain
 	// nodes, use the same selectors to selct the nodes that the NFS pods can

--- a/pkg/nfs/status.go
+++ b/pkg/nfs/status.go
@@ -19,7 +19,6 @@ const (
 )
 
 func (s *Deployment) updateStatus(status *storageosv1.NFSServerStatus) error {
-
 	if reflect.DeepEqual(s.nfsServer.Status, *status) {
 		return nil
 	}
@@ -41,7 +40,6 @@ func (s *Deployment) updateStatus(status *storageosv1.NFSServerStatus) error {
 
 // getStatus determines the status of the NFS Server deployment.
 func (s *Deployment) getStatus() (*storageosv1.NFSServerStatus, error) {
-
 	status := &storageosv1.NFSServerStatus{
 		Phase:        storageosv1.PhaseUnknown,
 		RemoteTarget: "",

--- a/pkg/storageos/configmap.go
+++ b/pkg/storageos/configmap.go
@@ -30,13 +30,13 @@ const (
 	v2EtcdTLSClientCAEnvVar   = "ETCD_TLS_CLIENT_CA"
 
 	// TODO: ETCD authentication information
-	etcdUsernameEnvVar = "ETCD_USERNAME"
-	etcdPasswordEnvVar = "ETCD_PASSWORD"
+	// etcdUsernameEnvVar = "ETCD_USERNAME"
+	// etcdPasswordEnvVar = "ETCD_PASSWORD"
 
 	// TODO: ETCD namespace in which to operate. All keys in ETCD will be prefixed by
 	// this value, allowing for multiple clusters to operate on the same ETCD
 	// instance.
-	etcdNamespaceEnvVar = "ETCD_NAMESPACE"
+	// etcdNamespaceEnvVar = "ETCD_NAMESPACE"
 
 	// Feature flags (enabled by default)
 	disableFencingEnvVar = "DISABLE_FENCING"
@@ -64,7 +64,7 @@ const (
 	k8sSchedulerExtenderEnvVar = "K8S_ENABLE_SCHEDULER_EXTENDER"
 
 	// TODO: Path to kubernetes config file.
-	kubconfigPathEnvVar = "KUBECONFIG"
+	// kubconfigPathEnvVar = "KUBECONFIG"
 
 	// CSI API listen socket location.  CSI is disabled if not set.
 	csiEndpointEnvVar = "CSI_ENDPOINT"
@@ -78,9 +78,9 @@ const (
 	// TODO: add to StorageOSCluster CR and optionally create Certificate CR?
 	// https://cert-manager.io/docs/usage/certificate/ Since secrets will be
 	// used, probably needs to be implemented in DaemonSet.
-	apiTLSCAEnvVar   = "API_TLS_CA"
-	apiTLSKeyEnvVar  = "API_TLS_KEY"
-	apiTLSCertEnvVar = "API_TLS_CERT"
+	// apiTLSCAEnvVar   = "API_TLS_CA"
+	// apiTLSKeyEnvVar  = "API_TLS_KEY"
+	// apiTLSCertEnvVar = "API_TLS_CERT"
 
 	// TODO: add to StorageOSCluster CR
 	// Health checking duration values
@@ -88,12 +88,12 @@ const (
 	// A duration string is a possibly signed sequence of decimal numbers, each
 	// with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
 	// "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-	healthProbeIntervalEnvVar = "HEALTH_PROBE_INTERVAL"
-	healthProbeTimeoutEnvVar  = "HEALTH_PROBE_TIMEOUT"
-	healthGracePeriodEnvVar   = "HEALTH_GRACE_PERIOD"
+	// healthProbeIntervalEnvVar = "HEALTH_PROBE_INTERVAL"
+	// healthProbeTimeoutEnvVar  = "HEALTH_PROBE_TIMEOUT"
+	// healthGracePeriodEnvVar   = "HEALTH_GRACE_PERIOD"
 
 	// Node capacity update interval.
-	nodeCapacityUpdateIntervalEnvVar = "NODE_CAPACITY_INTERVAL"
+	// nodeCapacityUpdateIntervalEnvVar = "NODE_CAPACITY_INTERVAL"
 
 	// TODO: General dial timeout settings (RPC, etcd...)
 	//
@@ -102,7 +102,7 @@ const (
 	// "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	//
 	// defaults to 5s.
-	dialTimeoutEnvVar = "DIAL_TIMEOUT"
+	// dialTimeoutEnvVar = "DIAL_TIMEOUT"
 
 	// Logging level: debug, info, warn or error.
 	logLevelEnvVar = "LOG_LEVEL"
@@ -129,7 +129,6 @@ const (
 
 // createService creates a ConfigMap to store the node container configuration.
 func (s *Deployment) createConfigMap() error {
-
 	config := configFromSpec(s.stos.Spec, CSIV1Supported(s.k8sVersion), s.nodev2)
 
 	labels := make(map[string]string)
@@ -292,7 +291,6 @@ func v2ConfigFromSpec(spec storageosv1.StorageOSClusterSpec) map[string]string {
 // addEtcdTLSConfig adds the config entries for TLS config.  The ENV var names
 // are different between V1 & V2.
 func addEtcdTLSConfig(config map[string]string, v2 bool) map[string]string {
-
 	caCert := v1EtcdTLSClientCAEnvVar
 	clientKey := v1EtcdTLSClientKeyEnvVar
 	clientCert := v1EtcdTLSClientCertEnvVar

--- a/pkg/storageos/configmap_test.go
+++ b/pkg/storageos/configmap_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func Test_configFromSpec(t *testing.T) {
-
 	v1DefaultSpec := storageosv1.StorageOSClusterSpec{}
 	v1DefaultConfig := map[string]string{
 		joinEnvVar:                 "",
@@ -398,6 +397,7 @@ func Test_configFromSpec(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Set wanted env vars.
 			// Don't parallelize tests as they will conflict.

--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -53,7 +53,9 @@ func (s Deployment) createCSIHelperStatefulSet(replicas int32) error {
 		},
 	}
 
-	s.addCommonPodProperties(&spec.Template.Spec)
+	if err := s.addCommonPodProperties(&spec.Template.Spec); err != nil {
+		return err
+	}
 
 	return s.k8sResourceManager.StatefulSet(statefulsetName, s.stos.Spec.GetResourceNS(), nil, spec).Create()
 }
@@ -82,7 +84,9 @@ func (s Deployment) createCSIHelperDeployment(replicas int32) error {
 		},
 	}
 
-	s.addCommonPodProperties(&spec.Template.Spec)
+	if err := s.addCommonPodProperties(&spec.Template.Spec); err != nil {
+		return err
+	}
 
 	return s.k8sResourceManager.Deployment(csiHelperName, s.stos.Spec.GetResourceNS(), nil, spec).Create()
 }

--- a/pkg/storageos/ingress.go
+++ b/pkg/storageos/ingress.go
@@ -19,7 +19,7 @@ func (s *Deployment) createIngress() error {
 
 	if s.stos.Spec.Ingress.TLS {
 		spec.TLS = []v1beta1.IngressTLS{
-			v1beta1.IngressTLS{
+			{
 				Hosts:      []string{s.stos.Spec.Ingress.Hostname},
 				SecretName: tlsSecretName,
 			},

--- a/pkg/storageos/podspec.go
+++ b/pkg/storageos/podspec.go
@@ -133,7 +133,6 @@ func (s *Deployment) addCSI(podSpec *corev1.PodSpec) {
 		// set in the StorageClass.
 		envVar := []corev1.EnvVar{}
 		if !s.nodev2 {
-
 			// Append CSI Provision Creds env var if enabled.
 			if s.stos.Spec.CSI.EnableProvisionCreds {
 				envVar = append(

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -74,7 +74,9 @@ func (s Deployment) createSchedulerDeployment(replicas int32) error {
 	}
 
 	// Add cluster config tolerations.
-	s.addTolerations(&spec.Template.Spec)
+	if err := s.addTolerations(&spec.Template.Spec); err != nil {
+		return err
+	}
 
 	// Add pod toleration for quick recovery on node failure.
 	addPodTolerationForRecovery(&spec.Template.Spec)

--- a/pkg/storageos/update_status.go
+++ b/pkg/storageos/update_status.go
@@ -55,7 +55,6 @@ func (s *Deployment) updateStorageOSStatus(status *storageosv1.StorageOSClusterS
 }
 
 func (s *Deployment) getStorageOSStatus() (*storageosv1.StorageOSClusterStatus, error) {
-
 	// Create an empty array because it's used to create cluster status. An
 	// uninitialized array results in error at cluster status validation.
 	// error: status.nodes in body must be of type array: "null"
@@ -108,7 +107,6 @@ func (s *Deployment) getStorageOSV2Status(nodeIPs []string) (*storageosv1.Storag
 // getStorageOSV1Status queries health of all the nodes in the join token and
 // returns the cluster status.
 func (s *Deployment) getStorageOSV1Status(nodeIPs []string) (*storageosv1.StorageOSClusterStatus, error) {
-
 	var readyNodes int
 
 	totalNodes := len(nodeIPs)
@@ -142,11 +140,8 @@ func (s *Deployment) getStorageOSV1Status(nodeIPs []string) (*storageosv1.Storag
 }
 
 func isHealthy(health *storageosv1.NodeHealth) bool {
-	if health.DirectfsInitiator+health.Director+health.KV+health.KVWrite+
-		health.Nats+health.Presentation+health.Rdb == strings.Repeat("alive", 7) {
-		return true
-	}
-	return false
+	return health.DirectfsInitiator+health.Director+health.KV+health.KVWrite+
+		health.Nats+health.Presentation+health.Rdb == strings.Repeat("alive", 7)
 }
 
 func isListening(host string, port string, timeout time.Duration) bool {

--- a/pkg/util/k8s/k8s_test.go
+++ b/pkg/util/k8s/k8s_test.go
@@ -189,6 +189,7 @@ func TestResourceManager(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewFakeClient()
 

--- a/pkg/util/k8s/resource/clusterrole.go
+++ b/pkg/util/k8s/resource/clusterrole.go
@@ -26,7 +26,6 @@ func NewClusterRole(
 	name string,
 	labels map[string]string,
 	rules []rbacv1.PolicyRule) *ClusterRole {
-
 	return &ClusterRole{
 		NamespacedName: types.NamespacedName{
 			Name: name,

--- a/pkg/util/k8s/resource/clusterrolebinding.go
+++ b/pkg/util/k8s/resource/clusterrolebinding.go
@@ -29,7 +29,6 @@ func NewClusterRoleBinding(
 	labels map[string]string,
 	subjects []rbacv1.Subject,
 	roleRef *rbacv1.RoleRef) *ClusterRoleBinding {
-
 	return &ClusterRoleBinding{
 		NamespacedName: types.NamespacedName{
 			Name: name,

--- a/pkg/util/k8s/resource/csidriver.go
+++ b/pkg/util/k8s/resource/csidriver.go
@@ -26,7 +26,6 @@ func NewCSIDriver(
 	name string,
 	labels map[string]string,
 	spec *storagev1beta1.CSIDriverSpec) *CSIDriver {
-
 	return &CSIDriver{
 		NamespacedName: types.NamespacedName{
 			Name: name,

--- a/pkg/util/k8s/resource/daemonset.go
+++ b/pkg/util/k8s/resource/daemonset.go
@@ -26,7 +26,6 @@ func NewDaemonSet(
 	name, namespace string,
 	labels map[string]string,
 	spec *appsv1.DaemonSetSpec) *DaemonSet {
-
 	return &DaemonSet{
 		NamespacedName: types.NamespacedName{
 			Name:      name,

--- a/pkg/util/k8s/resource/deployment.go
+++ b/pkg/util/k8s/resource/deployment.go
@@ -26,7 +26,6 @@ func NewDeployment(
 	name, namespace string,
 	labels map[string]string,
 	spec *appsv1.DeploymentSpec) *Deployment {
-
 	return &Deployment{
 		NamespacedName: types.NamespacedName{
 			Name:      name,

--- a/pkg/util/k8s/resource/ingress.go
+++ b/pkg/util/k8s/resource/ingress.go
@@ -28,7 +28,6 @@ func NewIngress(
 	labels map[string]string,
 	annotations map[string]string,
 	spec *extensionsv1beta1.IngressSpec) *Ingress {
-
 	return &Ingress{
 		NamespacedName: types.NamespacedName{
 			Name:      name,

--- a/pkg/util/k8s/resource/pvc.go
+++ b/pkg/util/k8s/resource/pvc.go
@@ -26,7 +26,6 @@ func NewPVC(
 	name, namespace string,
 	labels map[string]string,
 	spec *corev1.PersistentVolumeClaimSpec) *PVC {
-
 	return &PVC{
 		NamespacedName: types.NamespacedName{
 			Name:      name,

--- a/pkg/util/k8s/resource/role.go
+++ b/pkg/util/k8s/resource/role.go
@@ -26,7 +26,6 @@ func NewRole(
 	name, namespace string,
 	labels map[string]string,
 	rules []rbacv1.PolicyRule) *Role {
-
 	return &Role{
 		NamespacedName: types.NamespacedName{
 			Name:      name,

--- a/pkg/util/k8s/resource/rolebinding.go
+++ b/pkg/util/k8s/resource/rolebinding.go
@@ -28,7 +28,6 @@ func NewRoleBinding(
 	labels map[string]string,
 	subjects []rbacv1.Subject,
 	roleRef *rbacv1.RoleRef) *RoleBinding {
-
 	return &RoleBinding{
 		NamespacedName: types.NamespacedName{
 			Name:      name,

--- a/pkg/util/k8s/resource/secret.go
+++ b/pkg/util/k8s/resource/secret.go
@@ -28,7 +28,6 @@ func NewSecret(
 	labels map[string]string,
 	secType corev1.SecretType,
 	data map[string][]byte) *Secret {
-
 	return &Secret{
 		NamespacedName: types.NamespacedName{
 			Name:      name,

--- a/pkg/util/k8s/resource/service.go
+++ b/pkg/util/k8s/resource/service.go
@@ -29,7 +29,6 @@ func NewService(
 	labels map[string]string,
 	annotations map[string]string,
 	spec *corev1.ServiceSpec) *Service {
-
 	return &Service{
 		NamespacedName: types.NamespacedName{
 			Name:      name,

--- a/pkg/util/k8s/resource/serviceaccount.go
+++ b/pkg/util/k8s/resource/serviceaccount.go
@@ -24,7 +24,6 @@ func NewServiceAccount(
 	c client.Client,
 	name, namespace string,
 	labels map[string]string) *ServiceAccount {
-
 	return &ServiceAccount{
 		NamespacedName: types.NamespacedName{
 			Name:      name,

--- a/pkg/util/k8s/resource/statefulset.go
+++ b/pkg/util/k8s/resource/statefulset.go
@@ -26,7 +26,6 @@ func NewStatefulSet(
 	name, namespace string,
 	labels map[string]string,
 	spec *appsv1.StatefulSetSpec) *StatefulSet {
-
 	return &StatefulSet{
 		NamespacedName: types.NamespacedName{
 			Name:      name,

--- a/pkg/util/k8s/resource/storageclass.go
+++ b/pkg/util/k8s/resource/storageclass.go
@@ -28,7 +28,6 @@ func NewStorageClass(
 	labels map[string]string,
 	provisioner string,
 	params map[string]string) *StorageClass {
-
 	return &StorageClass{
 		NamespacedName: types.NamespacedName{
 			Name: name,

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -135,6 +135,7 @@ func (k K8SOps) GetStatefulSetsUsingStorageClassProvisioner(provisionerName stri
 		}
 
 		for _, template := range s.Spec.VolumeClaimTemplates {
+			template := template
 			sc, err := k.GetStorageClassForPVC(&template)
 			if err == nil && sc.Provisioner == provisionerName {
 				scStatefulsets.Items = append(scStatefulsets.Items, s)
@@ -189,6 +190,7 @@ func (k K8SOps) ScaleDownApps() error {
 
 	var valZero int32
 	for _, d := range deps.Items {
+		d := d
 		k.logger.WithValues("Namespace", d.GetNamespace(), "Name", d.GetName()).Info("scaling down deployment")
 
 		t := func() (interface{}, bool, error) {
@@ -223,6 +225,7 @@ func (k K8SOps) ScaleDownApps() error {
 	}
 
 	for _, s := range ss.Items {
+		s := s
 		k.logger.WithValues("Namespace", s.GetNamespace(), "Name", s.GetName()).Info("scaling down statefulset")
 
 		t := func() (interface{}, bool, error) {
@@ -268,6 +271,7 @@ func (k K8SOps) ScaleUpApps() error {
 	}
 
 	for _, d := range deps.Items {
+		d := d
 		k.logger.WithValues("Namespace", d.Namespace, "Name", d.Name).Info("restoring app")
 
 		t := func() (interface{}, bool, error) {
@@ -314,6 +318,7 @@ func (k K8SOps) ScaleUpApps() error {
 	}
 
 	for _, s := range ss.Items {
+		s := s
 		k.logger.WithValues("Namespace", s.Namespace, "Name", s.Name).Info("restoring app")
 
 		t := func() (interface{}, bool, error) {
@@ -357,7 +362,6 @@ func (k K8SOps) ScaleUpApps() error {
 		if _, err := task.DoRetryWithTimeout(t, statefulSetUpdateTimeout, defaultRetryInterval, k.logger); err != nil {
 			return err
 		}
-
 	}
 
 	return nil
@@ -433,7 +437,7 @@ func (k K8SOps) UpgradeDaemonSet(newImage string) error {
 			return nil, true, err
 		}
 
-		expectedGeneration, _ := expectedGenerations[ds.UID]
+		expectedGeneration := expectedGenerations[ds.UID]
 		if updatedDS.Status.ObservedGeneration != expectedGeneration {
 			return nil, true, fmt.Errorf("daemonset: [%s] %s still running previous generation: %d. Expected generation %d", ds.GetNamespace(), ds.GetName(), updatedDS.Status.ObservedGeneration, expectedGeneration)
 		}

--- a/pkg/util/k8sutil/k8sutil_test.go
+++ b/pkg/util/k8sutil/k8sutil_test.go
@@ -5,7 +5,6 @@ import (
 )
 
 func TestGetBaseK8SVersion(t *testing.T) {
-
 	testcases := []struct {
 		name        string
 		version     string
@@ -40,6 +39,7 @@ func TestGetBaseK8SVersion(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			k := K8SOps{}
 			version, err := k.getBaseK8SVersion(tc.version)

--- a/test/e2e/util/admission_controller.go
+++ b/test/e2e/util/admission_controller.go
@@ -21,11 +21,14 @@ import (
 // backed by StorageOS and a pod that uses the PVC.
 // NOTE: This test has a minimum k8s version requirement.
 func PodSchedulerAdmissionControllerTest(t *testing.T, ctx *framework.TestCtx) {
+	k8sVerMajor := 1
+	k8sVerMinor := 13
+	k8sVerPatch := 0
 	// Minimum version of k8s required to run this test.
 	minVersion := semver.Version{
-		Major: 1,
-		Minor: 13,
-		Patch: 0,
+		Major: uint64(k8sVerMajor),
+		Minor: uint64(k8sVerMinor),
+		Patch: uint64(k8sVerPatch),
 	}
 
 	// Check the k8s version before running this test. Admission controller

--- a/test/e2e/util/cluster.go
+++ b/test/e2e/util/cluster.go
@@ -345,9 +345,15 @@ func featureSupportAvailable(minVersion semver.Version) (bool, error) {
 // CSIDriverResourceTest checks if the CSIDriver resource is created. In k8s
 // 1.14+, CSIDriver is created as part of the cluster deployment.
 func CSIDriverResourceTest(t *testing.T, driverName string) {
+	k8sVerMajor := 1
+	k8sVerMinor := 14
+	k8sVerPatch := 0
+
 	// Minimum version of k8s required to run this test.
 	minVersion := semver.Version{
-		Major: 1, Minor: 14, Patch: 0,
+		Major: uint64(k8sVerMajor),
+		Minor: uint64(k8sVerMinor),
+		Patch: uint64(k8sVerPatch),
 	}
 
 	// Check the k8s version before running this test. CSIDriver built-in

--- a/test/e2e/util/nfs_cluster.go
+++ b/test/e2e/util/nfs_cluster.go
@@ -53,9 +53,15 @@ func DeployNFSServer(t *testing.T, ctx *framework.TestCtx, nfsServer *storageos.
 		return err
 	}
 
+	k8sVerMajor := 1
+	k8sVerMinor := 13
+	k8sVerPatch := 0
+
 	// Minimum version for running the complete test.
 	minVersion := semver.Version{
-		Major: 1, Minor: 13, Patch: 0,
+		Major: uint64(k8sVerMajor),
+		Minor: uint64(k8sVerMinor),
+		Patch: uint64(k8sVerPatch),
 	}
 
 	featureSupported, err := featureSupportAvailable(minVersion)
@@ -93,7 +99,7 @@ func DeployNFSServer(t *testing.T, ctx *framework.TestCtx, nfsServer *storageos.
 			Name:      nfsServer.Name,
 			Namespace: nfsServer.Namespace,
 		}
-		if f.Client.Get(goctx.TODO(), namespacedName, statefulset); err != nil {
+		if err := f.Client.Get(goctx.TODO(), namespacedName, statefulset); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
- Use golangci-lint for linting and fix all the lint errors.
  - Commented out some unused constants and functions which will be used in the future.
  - Skip the directories that are generated or copied from upstream projects.
- Update Makefile to install golangci-lint and general cleanup.