### PR TITLE
Update pod scheduler service address

### DIFF
--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -177,8 +177,8 @@ func (s Deployment) createSchedulerPolicy() error {
       }]
     }
 `
-	// Service address format: <service-name>.<namespace>.svc.cluster.local.
-	serviceEndpoint := fmt.Sprintf("%s.%s.svc.cluster.local", s.stos.Spec.GetServiceName(), s.stos.Spec.GetResourceNS())
+	// Service address format: <service-name>.<namespace>.svc.
+	serviceEndpoint := fmt.Sprintf("%s.%s.svc", s.stos.Spec.GetServiceName(), s.stos.Spec.GetResourceNS())
 	uriPath := uriPathV1
 	if s.nodev2 {
 		uriPath = uriPathV2

--- a/test/e2e/clusterCSINodeV2_test.go
+++ b/test/e2e/clusterCSINodeV2_test.go
@@ -57,15 +57,15 @@ func TestClusterCSINodeV2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f := framework.Global
-
-	// TODO - Status not confirmed working yet. Assume started after waiting
-	// for the timeout for now.
-	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: testutil.TestClusterCRName, Namespace: namespace}, testStorageOS)
-	if err != nil {
+	namespacedName := types.NamespacedName{
+		Name:      testutil.TestClusterCRName,
+		Namespace: namespace,
+	}
+	if err = testutil.ClusterStatusCheck(t, namespacedName, 1, testutil.RetryInterval, testutil.Timeout); err != nil {
 		t.Fatal(err)
 	}
-	testutil.ClusterStatusCheck(t, testStorageOS.Status, 1)
+
+	f := framework.Global
 
 	daemonset, err := f.KubeClient.AppsV1().DaemonSets(resourceNS).Get(context.TODO(), "storageos-daemonset", metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
Remove cluster.local in the service endpoint to be compatible with
clusters with custom DNS configurations.

Also, the e2e tests have failed a few times recently due to failure in
ClusterConfiguration status check.
Cluster status is not updated immediately once the cluster is ready. The
reconciliation may take a few seconds. Update the status check to retry,
fetch an updated status and check again, with a timeout.