### PR TITLE
k8s 1.19 fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.14.2
+      - image: circleci/golang:1.15.2
 
     working_directory: /go/src/github.com/storageos/cluster-operator
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ sudo: required
 language: go
 
 go:
-  - "1.14.2"
+  - "1.15.2"
 
 env:
   global:
     - CHANGE_MINIKUBE_NONE_USER=true
-    - K8S_VERSION="v1.18.6"
+    - K8S_VERSION="v1.19.0"
     - MINIKUBE_VERSION="v0.28.2"
     - IMAGE_NAME=storageos/cluster-operator
     - IMAGE_TAG=test
@@ -37,21 +37,21 @@ install: true
 
 jobs:
   include:
-    - go: "1.14"
+    - go: "1.15"
       sudo: required
       env:
         - "INSTALL_METHOD=olm"
-      name: OLM on KinD (k8s-1.18)
+      name: OLM on KinD (k8s-1.19)
       script: ./test/e2e.sh $INSTALL_METHOD
     - &base-test
-      go: "1.14"
+      go: "1.15"
       sudo: required
       env:
         - "INSTALL_METHOD=none"
-      name: KinD (k8s-1.18)
+      name: KinD (k8s-1.19)
       script: ./test/e2e.sh $INSTALL_METHOD
     - stage: deploy
-      go: "1.14"
+      go: "1.15"
       sudo: required
       name: Publish Container Image
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 
 go:
-  - "1.15.2"
+  - "1.14.2"
 
 env:
   global:
@@ -37,21 +37,21 @@ install: true
 
 jobs:
   include:
-    - go: "1.15"
+    - go: "1.14"
       sudo: required
       env:
         - "INSTALL_METHOD=olm"
       name: OLM on KinD (k8s-1.19)
       script: ./test/e2e.sh $INSTALL_METHOD
     - &base-test
-      go: "1.15"
+      go: "1.14"
       sudo: required
       env:
         - "INSTALL_METHOD=none"
       name: KinD (k8s-1.19)
       script: ./test/e2e.sh $INSTALL_METHOD
     - stage: deploy
-      go: "1.15"
+      go: "1.14"
       sudo: required
       name: Publish Container Image
       script:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GO_BUILD_CMD = go build -v
 GO_ENV = GOOS=linux CGO_ENABLED=0
 SDK_VERSION = v0.17.2
 MACHINE = $(shell uname -m)
-BUILD_IMAGE = golang:1.14.2
+BUILD_IMAGE = golang:1.15.2
 BASE_IMAGE = storageos/base-image:0.2.1
 BUILD_DIR = "build"
 OPERATOR_SDK = $(BUILD_DIR)/operator-sdk
@@ -18,7 +18,7 @@ NEW_VERSION ?= v2.2.0
 CACHE_DIR = $(shell pwd)/.cache
 PROJECT = github.com/storageos/cluster-operator
 GOARCH ?= amd64
-GO_VERSION = 1.14.2
+GO_VERSION = 1.15.2
 
 # Since go modules don't allow non-go files to be vendored, the code generator
 # scripts needed for updating the generated codes are downloaded in the cache

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=golang:1.14.2
+ARG BUILD_IMAGE=golang:1.15.2
 ARG BASE_IMAGE=storageos/base-image:0.2.1
 ARG OPERATOR_IMAGE=storageos/cluster-operator:test
 

--- a/build/rhel-build-service/Dockerfile
+++ b/build/rhel-build-service/Dockerfile
@@ -2,7 +2,7 @@
 # ARG BASE_IMAGE=storageos/base-image:0.2.1
 # ARG OPERATOR_IMAGE=storageos/cluster-operator:test
 
-FROM golang:1.14.2 AS build
+FROM golang:1.15.2 AS build
 # OPERATOR_IMAGE needs to be passed to operator make target for constructing
 # the ldflags.
 # ARG OPERATOR_IMAGE

--- a/internal/pkg/cert/cert.go
+++ b/internal/pkg/cert/cert.go
@@ -105,7 +105,7 @@ func NewSignedCert(cfg Config, key crypto.Signer, caCert *x509.Certificate, caKe
 			CommonName:   cfg.CommonName,
 			Organization: cfg.Organization,
 		},
-		DNSNames:     cfg.AltNames.DNSNames,
+		DNSNames:     []string{cfg.CommonName},
 		IPAddresses:  cfg.AltNames.IPs,
 		SerialNumber: serial,
 		NotBefore:    caCert.NotBefore,

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -1624,26 +1624,6 @@ func TestDeploySchedulerExtender(t *testing.T) {
 		t.Errorf("expected %q to be in scheduler policy configmap data", policyConfigKey)
 	}
 
-	// Get scheduler configuration configmap and check the data.
-	schedConfigcm := &corev1.ConfigMap{}
-	schedConfigNSName := types.NamespacedName{
-		Name:      schedulerConfigConfigMapName,
-		Namespace: defaultNS,
-	}
-
-	if err := c.Get(context.Background(), schedConfigNSName, schedConfigcm); err != nil {
-		t.Fatal("failed to get the created scheduler configuration configmap", err)
-	}
-
-	// Check if the expected key and value exists.
-	if val, exists := schedConfigcm.Data[schedulerConfigKey]; exists {
-		if len(val) == 0 {
-			t.Errorf("%q is empty, expected not to be empty", schedulerConfigKey)
-		}
-	} else {
-		t.Errorf("expected %q to be in scheduler configuration configmap data", schedulerConfigKey)
-	}
-
 	// Check the attributes of the scheduler deployment.
 	schedDeployment := &appsv1.Deployment{}
 	schedDeploymentNSName := types.NamespacedName{

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -13,10 +13,8 @@ import (
 )
 
 const (
-	policyConfigMapName          = "storageos-scheduler-policy"
-	policyConfigKey              = "policy.cfg"
-	schedulerConfigConfigMapName = "storageos-scheduler-config"
-	schedulerConfigKey           = "config.yaml"
+	policyConfigMapName = "storageos-scheduler-policy"
+	policyConfigKey     = "policy.cfg"
 
 	uriPathV1 = "/v1/scheduler"
 	uriPathV2 = "/v2/k8s/scheduler"
@@ -28,9 +26,6 @@ const (
 func (s *Deployment) createSchedulerExtender() error {
 	// Create configmap with scheduler configuration and policy.
 	if err := s.createSchedulerPolicy(); err != nil {
-		return err
-	}
-	if err := s.createSchedulerConfiguration(); err != nil {
 		return err
 	}
 
@@ -68,7 +63,6 @@ func (s Deployment) createSchedulerDeployment(replicas int32) error {
 			Spec: corev1.PodSpec{
 				ServiceAccountName: SchedulerSA,
 				Containers:         s.schedulerContainers(),
-				Volumes:            s.schedulerVolumes(),
 			},
 		},
 	}
@@ -94,29 +88,12 @@ func (s Deployment) schedulerContainers() []corev1.Container {
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Args: []string{
 				"kube-scheduler",
-				"--config=/storageos-scheduler/config.yaml",
+				"--leader-elect=true",
+				"--scheduler-name=" + SchedulerExtenderName,
+				"--policy-configmap=" + policyConfigMapName,
+				"--policy-configmap-namespace=" + s.stos.Spec.GetResourceNS(),
+				"--lock-object-name=" + SchedulerExtenderName,
 				"-v=4",
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "storageos-scheduler-config",
-					MountPath: "/storageos-scheduler",
-				},
-			},
-		},
-	}
-}
-
-// schedulerVolumes returns a list of volumes that should be part of the
-// scheduler extender deployment.
-func (s Deployment) schedulerVolumes() []corev1.Volume {
-	return []corev1.Volume{
-		{
-			Name: schedulerConfigConfigMapName,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: schedulerConfigConfigMapName},
-				},
 			},
 		},
 	}
@@ -129,9 +106,6 @@ func (s Deployment) deleteSchedulerExtender() error {
 		return err
 	}
 	if err := s.k8sResourceManager.ConfigMap(policyConfigMapName, namespace, nil, nil).Delete(); err != nil {
-		return err
-	}
-	if err := s.k8sResourceManager.ConfigMap(schedulerConfigConfigMapName, namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
 	if err := s.k8sResourceManager.ClusterRoleBinding(SchedulerClusterBindingName, nil, nil, nil).Delete(); err != nil {
@@ -205,56 +179,6 @@ func (s Deployment) createSchedulerPolicy() error {
 		"policy.cfg": policyConfig.String(),
 	}
 	return s.k8sResourceManager.ConfigMap(policyConfigMapName, s.stos.Spec.GetResourceNS(), nil, data).Create()
-}
-
-// schedulerConfigTemplate contains fields for rendering the scheduler
-// configuration.
-type schedulerConfigTemplate struct {
-	SchedulerName  string
-	PolicyName     string
-	Namespace      string
-	LeaderElection bool
-}
-
-// createSchedulerConfiguration creates a configmap with kube-scheduler
-// configuration.
-func (s Deployment) createSchedulerConfiguration() error {
-	configTemplate := `
-    apiVersion: "kubescheduler.config.k8s.io/v1alpha1"
-    kind: KubeSchedulerConfiguration
-    schedulerName: {{.SchedulerName}}
-    algorithmSource:
-      policy:
-        configMap:
-          namespace: {{.Namespace}}
-          name: {{.PolicyName}}
-    leaderElection:
-      leaderElect: {{.LeaderElection}}
-      lockObjectName: {{.SchedulerName}}
-      lockObjectNamespace: {{.Namespace}}
-`
-	schedConfigData := schedulerConfigTemplate{
-		SchedulerName:  SchedulerExtenderName,
-		PolicyName:     policyConfigMapName,
-		Namespace:      s.stos.Spec.GetResourceNS(),
-		LeaderElection: true,
-	}
-
-	// Render the scheduler configuration.
-	var schedConfig bytes.Buffer
-	tmpl, err := template.New("schedConfig").Parse(configTemplate)
-	if err != nil {
-		return err
-	}
-	if err := tmpl.Execute(&schedConfig, schedConfigData); err != nil {
-		return err
-	}
-
-	// Add the configuration in the configmap.
-	data := map[string]string{
-		"config.yaml": schedConfig.String(),
-	}
-	return s.k8sResourceManager.ConfigMap(schedulerConfigConfigMapName, s.stos.Spec.GetResourceNS(), nil, data).Create()
 }
 
 // podLabelsForScheduler returns labels for the scheduler pod.

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -2,7 +2,7 @@
 
 set -Eeuxo pipefail
 
-readonly K8S_LATEST="v1.18.6"
+readonly K8S_LATEST="v1.19.0"
 readonly KIND_LINK="https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-linux-amd64"
 
 OPERATOR_SDK="build/operator-sdk"


### PR DESCRIPTION
- Update golang to 1.15.2
- Update legacy cert for go 1.15 support
- Configure kube-scheduler with flags
- Update CI to use go 1.15 and k8s 1.19 