### PR TITLE
Don't create separate CSI registration mount if under /var/lib/kubelet

### DIFF
--- a/pkg/storageos/podspec.go
+++ b/pkg/storageos/podspec.go
@@ -2,6 +2,7 @@ package storageos
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/storageos/cluster-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -117,13 +118,19 @@ func (s *Deployment) addCSI(podSpec *corev1.PodSpec) {
 				MountPropagation: &mountPropagationBidirectional,
 			},
 			{
-				Name:      "plugin-dir",
-				MountPath: s.stos.Spec.GetCSIPluginDir(CSIV1Supported(s.k8sVersion)),
-			},
-			{
 				Name:      "device-dir",
 				MountPath: s.stos.Spec.GetCSIDeviceDir(),
 			},
+		}
+		// Only add a mount for the plugin-dir if it's not under the kubelet-dir
+		// mount path, which is now the k8s default.  Overlapping mounts will
+		// cause unmount issues when the container restarts, leaving entries in
+		// /proc/mounts.
+		if !strings.HasPrefix(s.stos.Spec.GetCSIPluginDir(CSIV1Supported(s.k8sVersion)), s.stos.Spec.GetCSIKubeletDir()) {
+			volMnts = append(volMnts, corev1.VolumeMount{
+				Name:      "plugin-dir",
+				MountPath: s.stos.Spec.GetCSIPluginDir(CSIV1Supported(s.k8sVersion)),
+			})
 		}
 
 		// Append volume mounts to the first container, the only container is the node container, at this point.


### PR DESCRIPTION
This fixes an issue where if the node container got in a restart loop (e.g. due to typo in etcd endpoint), then mounts weren't getting cleaned up correctly leading to excessive entries in /proc/mounts.

We were creating separate mounts for the kubelet dir (/var/lib/kubelet) and the CSI registration dir (which now defaults to /var/lib/kubelet/plugins_registry).  On restart the registration dir was not cleanly unmounted due to it overlapping.  The fix is to only create the registration mount if it's not underneath the kubelet dir.