### PR TITLE
Set app.kubernetes.io/component label

### DIFF
--- a/pkg/controller/storageoscluster/cluster.go
+++ b/pkg/controller/storageoscluster/cluster.go
@@ -42,7 +42,8 @@ func (c *StorageOSCluster) SetDeployment(r *ReconcileStorageOSCluster) {
 	// by any label selectors.
 	labels["app"] = "storageos"
 
-	// Add default resource app labels.
+	// Add default resource app labels.  Component will be set to "cluster" by
+	// default.
 	labels = k8s.AddDefaultAppLabels(c.cluster.Name, labels)
 
 	c.deployment = storageos.NewDeployment(r.client, r.discoveryClient, c.cluster, labels, r.recorder, r.scheme, r.k8sVersion, updateIfExists)

--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -290,9 +290,10 @@ func (s Deployment) deleteCSIHelper() error {
 func podLabelsForCSIHelpers(name, kind string) map[string]string {
 	// Combine CSI Helper specific labels with the default app labels.
 	labels := map[string]string{
-		"app":          appName,
-		"storageos_cr": name,
-		"kind":         kind,
+		"app":            appName,
+		"storageos_cr":   name,
+		"kind":           kind,
+		k8s.AppComponent: csiHelperName,
 	}
 	return k8s.AddDefaultAppLabels(name, labels)
 }

--- a/pkg/storageos/daemonset.go
+++ b/pkg/storageos/daemonset.go
@@ -316,9 +316,10 @@ func (s *Deployment) createDaemonSet() error {
 func podLabelsForDaemonSet(name string) map[string]string {
 	// Combine DaemonSet specific labels with the default app labels.
 	labels := map[string]string{
-		"app":          appName,
-		"storageos_cr": name,
-		"kind":         daemonsetKind,
+		"app":            appName,
+		"storageos_cr":   name,
+		"kind":           daemonsetKind,
+		k8s.AppComponent: daemonsetName,
 	}
 	return k8s.AddDefaultAppLabels(name, labels)
 }

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -185,9 +185,10 @@ func (s Deployment) createSchedulerPolicy() error {
 func podLabelsForScheduler(name string) map[string]string {
 	// Combine CSI Helper specific labels with the default app labels.
 	labels := map[string]string{
-		"app":          appName,
-		"storageos_cr": name,
-		"kind":         deploymentKind,
+		"app":            appName,
+		"storageos_cr":   name,
+		"kind":           deploymentKind,
+		k8s.AppComponent: SchedulerExtenderName,
 	}
 	return k8s.AddDefaultAppLabels(name, labels)
 }


### PR DESCRIPTION
Sets the app.kubernetes.io/component label differently for each component.  Previously they were all set to `cluster`.  New values are:
- `storageos-csi-helper` for CSI helpers.
- `storageos-daemonset` for DaemonSet.
- `storageos-scheduler` for the scehduler extender.

This will allow configuration of anti-affinty rules and Prometheus Service Monitors for individual components without adding additional labels.