### PR TITLE
Set CSI deployment as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,6 @@ Parameter | Description | Default
 `images.csiExternalAttacherContainer` | CSI External Attacher Container image |  Varies depending on Kubernetes version
 `images.csiExternalResizerContainer` | CSI External Resizer Container image |  Varies depending on Kubernetes version
 `ìmages.csiLivenessProbeContainer` | CSI Liveness Probe Container Image |  Varies depending on Kubernetes version
-`csi.enable` | Enable CSI setup | `false`
-`csi.enableProvisionCreds` | Enable CSI provision credentials | `false`
-`csi.enableControllerPublishCreds` | Enable CSI controller publish credentials | `false`
-`csi.enableNodePublishCreds` | Enable CSI node publish credentials | `false`
-`csi.enableControllerExpandCreds` | Enable CSI controller expand credentials | `false`
-`csi.deploymentStrategy` | CSI helper deployment strategy (`statefulset` or `deployment`) | `statefulset`
 `service.name` | Name of the Service used by the cluster | `storageos`
 `service.type` | Type of the Service used by the cluster | `ClusterIP`
 `service.externalPort` | External port of the Service used by the cluster | `5705`
@@ -354,52 +348,10 @@ data:
 
 ## CSI
 
-StorageOS also supports the [Container Storage Interface (CSI)](https://github.com/container-storage-interface/spec)
+StorageOS supports the [Container Storage Interface (CSI)](https://github.com/container-storage-interface/spec)
 to communicate with Kubernetes.
 
-Only versions 1.10+ are supported. CSI ensures forward compatibility with
-future releases of Kubernetes, as vendor-specific drivers will soon be
-deprecated from Kubernetes. However, some functionality is not yet supported.
-
-To enable CSI, set `csi.enable` to `true` in the `StorageOSCluster` resource
-config.
-
-```yaml
-apiVersion: "storageos.com/v1"
-kind: "StorageOSCluster"
-metadata:
-  name: "example-storageos"
-  namespace: "default"
-spec:
-  secretRefName: "storageos-api"
-  secretRefNamespace: "default"
-  csi:
-    enable: true
-```
-
-### CSI Credentials
-
-To enable CSI Credentials, ensure that CSI is enabled by setting `csi.enable` to
-`true`. Based on the type of credentials to enable, set the csi fields to
-`true`:
-
-```yaml
-apiVersion: "storageos.com/v1"
-kind: "StorageOSCluster"
-metadata:
-  name: "example-storageos"
-  namespace: "default"
-spec:
-  ...
-  ...
-  csi:
-    enable: true
-    enableProvisionCreds: true
-    enableControllerPublishCreds: true
-    enableNodePublishCreds: true
-  ...
-```
-
+CSI credentials are required for deploying StorageOS.
 Specify the CSI credentials as part of the storageos secret object as:
 
 ```yaml

--- a/deploy/crds/storageos.com_v1_storageoscluster_cr.yaml
+++ b/deploy/crds/storageos.com_v1_storageoscluster_cr.yaml
@@ -23,8 +23,8 @@ spec:
   #   csiLivenessProbeContainer:
   #   hyperkubeContainer:
   #   nfsContainer:
-  csi:
-    enable: true
+  # csi:
+  #   enable: true
   #   endpoint: /var/lib/kubelet/device-plugins/
   #   registrarSocketDir: /var/lib/kubelet/device-plugins/
   #   kubeletDir: /var/lib/kubelet
@@ -37,7 +37,7 @@ spec:
   #   enableControllerExpandCreds: false
   #   kubeletRegistrationPath: /var/lib/kubelet/plugins/storageos/csi.sock
   #   driverRegisterationMode: node-register
-  #   DriverRequiresAttachment: "true"
+  #   driverRequiresAttachment: "true"
   #   deploymentStrategy: "deployment"
   # service:
   #   name: "storageos"

--- a/deploy/olm/olm.sh
+++ b/deploy/olm/olm.sh
@@ -28,7 +28,7 @@ install_storageos_operator() {
     echo
 }
 
-# Install storageos with default CSI helpers(StatefulSet).
+# Install storageos with default CSI helpers.
 install_storageos() {
     echo "Install StorageOS"
 
@@ -41,9 +41,9 @@ install_storageos() {
     until kubectl -n storageos get daemonset storageos-daemonset --no-headers -o go-template='{{.status.numberReady}}' | grep -q 1; do sleep 5; done
     echo "Daemonset ready!"
 
-    echo "Waiting for storageos statefulset to be ready"
-    until kubectl -n storageos get statefulset storageos-statefulset --no-headers -o go-template='{{.status.readyReplicas}}' | grep -q 1; do sleep 5; done
-    echo "Statefulset ready!"
+    echo "Waiting for csi helper deployment to be ready"
+    until kubectl -n storageos get deployment storageos-csi-helper --no-headers -o go-template='{{.status.readyReplicas}}' | grep -q 1; do sleep 5; done
+    echo "CSI Helper Deployment ready!"
 }
 
 uninstall_storageos() {

--- a/deploy/storageos-operators.olm.cr.yaml
+++ b/deploy/storageos-operators.olm.cr.yaml
@@ -7,8 +7,6 @@ spec:
   secretRefName: "storageos-api"
   secretRefNamespace: "default"
   namespace: "storageos"
-  csi:
-    enable: true
   kvBackend:
     address: "etcd-client.default.svc.cluster.local:2379"
 ---

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -60,7 +60,7 @@ const (
 	DefaultCSIKubeletRegistrationPath  = "/storageos/csi.sock"
 	DefaultCSIDriverRegistrationMode   = "node-register"
 	DefaultCSIDriverRequiresAttachment = "true"
-	DefaultCSIDeploymentStrategy       = "statefulset"
+	DefaultCSIDeploymentStrategy       = "deployment"
 )
 
 func getDefaultCSIEndpoint(pluginRegistrationPath string) string {

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -395,7 +395,7 @@ func TestCreateCSIHelper(t *testing.T) {
 					Enable: true,
 				},
 			},
-			wantHelperDeployment: false,
+			wantHelperDeployment: true,
 		},
 		{
 			name: "CSI helpers statefulset",

--- a/test/e2e/clusterCSINodeV2_test.go
+++ b/test/e2e/clusterCSINodeV2_test.go
@@ -32,10 +32,6 @@ func TestClusterCSINodeV2(t *testing.T) {
 		SecretRefName:      "storageos-api",
 		SecretRefNamespace: "default",
 		Namespace:          resourceNS,
-		CSI: storageos.StorageOSClusterCSI{
-			Enable:             true,
-			DeploymentStrategy: "deployment",
-		},
 		Tolerations: []corev1.Toleration{
 			{
 				Key:      "key",

--- a/test/e2e/util/cluster.go
+++ b/test/e2e/util/cluster.go
@@ -162,21 +162,10 @@ func DeployCluster(t *testing.T, ctx *framework.Context, cluster *storageos.Stor
 		t.Fatal(err)
 	}
 
-	if cluster.Spec.CSI.Enable {
-		// Wait for the appropriate CSI helper based on the kind of helper
-		// deployment.
-		switch cluster.Spec.GetCSIDeploymentStrategy() {
-		case "deployment":
-			err = e2eutil.WaitForDeployment(t, f.KubeClient, cluster.Spec.GetResourceNS(), "storageos-csi-helper", 1, RetryInterval, Timeout*2)
-			if err != nil {
-				t.Fatal(err)
-			}
-		case "statefulset":
-			err = WaitForStatefulSet(t, f.KubeClient, cluster.Spec.GetResourceNS(), "storageos-statefulset", RetryInterval, Timeout*2)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
+	// Wait for the CSI helpers.
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, cluster.Spec.GetResourceNS(), "storageos-csi-helper", 1, RetryInterval, Timeout*2)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	return nil


### PR DESCRIPTION
This change simplifies the ClusterConfiguration custom resource attributes, making CSI deployments implicit.
The CSI helper deployment strategy default is changed to "deployment".

Updates all the tests to remove explicit CSI options in ClusterConfiguration.

With this, minimal ClusterConfiguration for deploying StorageOS v2 becomes:

```yaml
apiVersion: storageos.com/v1
kind: StorageOSCluster
metadata:
  name: example-storageoscluster
  namespace: "default"
spec:
  secretRefName: "storageos-api"
  secretRefNamespace: "default"
  kvBackend:
    address: <etcd-address>
```