### PR TITLE
node: Reset client on unauthorized error

### DIFF
--- a/internal/pkg/client/storageos/common/error.go
+++ b/internal/pkg/client/storageos/common/error.go
@@ -5,4 +5,5 @@ import "errors"
 // StorageOS API client errors.
 var (
 	ErrResourceNotFound = errors.New("resource not found")
+	ErrUnauthorized     = errors.New("unauthorized")
 )


### PR DESCRIPTION
CP auth token expires after 5 minutes by default. This causes requests
to fail with unauthorized error.

Reset v2 client when 401 unauthorized error is received in the node
controller.