### PR TITLE
Add default tolerations to node DaemonSet only

### DIFF
--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -437,23 +437,6 @@ spec:
                   name: operatormetrics
                 - containerPort: 5720
                   name: podschedwebhook
-              tolerations:
-              - key: node.kubernetes.io/disk-pressure
-                operator: Exists
-              - key: node.kubernetes.io/memory-pressure
-                operator: Exists
-              - key: node.kubernetes.io/network-unavailable
-                operator: Exists
-              - key: node.kubernetes.io/not-ready
-                operator: Exists
-              - key: node.kubernetes.io/out-of-disk
-                operator: Exists
-              - key: node.kubernetes.io/pid-pressure
-                operator: Exists
-              - key: node.kubernetes.io/unreachable
-                operator: Exists
-              - key: node.kubernetes.io/unschedulable
-                operator: Exists
   customresourcedefinitions:
     owned:
     - name: storageosclusters.storageos.com

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -436,23 +436,6 @@ spec:
                   name: operatormetrics
                 - containerPort: 5720
                   name: podschedwebhook
-              tolerations:
-              - key: node.kubernetes.io/disk-pressure
-                operator: Exists
-              - key: node.kubernetes.io/memory-pressure
-                operator: Exists
-              - key: node.kubernetes.io/network-unavailable
-                operator: Exists
-              - key: node.kubernetes.io/not-ready
-                operator: Exists
-              - key: node.kubernetes.io/out-of-disk
-                operator: Exists
-              - key: node.kubernetes.io/pid-pressure
-                operator: Exists
-              - key: node.kubernetes.io/unreachable
-                operator: Exists
-              - key: node.kubernetes.io/unschedulable
-                operator: Exists
   customresourcedefinitions:
     owned:
     - name: storageosclusters.storageos.com

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -82,22 +82,6 @@ spec:
             - name: JAEGER_SERVICE_NAME
               value: ""
       tolerations:
-      - key: node.kubernetes.io/disk-pressure
-        operator: Exists
-      - key: node.kubernetes.io/memory-pressure
-        operator: Exists
-      - key: node.kubernetes.io/network-unavailable
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node.kubernetes.io/out-of-disk
-        operator: Exists
-      - key: node.kubernetes.io/pid-pressure
-        operator: Exists
-      - key: node.kubernetes.io/unreachable
-        operator: Exists
-      - key: node.kubernetes.io/unschedulable
-        operator: Exists
       - key: "key"
         operator: "Equal"
         value: "value"

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -1065,23 +1065,6 @@ data:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.namespace
-                    tolerations:
-                    - key: node.kubernetes.io/disk-pressure
-                      operator: Exists
-                    - key: node.kubernetes.io/memory-pressure
-                      operator: Exists
-                    - key: node.kubernetes.io/network-unavailable
-                      operator: Exists
-                    - key: node.kubernetes.io/not-ready
-                      operator: Exists
-                    - key: node.kubernetes.io/out-of-disk
-                      operator: Exists
-                    - key: node.kubernetes.io/pid-pressure
-                      operator: Exists
-                    - key: node.kubernetes.io/unreachable
-                      operator: Exists
-                    - key: node.kubernetes.io/unschedulable
-                      operator: Exists
         customresourcedefinitions:
           owned:
           - name: storageosclusters.storageos.com

--- a/pkg/storageos/daemonset.go
+++ b/pkg/storageos/daemonset.go
@@ -298,7 +298,7 @@ func (s *Deployment) createDaemonSet() error {
 		s.addNodeContainerProbes(nodeContainer)
 	}
 
-	if err := s.addTolerations(podSpec); err != nil {
+	if err := s.addTolerationsWithDefaults(podSpec); err != nil {
 		return err
 	}
 

--- a/pkg/storageos/podspec.go
+++ b/pkg/storageos/podspec.go
@@ -280,6 +280,13 @@ func (s *Deployment) addNodeAffinity(podSpec *corev1.PodSpec) {
 // addTolerations adds tolerations to the given pod spec from cluster
 // spec Tolerations.
 func (s *Deployment) addTolerations(podSpec *corev1.PodSpec) error {
+	return util.AddTolerations(podSpec, s.stos.Spec.Tolerations)
+}
+
+// addTolerationsWithDefaults adds the default tolerations along with the
+// tolerations in the cluster configuration to a given pod spec. The default
+// tolerations prevent pod eviction under various conditions.
+func (s *Deployment) addTolerationsWithDefaults(podSpec *corev1.PodSpec) error {
 	return util.AddTolerations(podSpec, s.stos.Spec.GetTolerations())
 }
 


### PR DESCRIPTION
This adds a new function `addTolerationsWithDefaults()` to add the
cluster config tolerations with the default tolerations and changes
addTolerations() to only set the tolerations from the cluster config.

addTolerationsWithDefaults() is used by DaemonSet deployment to have
default tolerations in node DaemonSet only.

CSI helpers, scheduler and the operator itself will not have any
default tolerations.