### PR TITLE
Add default tolerations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ golangci-lint: ## Install golangci-lint
 .PHONY: unittest scorecard-test
 
 unittest: ## Run all the unit tests.
-	go test -v -race `go list -v ./... | grep -v test/e2e | grep -v olm`
+	go test -v -race `go list -v ./... | grep -v test/e2e | grep -v olm` -count=1
 
 # Runs the operator-sdk scorecard tests. Expects the operator to be installed
 # using OLM first.

--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -437,6 +437,23 @@ spec:
                   name: operatormetrics
                 - containerPort: 5720
                   name: podschedwebhook
+              tolerations:
+              - key: node.kubernetes.io/disk-pressure
+                operator: Exists
+              - key: node.kubernetes.io/memory-pressure
+                operator: Exists
+              - key: node.kubernetes.io/network-unavailable
+                operator: Exists
+              - key: node.kubernetes.io/not-ready
+                operator: Exists
+              - key: node.kubernetes.io/out-of-disk
+                operator: Exists
+              - key: node.kubernetes.io/pid-pressure
+                operator: Exists
+              - key: node.kubernetes.io/unreachable
+                operator: Exists
+              - key: node.kubernetes.io/unschedulable
+                operator: Exists
   customresourcedefinitions:
     owned:
     - name: storageosclusters.storageos.com

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -436,6 +436,23 @@ spec:
                   name: operatormetrics
                 - containerPort: 5720
                   name: podschedwebhook
+              tolerations:
+              - key: node.kubernetes.io/disk-pressure
+                operator: Exists
+              - key: node.kubernetes.io/memory-pressure
+                operator: Exists
+              - key: node.kubernetes.io/network-unavailable
+                operator: Exists
+              - key: node.kubernetes.io/not-ready
+                operator: Exists
+              - key: node.kubernetes.io/out-of-disk
+                operator: Exists
+              - key: node.kubernetes.io/pid-pressure
+                operator: Exists
+              - key: node.kubernetes.io/unreachable
+                operator: Exists
+              - key: node.kubernetes.io/unschedulable
+                operator: Exists
   customresourcedefinitions:
     owned:
     - name: storageosclusters.storageos.com

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -82,6 +82,22 @@ spec:
             - name: JAEGER_SERVICE_NAME
               value: ""
       tolerations:
+      - key: node.kubernetes.io/disk-pressure
+        operator: Exists
+      - key: node.kubernetes.io/memory-pressure
+        operator: Exists
+      - key: node.kubernetes.io/network-unavailable
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - key: node.kubernetes.io/pid-pressure
+        operator: Exists
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+      - key: node.kubernetes.io/unschedulable
+        operator: Exists
       - key: "key"
         operator: "Equal"
         value: "value"

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -1065,6 +1065,23 @@ data:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.namespace
+                    tolerations:
+                    - key: node.kubernetes.io/disk-pressure
+                      operator: Exists
+                    - key: node.kubernetes.io/memory-pressure
+                      operator: Exists
+                    - key: node.kubernetes.io/network-unavailable
+                      operator: Exists
+                    - key: node.kubernetes.io/not-ready
+                      operator: Exists
+                    - key: node.kubernetes.io/out-of-disk
+                      operator: Exists
+                    - key: node.kubernetes.io/pid-pressure
+                      operator: Exists
+                    - key: node.kubernetes.io/unreachable
+                      operator: Exists
+                    - key: node.kubernetes.io/unschedulable
+                      operator: Exists
         customresourcedefinitions:
           owned:
           - name: storageosclusters.storageos.com

--- a/internal/pkg/toleration/doc.go
+++ b/internal/pkg/toleration/doc.go
@@ -1,0 +1,2 @@
+// Package toleration contains kubernetes related tolerations.
+package toleration

--- a/internal/pkg/toleration/toleration.go
+++ b/internal/pkg/toleration/toleration.go
@@ -1,0 +1,99 @@
+package toleration
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Taint constants taken from k8s.io/api release-1.17 branch.
+// https://github.com/kubernetes/api/blob/release-1.17/core/v1/well_known_taints.go
+// TODO: Replace these constants with k8s.io/api constants after updating the
+// k8s dependency. TaintNodeOutOfDisk is not an upstream constant.
+const (
+	// TaintNodeNotReady will be added when node is not ready
+	// and feature-gate for TaintBasedEvictions flag is enabled,
+	// and removed when node becomes ready.
+	TaintNodeNotReady = "node.kubernetes.io/not-ready"
+
+	// TaintNodeUnreachable will be added when node becomes unreachable
+	// (corresponding to NodeReady status ConditionUnknown)
+	// and feature-gate for TaintBasedEvictions flag is enabled,
+	// and removed when node becomes reachable (NodeReady status ConditionTrue).
+	TaintNodeUnreachable = "node.kubernetes.io/unreachable"
+
+	// TaintNodeUnschedulable will be added when node becomes unschedulable
+	// and feature-gate for TaintNodesByCondition flag is enabled,
+	// and removed when node becomes scheduable.
+	TaintNodeUnschedulable = "node.kubernetes.io/unschedulable"
+
+	// TaintNodeMemoryPressure will be added when node has memory pressure
+	// and feature-gate for TaintNodesByCondition flag is enabled,
+	// and removed when node has enough memory.
+	TaintNodeMemoryPressure = "node.kubernetes.io/memory-pressure"
+
+	// TaintNodeDiskPressure will be added when node has disk pressure
+	// and feature-gate for TaintNodesByCondition flag is enabled,
+	// and removed when node has enough disk.
+	TaintNodeDiskPressure = "node.kubernetes.io/disk-pressure"
+
+	// TaintNodeNetworkUnavailable will be added when node's network is unavailable
+	// and feature-gate for TaintNodesByCondition flag is enabled,
+	// and removed when network becomes ready.
+	TaintNodeNetworkUnavailable = "node.kubernetes.io/network-unavailable"
+
+	// TaintNodePIDPressure will be added when node has pid pressure
+	// and feature-gate for TaintNodesByCondition flag is enabled,
+	// and removed when node has enough disk.
+	TaintNodePIDPressure = "node.kubernetes.io/pid-pressure"
+
+	// TaintNodePIDPressure will be added when node runs out of disk space, and
+	// removed when disk space becomes available.
+	TaintNodeOutOfDisk = "node.kubernetes.io/out-of-disk"
+)
+
+// GetDefaultTolerations returns a collection of default tolerations for
+// StorageOS related resources.
+// NOTE: An empty effect matches all effects with the given key.
+func GetDefaultTolerations() []corev1.Toleration {
+	return []corev1.Toleration{
+		{
+			Key:      TaintNodeDiskPressure,
+			Operator: corev1.TolerationOpExists,
+			Effect:   "",
+		},
+		{
+			Key:      TaintNodeMemoryPressure,
+			Operator: corev1.TolerationOpExists,
+			Effect:   "",
+		},
+		{
+			Key:      TaintNodeNetworkUnavailable,
+			Operator: corev1.TolerationOpExists,
+			Effect:   "",
+		},
+		{
+			Key:      TaintNodeNotReady,
+			Operator: corev1.TolerationOpExists,
+			Effect:   "",
+		},
+		{
+			Key:      TaintNodeOutOfDisk,
+			Operator: corev1.TolerationOpExists,
+			Effect:   "",
+		},
+		{
+			Key:      TaintNodePIDPressure,
+			Operator: corev1.TolerationOpExists,
+			Effect:   "",
+		},
+		{
+			Key:      TaintNodeUnreachable,
+			Operator: corev1.TolerationOpExists,
+			Effect:   "",
+		},
+		{
+			Key:      TaintNodeUnschedulable,
+			Operator: corev1.TolerationOpExists,
+			Effect:   "",
+		},
+	}
+}

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/storageos/cluster-operator/internal/pkg/image"
+	"github.com/storageos/cluster-operator/internal/pkg/toleration"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -542,6 +543,19 @@ func (s StorageOSClusterSpec) GetCSIDeploymentStrategy() string {
 		return s.CSI.DeploymentStrategy
 	}
 	return DefaultCSIDeploymentStrategy
+}
+
+// GetTolerations returns the tolerations applied to all the StorageOS related
+// pods.
+func (s StorageOSClusterSpec) GetTolerations() []corev1.Toleration {
+	tolerations := toleration.GetDefaultTolerations()
+
+	// Append the tolerations specified in the spec.
+	if len(s.Tolerations) > 0 {
+		tolerations = append(tolerations, s.Tolerations...)
+	}
+
+	return tolerations
 }
 
 // ContainerImages contains image names of all the containers used by the operator.

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/storageos/cluster-operator/internal/pkg/image"
+	"github.com/storageos/cluster-operator/internal/pkg/toleration"
 	storageosapis "github.com/storageos/cluster-operator/pkg/apis"
 	api "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 )
@@ -958,11 +959,16 @@ func TestDeployNodeAffinity(t *testing.T) {
 }
 
 func TestDeployTolerations(t *testing.T) {
+	defaultTolerations := toleration.GetDefaultTolerations()
+
 	testCases := []struct {
 		name        string
 		tolerations []corev1.Toleration
 		wantError   bool
 	}{
+		{
+			name: "No tolerations, default",
+		},
 		{
 			name: "TolerationOpExists without value",
 			tolerations: []corev1.Toleration{
@@ -1061,8 +1067,10 @@ func TestDeployTolerations(t *testing.T) {
 
 			podSpec := createdDaemonset.Spec.Template.Spec
 
-			if !reflect.DeepEqual(podSpec.Tolerations, stosCluster.Spec.Tolerations) {
-				t.Errorf("unexpected Tolerations value:\n\t(GOT) %v\n\t(WNT) %v", podSpec.Tolerations, stosCluster.Spec.Tolerations)
+			wantTolerations := append(defaultTolerations, tc.tolerations...)
+
+			if !reflect.DeepEqual(podSpec.Tolerations, wantTolerations) {
+				t.Errorf("unexpected Tolerations value:\n\t(GOT) %v\n\t(WNT) %v", podSpec.Tolerations, wantTolerations)
 			}
 		})
 	}

--- a/pkg/storageos/podspec.go
+++ b/pkg/storageos/podspec.go
@@ -280,7 +280,7 @@ func (s *Deployment) addNodeAffinity(podSpec *corev1.PodSpec) {
 // addTolerations adds tolerations to the given pod spec from cluster
 // spec Tolerations.
 func (s *Deployment) addTolerations(podSpec *corev1.PodSpec) error {
-	return util.AddTolerations(podSpec, s.stos.Spec.Tolerations)
+	return util.AddTolerations(podSpec, s.stos.Spec.GetTolerations())
 }
 
 // addTLSEtcdCerts adds the etcd TLS secret as a secret mount in the given


### PR DESCRIPTION
Adds default tolerations to node daemonset, csi-helpers deployment, storageos-scheduler deployment and the operator deployment itself.

Default tolerations are combined with the user provided tolerations in cluster config. Since k8s internally applies some of the same tolerations in addition to the provided tolerations, there's no toleration override, new tolerations are appended to the list of tolerations.