### PR TITLE
Use OSDK CLI v0.18.2 and generate v1beta1 CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OPERATOR_IMAGE ?= storageos/cluster-operator:test
 GO_BUILD_CMD = go build -v
 GO_ENV = GOOS=linux CGO_ENABLED=0
-SDK_VERSION = v0.17.2
+SDK_VERSION = v0.18.2
 MACHINE = $(shell uname -m)
 BUILD_IMAGE = golang:1.14.2
 BASE_IMAGE = storageos/base-image:0.2.1
@@ -81,7 +81,7 @@ k8s-code-gen:
 go-gen: operator-sdk k8s-code-gen
 	# generate k8s requires GOROOT to be set.
 	GOROOT=$(GOPATH) GO111MODULE=on $(OPERATOR_SDK) generate k8s
-	GO111MODULE=on $(OPERATOR_SDK) generate crds
+	GO111MODULE=on $(OPERATOR_SDK) generate crds --crd-version=v1beta1
 	# TODO: Install kube-openapi and generate OpenAPI. Operator-sdk no
 	# longer provides subcommand to generate OpenAPI. Install
 	# k8s.io/kube-openapi


### PR DESCRIPTION
We already use operator-sdk v0.18 go package. Use the new OSDK CLI with
`--crd-version` flag to generate v1beta1 CRDs.