### PR TITLE
Remove node v1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,14 @@ install: true
 
 jobs:
   include:
-    - go: "1.14"
-      sudo: required
-      env:
-        - "INSTALL_METHOD=olm"
-      name: OLM on KinD (k8s-1.19)
-      script: ./test/e2e.sh $INSTALL_METHOD
+    # Temporary disable until:
+    # https://github.com/operator-framework/operator-registry/pull/466
+    # - go: "1.14"
+    #   sudo: required
+    #   env:
+    #     - "INSTALL_METHOD=olm"
+    #   name: OLM on KinD (k8s-1.19)
+    #   script: ./test/e2e.sh $INSTALL_METHOD
     - &base-test
       go: "1.14"
       sudo: required

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -312,17 +312,12 @@ func (s StorageOSClusterSpec) GetCSIClusterDriverRegistrarImage() string {
 }
 
 // GetCSIExternalProvisionerImage returns CSI external provisioner container image.
-func (s StorageOSClusterSpec) GetCSIExternalProvisionerImage(csiv1 bool, nodev2 bool) string {
+func (s StorageOSClusterSpec) GetCSIExternalProvisionerImage(csiv1 bool) string {
 	if s.Images.CSIExternalProvisionerContainer != "" {
 		return s.Images.CSIExternalProvisionerContainer
 	}
 	if csiv1 {
-		// v2 requires a more recent provisioner that passes PVC name &
-		// namespace as annotations.
-		if nodev2 {
-			return image.GetDefaultImage(image.CSIv1ExternalProvisionerImageEnvVar, image.CSIv1ExternalProvisionerContainerImageV2)
-		}
-		return image.GetDefaultImage(image.CSIv1ExternalProvisionerImageEnvVar, image.CSIv1ExternalProvisionerContainerImageV1)
+		return image.GetDefaultImage(image.CSIv1ExternalProvisionerImageEnvVar, image.CSIv1ExternalProvisionerContainerImageV2)
 	}
 	return image.GetDefaultImage(image.CSIv0ExternalProvisionerImageEnvVar, image.CSIv0ExternalProvisionerContainerImage)
 }

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -20,10 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	storageosclientcommon "github.com/storageos/cluster-operator/internal/pkg/client/storageos/common"
-	storageosclientv1 "github.com/storageos/cluster-operator/internal/pkg/client/storageos/v1"
 	storageosclientv2 "github.com/storageos/cluster-operator/internal/pkg/client/storageos/v2"
 	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
-	storageos "github.com/storageos/cluster-operator/pkg/storageos"
 )
 
 var log = logf.Log.WithName("storageos.node")
@@ -270,18 +268,10 @@ func (r *ReconcileNode) setClientForCluster(cluster *storageosv1.StorageOSCluste
 		clusterUID:        cluster.GetUID(),
 	}
 
-	// Initialize StorageOS client based on the version of StorageOS cluster.
-	if storageos.NodeV2Image(cluster.Spec.GetNodeContainerImage()) {
-		r.stosClient.client.Ctx, r.stosClient.client.V2, err = storageosclientv2.NewClientFromSecret(serviceInstance.Spec.ClusterIP, secretInstance)
-		if err != nil {
-			return fmt.Errorf("failed to create StorageOS v2 client: %v", err)
-		}
-	} else {
-		r.stosClient.client.V1, err = storageosclientv1.NewClientFromSecret(serviceInstance.Spec.ClusterIP, secretInstance)
-		if err != nil {
-			return fmt.Errorf("failed to create StorageOS v1 client: %v", err)
-		}
+	// Initialize StorageOS client.
+	r.stosClient.client.Ctx, r.stosClient.client.V2, err = storageosclientv2.NewClientFromSecret(serviceInstance.Spec.ClusterIP, secretInstance)
+	if err != nil {
+		return fmt.Errorf("failed to create StorageOS client: %v", err)
 	}
-
 	return nil
 }

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -339,13 +339,13 @@ func (r *ReconcileStorageOSCluster) updateSpec(m *storageosv1.StorageOSCluster) 
 		properties[&m.Spec.Images.CSILivenessProbeContainer] = m.Spec.GetCSILivenessProbeImage()
 	}
 
-	properties[&m.Spec.Images.CSIExternalProvisionerContainer] = m.Spec.GetCSIExternalProvisionerImage(storageos.CSIV1Supported(r.k8sVersion), storageos.NodeV2Image(m.Spec.GetNodeContainerImage()))
+	properties[&m.Spec.Images.CSIExternalProvisionerContainer] = m.Spec.GetCSIExternalProvisionerImage(storageos.CSIV1Supported(r.k8sVersion))
 
 	properties[&m.Spec.Images.CSIExternalAttacherContainer] = m.Spec.GetCSIExternalAttacherImage(storageos.CSIV1Supported(r.k8sVersion), storageos.CSIExternalAttacherV2Supported(r.k8sVersion))
 
 	// Add external resizer image if storageos v2 and supported k8s
 	// version.
-	if storageos.CSIExternalResizerSupported(r.k8sVersion) && storageos.NodeV2Image(m.Spec.GetNodeContainerImage()) {
+	if storageos.CSIExternalResizerSupported(r.k8sVersion) {
 		properties[&m.Spec.Images.CSIExternalResizerContainer] = m.Spec.GetCSIExternalResizerImage()
 	}
 

--- a/pkg/storageos/configmap.go
+++ b/pkg/storageos/configmap.go
@@ -10,24 +10,15 @@ import (
 )
 
 const (
-
-	// External ETCD config, V1 only.
-	kvBackendEnvVar = "KV_BACKEND"
-	kvAddrEnvVar    = "KV_ADDR"
-	joinEnvVar      = "JOIN"
-
 	// Comma separated list of endpoints on which we will try to connect to the
 	// cluster's ETCD instances.
 	etcdEndpointsEnvVar = "ETCD_ENDPOINTS"
 
-	// TODO: ETCD TLS configuration information. The key/cert/CA need to be PEM encoded
+	// ETCD TLS configuration information. The key/cert/CA need to be PEM encoded
 	// DER bytes
-	v1EtcdTLSClientKeyEnvVar  = "TLS_ETCD_CLIENT_KEY"
-	v1EtcdTLSClientCertEnvVar = "TLS_ETCD_CLIENT_CERT"
-	v1EtcdTLSClientCAEnvVar   = "TLS_ETCD_CA"
-	v2EtcdTLSClientKeyEnvVar  = "ETCD_TLS_CLIENT_KEY"
-	v2EtcdTLSClientCertEnvVar = "ETCD_TLS_CLIENT_CERT"
-	v2EtcdTLSClientCAEnvVar   = "ETCD_TLS_CLIENT_CA"
+	etcdTLSClientKeyEnvVar  = "ETCD_TLS_CLIENT_KEY"
+	etcdTLSClientCertEnvVar = "ETCD_TLS_CLIENT_CERT"
+	etcdTLSClientCAEnvVar   = "ETCD_TLS_CLIENT_CA"
 
 	// TODO: ETCD authentication information
 	// etcdUsernameEnvVar = "ETCD_USERNAME"
@@ -39,9 +30,8 @@ const (
 	// etcdNamespaceEnvVar = "ETCD_NAMESPACE"
 
 	// Feature flags (enabled by default)
-	disableFencingEnvVar = "DISABLE_FENCING"
-	disableTCMUEnvVar    = "DISABLE_TCMU"
-	forceTCMUEnvVar      = "FORCE_TCMU"
+	disableTCMUEnvVar = "DISABLE_TCMU"
+	forceTCMUEnvVar   = "FORCE_TCMU"
 
 	// When set to TRUE usage data will not be logged on StorageOS servers.
 	disableTelemetryEnvVar = "DISABLE_TELEMETRY"
@@ -54,8 +44,7 @@ const (
 	disableVersionCheckEnvVar = "DISABLE_VERSION_CHECK"
 
 	// Namespace in which storageos operates.
-	v1NamespaceEnvVar = "NAMESPACE"
-	v2NamespaceEnvVar = "K8S_NAMESPACE"
+	namespaceEnvVar = "K8S_NAMESPACE"
 
 	// The kubernetes distribution in which storageos is operating.
 	k8sDistroEnvVar = "K8S_DISTRO"
@@ -107,7 +96,7 @@ const (
 	// Logging level: debug, info, warn or error.
 	logLevelEnvVar = "LOG_LEVEL"
 
-	// Logger format: text or json.
+	// Logger format: default or json.
 	logFormatEnvVar = "LOG_FORMAT"
 
 	// Tracing configuration.  Intended for internal development use only and
@@ -129,7 +118,7 @@ const (
 
 // createService creates a ConfigMap to store the node container configuration.
 func (s *Deployment) createConfigMap() error {
-	config := configFromSpec(s.stos.Spec, CSIV1Supported(s.k8sVersion), s.nodev2)
+	config := configFromSpec(s.stos.Spec, CSIV1Supported(s.k8sVersion))
 
 	labels := make(map[string]string)
 
@@ -140,88 +129,13 @@ func (s *Deployment) createConfigMap() error {
 	return nil
 }
 
-// configFromSpec generates config entries for the given major version of the
-// node container and CSI spec required.
+// configFromSpec generates config entries.
 //
 //     Config set in DaemonSet env vars:
 //       - HOSTNAME (reads from spec.nodeName)
 //       - ADVERTISE_IP (reads from status.podIP)
 //       - BOOTSTRAP_USERNAME, BOOTSTRAP_PASSWORD (reads from secret)
-func configFromSpec(spec storageosv1.StorageOSClusterSpec, csiv1 bool, nodev2 bool) map[string]string {
-	if nodev2 {
-		return v2ConfigFromSpec(spec)
-	}
-	return v1ConfigFromSpec(spec, csiv1)
-}
-
-func v1ConfigFromSpec(spec storageosv1.StorageOSClusterSpec, csiv1 bool) map[string]string {
-	config := make(map[string]string)
-
-	// Etcd endpoint, and join for V1.
-	// Join must be set.
-	config[joinEnvVar] = spec.Join
-
-	// If external etcd is enabled, KV_BACKEND must be set to "etcd" and
-	// KV_ADDRESS set to a comma separated list of endpoints.
-	if spec.KVBackend.Backend != "" {
-		config[kvBackendEnvVar] = spec.KVBackend.Backend
-	}
-	if spec.KVBackend.Address != "" {
-		config[kvAddrEnvVar] = spec.KVBackend.Address
-	}
-
-	// Append Etcd TLS config, if given.  Volumes are created in Podspec.
-	if spec.TLSEtcdSecretRefName != "" && spec.TLSEtcdSecretRefNamespace != "" {
-		config = addEtcdTLSConfig(config, false)
-	}
-
-	// Always show telemetry and feature options to ensure they're visble.
-	config[disableTelemetryEnvVar] = strconv.FormatBool(spec.DisableTelemetry)
-
-	// Features
-	config[disableFencingEnvVar] = strconv.FormatBool(spec.DisableFencing)
-
-	// DISABLE_TCMU and FORCE_TCMU should not be set unless under advice from
-	// support.  Only show the vars if set.
-	if spec.DisableTCMU {
-		config[disableTCMUEnvVar] = strconv.FormatBool(spec.DisableTCMU)
-	}
-	if spec.ForceTCMU {
-		config[forceTCMUEnvVar] = strconv.FormatBool(spec.ForceTCMU)
-	}
-
-	config[v1NamespaceEnvVar] = spec.GetResourceNS()
-
-	if spec.K8sDistro != "" {
-		config[k8sDistroEnvVar] = spec.K8sDistro
-	}
-
-	// CSI is optional in V1.
-	if spec.CSI.Enable {
-		config[csiEndpointEnvVar] = spec.GetCSIEndpoint(csiv1)
-		config[csiVersionEnvVar] = spec.GetCSIVersion(csiv1)
-	}
-
-	// Since we're running in k8s, always listen on the the scheduler extender
-	// api endpoints.  The feature can be disabled with the operator.  This
-	// allows users to toggle the feature without restarting the cluster.
-	config[k8sSchedulerExtenderEnvVar] = "true"
-
-	// If kubelet is running in a container, sharedDir should be set.
-	if spec.SharedDir != "" {
-		config[deviceDirEnvVar] = fmt.Sprintf("%s/devices", spec.SharedDir)
-	}
-
-	config[logFormatEnvVar] = "text"
-	config[logLevelEnvVar] = "info"
-	if spec.Debug {
-		config[logLevelEnvVar] = debugVal
-	}
-
-	return config
-}
-
-func v2ConfigFromSpec(spec storageosv1.StorageOSClusterSpec) map[string]string {
+func configFromSpec(spec storageosv1.StorageOSClusterSpec, csiv1 bool) map[string]string {
 	config := make(map[string]string)
 
 	// ETCD_ENDPOINTS must be set to a comma separated list of endpoints.
@@ -229,7 +143,9 @@ func v2ConfigFromSpec(spec storageosv1.StorageOSClusterSpec) map[string]string {
 
 	// Append Etcd TLS config, if given.  Volumes are created in Podspec.
 	if spec.TLSEtcdSecretRefName != "" && spec.TLSEtcdSecretRefNamespace != "" {
-		config = addEtcdTLSConfig(config, true)
+		config[etcdTLSClientCAEnvVar] = filepath.Join(tlsEtcdRootPath, tlsEtcdCA)
+		config[etcdTLSClientKeyEnvVar] = filepath.Join(tlsEtcdRootPath, tlsEtcdClientKey)
+		config[etcdTLSClientCertEnvVar] = filepath.Join(tlsEtcdRootPath, tlsEtcdClientCert)
 	}
 
 	// Always show telemetry and feature options to ensure they're visble.
@@ -249,7 +165,7 @@ func v2ConfigFromSpec(spec storageosv1.StorageOSClusterSpec) map[string]string {
 		config[forceTCMUEnvVar] = strconv.FormatBool(spec.ForceTCMU)
 	}
 
-	config[v2NamespaceEnvVar] = spec.GetResourceNS()
+	config[namespaceEnvVar] = spec.GetResourceNS()
 
 	if spec.K8sDistro != "" {
 		config[k8sDistroEnvVar] = spec.K8sDistro
@@ -284,26 +200,6 @@ func v2ConfigFromSpec(spec storageosv1.StorageOSClusterSpec) map[string]string {
 	if val := os.Getenv(jaegerServiceNameEnvVar); val != "" {
 		config[jaegerServiceNameEnvVar] = val
 	}
-
-	return config
-}
-
-// addEtcdTLSConfig adds the config entries for TLS config.  The ENV var names
-// are different between V1 & V2.
-func addEtcdTLSConfig(config map[string]string, v2 bool) map[string]string {
-	caCert := v1EtcdTLSClientCAEnvVar
-	clientKey := v1EtcdTLSClientKeyEnvVar
-	clientCert := v1EtcdTLSClientCertEnvVar
-
-	if v2 {
-		caCert = v2EtcdTLSClientCAEnvVar
-		clientKey = v2EtcdTLSClientKeyEnvVar
-		clientCert = v2EtcdTLSClientCertEnvVar
-	}
-
-	config[caCert] = filepath.Join(tlsEtcdRootPath, tlsEtcdCA)
-	config[clientKey] = filepath.Join(tlsEtcdRootPath, tlsEtcdClientKey)
-	config[clientCert] = filepath.Join(tlsEtcdRootPath, tlsEtcdClientCert)
 
 	return config
 }

--- a/pkg/storageos/configmap_test.go
+++ b/pkg/storageos/configmap_test.go
@@ -9,19 +9,8 @@ import (
 )
 
 func Test_configFromSpec(t *testing.T) {
-	v1DefaultSpec := storageosv1.StorageOSClusterSpec{}
-	v1DefaultConfig := map[string]string{
-		joinEnvVar:                 "",
-		disableFencingEnvVar:       "false",
-		disableTelemetryEnvVar:     "false",
-		k8sSchedulerExtenderEnvVar: "true",
-		v1NamespaceEnvVar:          "kube-system",
-		logFormatEnvVar:            "text",
-		logLevelEnvVar:             "info",
-	}
-
-	v2DefaultSpec := storageosv1.StorageOSClusterSpec{}
-	v2DefaultConfig := map[string]string{
+	defaultSpec := storageosv1.StorageOSClusterSpec{}
+	defaultConfig := map[string]string{
 		csiEndpointEnvVar:           "unix:///var/lib/kubelet/plugins_registry/storageos/csi.sock",
 		csiVersionEnvVar:            "v1",
 		disableCrashReportingEnvVar: "false",
@@ -29,7 +18,7 @@ func Test_configFromSpec(t *testing.T) {
 		disableVersionCheckEnvVar:   "false",
 		etcdEndpointsEnvVar:         "",
 		k8sSchedulerExtenderEnvVar:  "true",
-		v2NamespaceEnvVar:           "kube-system",
+		namespaceEnvVar:             "kube-system",
 		logFormatEnvVar:             "json",
 		logLevelEnvVar:              "info",
 		// disableFencingEnvVar:        "false",
@@ -40,265 +29,57 @@ func Test_configFromSpec(t *testing.T) {
 		spec       storageosv1.StorageOSClusterSpec
 		env        map[string]string
 		csiv1      bool
-		nodev2     bool
 		wantbase   map[string]string
 		wantcustom map[string]string
 	}{
 		{
-			name:     "v1 defaults",
-			spec:     v1DefaultSpec,
+			name:     "defaults",
+			spec:     defaultSpec,
 			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
+			wantbase: defaultConfig,
 		},
 		{
-			name: "v1 csi",
+			name: "csi",
 			spec: storageosv1.StorageOSClusterSpec{
 				CSI: storageosv1.StorageOSClusterCSI{
 					Enable: true,
 				},
 			},
 			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				csiEndpointEnvVar: "unix:///var/lib/kubelet/plugins_registry/storageos/csi.sock",
-				csiVersionEnvVar:  "v1",
-			},
+			wantbase: defaultConfig,
 		},
 		{
-			name: "v1 csi v0",
+			name: "csi v0 - override to csi v1",
 			spec: storageosv1.StorageOSClusterSpec{
 				CSI: storageosv1.StorageOSClusterCSI{
 					Enable: true,
 				},
 			},
 			csiv1:    false,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				csiEndpointEnvVar: "unix:///var/lib/kubelet/plugins/storageos/csi.sock",
-				csiVersionEnvVar:  "v0",
-			},
-		},
-		{
-			name: "v1 join",
-			spec: storageosv1.StorageOSClusterSpec{
-				Join: "1.2.3.4,5.6.7.8,4.3.2.1",
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				joinEnvVar: "1.2.3.4,5.6.7.8,4.3.2.1",
-			},
-		},
-		{
-			name: "v1 shared-dir",
-			spec: storageosv1.StorageOSClusterSpec{
-				SharedDir: "some-dir-path",
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				deviceDirEnvVar: "some-dir-path/devices",
-			},
-		},
-		{
-			name: "v1 disable telemetry",
-			spec: storageosv1.StorageOSClusterSpec{
-				DisableTelemetry: true,
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				disableTelemetryEnvVar: "true",
-			},
-		},
-		{
-			name: "v1 disable fencing",
-			spec: storageosv1.StorageOSClusterSpec{
-				DisableFencing: true,
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				disableFencingEnvVar: "true",
-			},
-		},
-		{
-			name: "v1 disable tcmu",
-			spec: storageosv1.StorageOSClusterSpec{
-				DisableTCMU: true,
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				disableTCMUEnvVar: "true",
-			},
-		},
-		{
-			name: "v1 force tcmu",
-			spec: storageosv1.StorageOSClusterSpec{
-				ForceTCMU: true,
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				forceTCMUEnvVar: "true",
-			},
-		},
-		{
-			name: "v1 kv backend only",
-			spec: storageosv1.StorageOSClusterSpec{
-				KVBackend: storageosv1.StorageOSClusterKVBackend{
-					Backend: "etcd",
-				},
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				kvBackendEnvVar: "etcd",
-			},
-		},
-		{
-			name: "v1 kv address only",
-			spec: storageosv1.StorageOSClusterSpec{
-				KVBackend: storageosv1.StorageOSClusterKVBackend{
-					Address: "etcd-client:2379",
-				},
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				kvAddrEnvVar: "etcd-client:2379",
-			},
-		},
-		{
-			name: "v1 external etcd",
-			spec: storageosv1.StorageOSClusterSpec{
-				KVBackend: storageosv1.StorageOSClusterKVBackend{
-					Backend: "etcd",
-					Address: "etcd-client:2379",
-				},
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				kvBackendEnvVar: "etcd",
-				kvAddrEnvVar:    "etcd-client:2379",
-			},
-		},
-		{
-			name: "v1 etcd TLS",
-			spec: storageosv1.StorageOSClusterSpec{
-				TLSEtcdSecretRefName:      "etcd-certs",
-				TLSEtcdSecretRefNamespace: "default",
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				v1EtcdTLSClientCAEnvVar:   "/run/storageos/pki/etcd-client-ca.crt",
-				v1EtcdTLSClientKeyEnvVar:  "/run/storageos/pki/etcd-client.key",
-				v1EtcdTLSClientCertEnvVar: "/run/storageos/pki/etcd-client.crt",
-			},
-		},
-		{
-			name: "v1 external etcd with TLS",
-			spec: storageosv1.StorageOSClusterSpec{
-				KVBackend: storageosv1.StorageOSClusterKVBackend{
-					Backend: "etcd",
-					Address: "etcd-client:2379",
-				},
-				TLSEtcdSecretRefName:      "etcd-certs",
-				TLSEtcdSecretRefNamespace: "default",
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				kvBackendEnvVar:           "etcd",
-				kvAddrEnvVar:              "etcd-client:2379",
-				v1EtcdTLSClientCAEnvVar:   "/run/storageos/pki/etcd-client-ca.crt",
-				v1EtcdTLSClientKeyEnvVar:  "/run/storageos/pki/etcd-client.key",
-				v1EtcdTLSClientCertEnvVar: "/run/storageos/pki/etcd-client.crt",
-			},
-		},
-		{
-			name: "v1 distro",
-			spec: storageosv1.StorageOSClusterSpec{
-				K8sDistro: "some-distro-name",
-			},
-			csiv1:    true,
-			nodev2:   false,
-			wantbase: v1DefaultConfig,
-			wantcustom: map[string]string{
-				k8sDistroEnvVar: "some-distro-name",
-			},
-		},
-
-		{
-			name:     "v2 defaults",
-			spec:     v2DefaultSpec,
-			csiv1:    true,
-			nodev2:   true,
-			wantbase: v2DefaultConfig,
-		},
-		{
-			name: "v2 csi",
-			spec: storageosv1.StorageOSClusterSpec{
-				CSI: storageosv1.StorageOSClusterCSI{
-					Enable: true,
-				},
-			},
-			csiv1:    true,
-			nodev2:   true,
-			wantbase: v2DefaultConfig,
-		},
-		{
-			name: "v2 csi v0 - override to csi v1",
-			spec: storageosv1.StorageOSClusterSpec{
-				CSI: storageosv1.StorageOSClusterCSI{
-					Enable: true,
-				},
-			},
-			csiv1:    false,
-			nodev2:   true,
-			wantbase: v2DefaultConfig,
+			wantbase: defaultConfig,
 			wantcustom: map[string]string{
 				csiEndpointEnvVar: "unix:///var/lib/kubelet/plugins_registry/storageos/csi.sock",
 				csiVersionEnvVar:  "v1",
 			},
 		},
 		{
-			name: "v2 shared-dir",
+			name: "shared-dir",
 			spec: storageosv1.StorageOSClusterSpec{
 				SharedDir: "some-dir-path",
 			},
 			csiv1:    true,
-			nodev2:   true,
-			wantbase: v2DefaultConfig,
+			wantbase: defaultConfig,
 			wantcustom: map[string]string{
 				deviceDirEnvVar: "some-dir-path/devices",
 			},
 		},
 		{
-			name: "v2 disable telemetry",
+			name: "disable telemetry",
 			spec: storageosv1.StorageOSClusterSpec{
 				DisableTelemetry: true,
 			},
 			csiv1:    true,
-			nodev2:   true,
-			wantbase: v2DefaultConfig,
+			wantbase: defaultConfig,
 			wantcustom: map[string]string{
 				disableTelemetryEnvVar:      "true",
 				disableCrashReportingEnvVar: "true",
@@ -307,90 +88,83 @@ func Test_configFromSpec(t *testing.T) {
 		},
 		// Enable this when fencing is supported.
 		// {
-		// 	name: "v2 disable fencing",
+		// 	name: "disable fencing",
 		// 	spec: storageosv1.StorageOSClusterSpec{
 		// 		DisableFencing: true,
 		// 	},
 		// 	csiv1:    true,
-		// 	nodev2:   true,
 		// 	wantbase: v2DefaultConfig,
 		// 	wantcustom: map[string]string{
 		// 		disableFencingEnvVar: "true",
 		// 	},
 		// },
 		{
-			name: "v2 disable tcmu",
+			name: "disable tcmu",
 			spec: storageosv1.StorageOSClusterSpec{
 				DisableTCMU: true,
 			},
 			csiv1:    true,
-			nodev2:   true,
-			wantbase: v2DefaultConfig,
+			wantbase: defaultConfig,
 			wantcustom: map[string]string{
 				disableTCMUEnvVar: "true",
 			},
 		},
 		{
-			name: "v2 force tcmu",
+			name: "force tcmu",
 			spec: storageosv1.StorageOSClusterSpec{
 				ForceTCMU: true,
 			},
 			csiv1:    true,
-			nodev2:   true,
-			wantbase: v2DefaultConfig,
+			wantbase: defaultConfig,
 			wantcustom: map[string]string{
 				forceTCMUEnvVar: "true",
 			},
 		},
 		{
-			name: "v2 etcd TLS",
+			name: "etcd TLS",
 			spec: storageosv1.StorageOSClusterSpec{
 				TLSEtcdSecretRefName:      "etcd-certs",
 				TLSEtcdSecretRefNamespace: "default",
 			},
 			csiv1:    true,
-			nodev2:   true,
-			wantbase: v2DefaultConfig,
+			wantbase: defaultConfig,
 			wantcustom: map[string]string{
-				v2EtcdTLSClientCAEnvVar:   "/run/storageos/pki/etcd-client-ca.crt",
-				v2EtcdTLSClientKeyEnvVar:  "/run/storageos/pki/etcd-client.key",
-				v2EtcdTLSClientCertEnvVar: "/run/storageos/pki/etcd-client.crt",
+				etcdTLSClientCAEnvVar:   "/run/storageos/pki/etcd-client-ca.crt",
+				etcdTLSClientKeyEnvVar:  "/run/storageos/pki/etcd-client.key",
+				etcdTLSClientCertEnvVar: "/run/storageos/pki/etcd-client.crt",
 			},
 		},
 		{
-			name: "v2 distro",
+			name: "distro",
 			spec: storageosv1.StorageOSClusterSpec{
 				K8sDistro: "some-distro-name",
 			},
 			csiv1:    true,
-			nodev2:   true,
-			wantbase: v2DefaultConfig,
+			wantbase: defaultConfig,
 			wantcustom: map[string]string{
 				k8sDistroEnvVar: "some-distro-name",
 			},
 		},
 		{
-			name: "v2 jaeger endpoint",
-			spec: v2DefaultSpec,
+			name: "jaeger endpoint",
+			spec: defaultSpec,
 			env: map[string]string{
 				jaegerEndpointEnvVar: "http:/1.2.3.4:1234",
 			},
 			csiv1:    true,
-			nodev2:   true,
-			wantbase: v2DefaultConfig,
+			wantbase: defaultConfig,
 			wantcustom: map[string]string{
 				jaegerEndpointEnvVar: "http:/1.2.3.4:1234",
 			},
 		},
 		{
-			name: "v2 jaeger service name",
-			spec: v2DefaultSpec,
+			name: "jaeger service name",
+			spec: defaultSpec,
 			env: map[string]string{
 				jaegerServiceNameEnvVar: "test-1234",
 			},
 			csiv1:    true,
-			nodev2:   true,
-			wantbase: v2DefaultConfig,
+			wantbase: defaultConfig,
 			wantcustom: map[string]string{
 				jaegerServiceNameEnvVar: "test-1234",
 			},
@@ -418,7 +192,7 @@ func Test_configFromSpec(t *testing.T) {
 				want[k] = v
 			}
 
-			if got := configFromSpec(tt.spec, tt.csiv1, tt.nodev2); !reflect.DeepEqual(got, want) {
+			if got := configFromSpec(tt.spec, tt.csiv1); !reflect.DeepEqual(got, want) {
 				t.Errorf("configFromSpec() got:\n%v\n want:\n%v\n", got, want)
 			}
 		})

--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -110,13 +110,14 @@ func (s Deployment) csiHelperContainers() ([]corev1.Container, error) {
 	privileged := true
 	containers := []corev1.Container{
 		{
-			Image:           s.stos.Spec.GetCSIExternalProvisionerImage(CSIV1Supported(s.k8sVersion), s.nodev2),
+			Image:           s.stos.Spec.GetCSIExternalProvisionerImage(CSIV1Supported(s.k8sVersion)),
 			Name:            "csi-external-provisioner",
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Args: []string{
 				"--v=5",
 				"--provisioner=storageos", // deprecated in v1.1.0, but required for v1.0.0 (CSI v0).
 				"--csi-address=$(ADDRESS)",
+				"--extra-create-metadata",
 			},
 			Env: []corev1.EnvVar{
 				{
@@ -160,39 +161,34 @@ func (s Deployment) csiHelperContainers() ([]corev1.Container, error) {
 		},
 	}
 
-	if s.nodev2 {
-		// v2 provisioner requires additional startup flag.
-		containers[0].Args = append(containers[0].Args, "--extra-create-metadata")
-
-		// v2 supports volume resize.
-		// Add CSI external resizer if it's supported by the version of k8s.
-		if CSIExternalResizerSupported(s.k8sVersion) {
-			resizer := corev1.Container{
-				Image:           s.stos.Spec.GetCSIExternalResizerImage(),
-				Name:            "csi-external-resizer",
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				Args: []string{
-					"--v=5",
-					"--csi-address=$(ADDRESS)",
+	// v2 supports volume resize.
+	// Add CSI external resizer if it's supported by the version of k8s.
+	if CSIExternalResizerSupported(s.k8sVersion) {
+		resizer := corev1.Container{
+			Image:           s.stos.Spec.GetCSIExternalResizerImage(),
+			Name:            "csi-external-resizer",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Args: []string{
+				"--v=5",
+				"--csi-address=$(ADDRESS)",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  addressEnvVar,
+					Value: "/csi/csi.sock",
 				},
-				Env: []corev1.EnvVar{
-					{
-						Name:  addressEnvVar,
-						Value: "/csi/csi.sock",
-					},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: &privileged,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "plugin-dir",
+					MountPath: "/csi",
 				},
-				SecurityContext: &corev1.SecurityContext{
-					Privileged: &privileged,
-				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      "plugin-dir",
-						MountPath: "/csi",
-					},
-				},
-			}
-			containers = append(containers, resizer)
+			},
 		}
+		containers = append(containers, resizer)
 	}
 
 	// CSI v1 requires running CSI driver registrar to register the driver along

--- a/pkg/storageos/csidriver.go
+++ b/pkg/storageos/csidriver.go
@@ -18,13 +18,7 @@ func (s *Deployment) createCSIDriver() error {
 		AttachRequired: &attachRequired,
 		PodInfoOnMount: &podInfoRequired,
 	}
-
-	driverName := CSIProvisionerName
-	if s.nodev2 {
-		driverName = StorageOSProvisionerName
-	}
-
-	return k8sresource.NewCSIDriver(s.client, driverName, nil, spec).Create()
+	return k8sresource.NewCSIDriver(s.client, StorageOSProvisionerName, nil, spec).Create()
 }
 
 // deleteCSIDriver deletes the StorageOS CSIDriver resource.

--- a/pkg/storageos/daemonset.go
+++ b/pkg/storageos/daemonset.go
@@ -35,38 +35,17 @@ const (
 	sysAdminCap = "SYS_ADMIN"
 	debugVal    = "xdebug"
 
-	// V1 Only
-	adminUsernameEnvVar                 = "ADMIN_USERNAME"
-	adminPasswordEnvVar                 = "ADMIN_PASSWORD"
-	csiRequireCredsCreateEnvVar         = "CSI_REQUIRE_CREDS_CREATE_VOL"
-	csiRequireCredsDeleteEnvVar         = "CSI_REQUIRE_CREDS_DELETE_VOL"
-	csiProvisionCredsUsernameEnvVar     = "CSI_PROVISION_CREDS_USERNAME"
-	csiProvisionCredsPasswordEnvVar     = "CSI_PROVISION_CREDS_PASSWORD"
-	csiRequireCredsCtrlPubEnvVar        = "CSI_REQUIRE_CREDS_CTRL_PUB_VOL"
-	csiRequireCredsCtrlUnpubEnvVar      = "CSI_REQUIRE_CREDS_CTRL_UNPUB_VOL"
-	csiControllerPubCredsUsernameEnvVar = "CSI_CTRL_PUB_CREDS_USERNAME"
-	csiControllerPubCredsPasswordEnvVar = "CSI_CTRL_PUB_CREDS_PASSWORD"
-	csiRequireCredsNodePubEnvVar        = "CSI_REQUIRE_CREDS_NODE_PUB_VOL"
-	csiNodePubCredsUsernameEnvVar       = "CSI_NODE_PUB_CREDS_USERNAME"
-	csiNodePubCredsPasswordEnvVar       = "CSI_NODE_PUB_CREDS_PASSWORD"
-
 	// Configmap file mode.
 	cmFileMode os.FileMode = 0600
 )
 
 // getNodeUsernameEnvVar returns the env var used to set the bootstrap username.
 func (s *Deployment) getNodeUsernameEnvVar() string {
-	if !s.nodev2 {
-		return adminUsernameEnvVar
-	}
 	return bootstrapUsernameEnvVar
 }
 
 // getNodePasswordEnvVar returns the env var used to set the bootstrap password.
 func (s *Deployment) getNodePasswordEnvVar() string {
-	if !s.nodev2 {
-		return adminPasswordEnvVar
-	}
 	return bootstrapPasswordEnvVar
 }
 
@@ -292,11 +271,6 @@ func (s *Deployment) createDaemonSet() error {
 	s.addTLSEtcdCerts(podSpec)
 
 	s.addNodeAffinity(podSpec)
-
-	// TODO: update when V2 supports health endpoint.
-	if !s.nodev2 {
-		s.addNodeContainerProbes(nodeContainer)
-	}
 
 	if err := s.addTolerationsWithDefaults(podSpec); err != nil {
 		return err

--- a/pkg/storageos/delete.go
+++ b/pkg/storageos/delete.go
@@ -55,7 +55,7 @@ func (s *Deployment) Delete() error {
 		return err
 	}
 
-	if err := s.k8sResourceManager.ClusterRole(NFSClusterRoleName, namespace, nil, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ClusterRole(NFSClusterRoleName, nil, nil).Delete(); err != nil {
 		return err
 	}
 

--- a/pkg/storageos/delete.go
+++ b/pkg/storageos/delete.go
@@ -55,7 +55,7 @@ func (s *Deployment) Delete() error {
 		return err
 	}
 
-	if err := s.k8sResourceManager.Role(NFSClusterRoleName, namespace, nil, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ClusterRole(NFSClusterRoleName, namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
 

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -242,17 +242,7 @@ func TestCreateDaemonSet(t *testing.T) {
 			wantK8sDistro: "some-distro-name",
 		},
 		{
-			name: "v1 creds env vars",
-			spec: api.StorageOSClusterSpec{
-				Images: api.ContainerImages{
-					NodeContainer: "storageos/node:1.5.4",
-				},
-			},
-			wantUserNameEnvVar: adminUsernameEnvVar,
-			wantPasswordEnvVar: adminPasswordEnvVar,
-		},
-		{
-			name: "v2 creds env vars",
+			name: "creds env vars",
 			spec: api.StorageOSClusterSpec{
 				Images: api.ContainerImages{
 					NodeContainer: "storageos/node:v2.0.0",
@@ -596,101 +586,6 @@ func TestCreateAPIManager(t *testing.T) {
 	}
 }
 
-// NOTE: Unsupported legacy test.
-func TestDeployLegacy(t *testing.T) {
-	// This test used to work with the controller-runtime fake client. The fake
-	// client has been deprecated and this test fails due to unexpected issues.
-	// TODO: Move this test to use envtest
-	// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.0/pkg/envtest?tab=doc.
-	t.Skip("skipping... fails with the controller-runtime fake client")
-
-	const (
-		containersCount = 1
-		volumesCount    = 5 // includes ConfigMap volume
-	)
-
-	stosCluster := &api.StorageOSCluster{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: gvk.GroupVersion().String(),
-			Kind:       gvk.Kind,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "teststos",
-			Namespace: "default",
-		},
-	}
-
-	testCases := []struct {
-		name       string
-		k8sVersion string
-	}{
-		{
-			name:       "empty",
-			k8sVersion: "",
-		},
-		{
-			name:       "1.9",
-			k8sVersion: "1.9",
-		},
-		{
-			name:       "1.11.0",
-			k8sVersion: "1.11.0",
-		},
-		{
-			name:       "1.12.2",
-			k8sVersion: "1.12.2",
-		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			c := fake.NewFakeClientWithScheme(testScheme)
-			if err := c.Create(context.Background(), stosCluster); err != nil {
-				t.Fatalf("failed to create storageoscluster object: %v", err)
-			}
-
-			dc, err := getFakeDiscoveryClient()
-			if err != nil {
-				t.Fatalf("failed to create discovery client: %v", err)
-			}
-
-			deploy := NewDeployment(c, dc, stosCluster, nil, nil, testScheme, tc.k8sVersion, false)
-			if err := deploy.Deploy(); err != nil {
-				t.Fatalf("failed to deploy cluster: %v", err)
-			}
-
-			createdDaemonset := &appsv1.DaemonSet{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "apps/v1",
-					Kind:       "DaemonSet",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      daemonsetName,
-					Namespace: stosCluster.Spec.GetResourceNS(),
-				},
-			}
-
-			nsName := types.NamespacedName{
-				Name:      daemonsetName,
-				Namespace: defaultNS,
-			}
-
-			if err := c.Get(context.Background(), nsName, createdDaemonset); err != nil {
-				t.Fatal("failed to get the created daemonset", err)
-			}
-
-			if len(createdDaemonset.Spec.Template.Spec.Containers) != containersCount {
-				t.Errorf("unexpected number of containers in the DaemonSet:\n\t(GOT) %d\n\t(WNT) %d", len(createdDaemonset.Spec.Template.Spec.Containers), containersCount)
-			}
-
-			if len(createdDaemonset.Spec.Template.Spec.Volumes) != volumesCount {
-				t.Errorf("unexpected number of volumes in the DaemonSet:\n\t(GOT) %d\n\t(WNT) %d", len(createdDaemonset.Spec.Template.Spec.Volumes), volumesCount)
-			}
-		})
-	}
-}
-
 func TestDeployCSI(t *testing.T) {
 	const (
 		kubeletPluginsWatcherDriverRegArgsCount = 3
@@ -811,7 +706,7 @@ func TestDeployCSI(t *testing.T) {
 	}
 }
 
-func TestDeployKVBackend(t *testing.T) {
+func TestDeployEtcdEndpoints(t *testing.T) {
 	testKVAddr := "1.2.3.4:1111,4.3.2.1:0000"
 	testBackend := "etcd"
 
@@ -868,29 +763,17 @@ func TestDeployKVBackend(t *testing.T) {
 		t.Fatal("failed to get the created configmap", err)
 	}
 
-	foundKVAddr := false
-	foundKVBackend := false
-
+	foundEndpoints := false
 	for k, v := range createdConfigMap.Data {
-		switch k {
-		case kvAddrEnvVar:
-			foundKVAddr = true
+		if k == etcdEndpointsEnvVar {
+			foundEndpoints = true
 			if v != testKVAddr {
 				t.Errorf("unexpected %s value:\n\t(GOT) %s\n\t(WNT) %s", etcdEndpointsEnvVar, v, testKVAddr)
 			}
-		case kvBackendEnvVar:
-			foundKVBackend = true
-			if v != testBackend {
-				t.Errorf("unexpected %s value:\n\t(GOT) %s\n\t(WNT) %s", kvBackendEnvVar, v, testBackend)
-			}
 		}
 	}
-
-	if !foundKVAddr {
-		t.Errorf("expected %s to be in the pod spec env", kvAddrEnvVar)
-	}
-	if !foundKVBackend {
-		t.Errorf("expected %s to be in the pod spec env", kvBackendEnvVar)
+	if !foundEndpoints {
+		t.Errorf("expected %s to be in the pod spec env", etcdEndpointsEnvVar)
 	}
 }
 
@@ -1971,7 +1854,7 @@ func TestContainerImageSelection(t *testing.T) {
 
 	// Given image name, cluster spec and k8s version, return the appropriate
 	// image.
-	getImage := func(name string, spec api.StorageOSClusterSpec, k8sVersion string, nodeV2 bool) string {
+	getImage := func(name string, spec api.StorageOSClusterSpec, k8sVersion string) string {
 		csiV1Supported := CSIV1Supported(k8sVersion)
 		attacherV2Supported := CSIExternalAttacherV2Supported(k8sVersion)
 
@@ -1985,7 +1868,7 @@ func TestContainerImageSelection(t *testing.T) {
 		case csiNodeDriverRegistrarImage:
 			return spec.GetCSINodeDriverRegistrarImage(csiV1Supported)
 		case csiExternalProvisionerImage:
-			return spec.GetCSIExternalProvisionerImage(csiV1Supported, nodeV2)
+			return spec.GetCSIExternalProvisionerImage(csiV1Supported)
 		case csiExternalAttacherImage:
 			return spec.GetCSIExternalAttacherImage(csiV1Supported, attacherV2Supported)
 		case csiLivenessProbeImage:
@@ -2004,7 +1887,6 @@ func TestContainerImageSelection(t *testing.T) {
 		envVars     map[string]string
 		clusterSpec api.StorageOSClusterSpec
 		k8sVersion  string
-		nodev2      bool
 		wantImages  map[string]string
 	}{
 		{
@@ -2075,24 +1957,8 @@ func TestContainerImageSelection(t *testing.T) {
 			},
 		},
 		{
-			name:       "no env vars, no overrides, fallback images - k8s 1.13, node v1",
-			k8sVersion: "1.13.0",
-			wantImages: map[string]string{
-				storageOSNodeImage:             image.DefaultNodeContainerImage,
-				storageOSInitImage:             image.DefaultInitContainerImage,
-				csiClusterDriverRegistrarImage: image.CSIv1ClusterDriverRegistrarContainerImage,
-				csiNodeDriverRegistrarImage:    image.CSIv1NodeDriverRegistrarContainerImage,
-				csiExternalProvisionerImage:    image.CSIv1ExternalProvisionerContainerImageV1,
-				csiExternalAttacherImage:       image.CSIv1ExternalAttacherContainerImage,
-				csiLivenessProbeImage:          image.CSIv1LivenessProbeContainerImage,
-				kubeSchedulerImage:             fmt.Sprintf("%s:%s", image.DefaultKubeSchedulerContainerRegistry, "v1.13.0"),
-				nfsImage:                       image.DefaultNFSContainerImage,
-			},
-		},
-		{
 			name:       "no env vars, no overrides, fallback images - k8s 1.13, node v2",
 			k8sVersion: "1.13.0",
-			nodev2:     true,
 			wantImages: map[string]string{
 				storageOSNodeImage:             image.DefaultNodeContainerImage,
 				storageOSInitImage:             image.DefaultInitContainerImage,
@@ -2149,44 +2015,10 @@ func TestContainerImageSelection(t *testing.T) {
 			}()
 
 			for imgName, wantImg := range tc.wantImages {
-				gotImg := getImage(imgName, tc.clusterSpec, tc.k8sVersion, tc.nodev2)
+				gotImg := getImage(imgName, tc.clusterSpec, tc.k8sVersion)
 				if gotImg != wantImg {
 					t.Errorf("unexpected image selected for %s:\n\t(WNT) %s\n\t(GOT) %s", imgName, wantImg, gotImg)
 				}
-			}
-		})
-	}
-}
-
-func Test_NodeV2Image(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		image string
-		want  bool
-	}{
-		{image: "storageos/node", want: false},
-		{image: "storageos/node:1.0.0", want: false},
-		{image: "storageos/node:1.2.0-alpha1", want: false},
-		{image: "storageos/node:1.5.4-rc2", want: false},
-		{image: "storageos/node:7c46250197bf", want: false},
-		{image: "storageos/node:2.0.0", want: true},
-		{image: "storageos/node:v2.0.0", want: true},
-		{image: "storageos/node:c2", want: true},
-		{image: "storageos/node:v2", want: true},
-		{image: "storageos/node:2.0.0-alpha1", want: true},
-		{image: "storageos/node:c2-7c46250197bf", want: true},
-		{image: "myregistryhost:5000/storageos/node:1.0.0", want: false},
-		{image: "myregistryhost:5000/storageos/node:2.0.0", want: true},
-		{image: "invalidscheme://myregistryhost:5000/storageos/node:2.0.0", want: true},
-		{image: "2.0.0", want: false},
-	}
-	for _, tt := range tests {
-		var tt = tt
-		t.Run(tt.image, func(t *testing.T) {
-			t.Parallel()
-			if got := NodeV2Image(tt.image); got != tt.want {
-				t.Errorf("NodeV2Image(%s) = %v, want %v", tt.image, got, tt.want)
 			}
 		})
 	}

--- a/pkg/storageos/deployment.go
+++ b/pkg/storageos/deployment.go
@@ -21,7 +21,6 @@ type Deployment struct {
 	scheme             *runtime.Scheme
 	update             bool
 	k8sResourceManager *k8s.ResourceManager
-	nodev2             bool
 }
 
 // NewDeployment creates a new Deployment given a k8c client, storageos manifest
@@ -44,6 +43,5 @@ func NewDeployment(
 		scheme:             scheme,
 		update:             update,
 		k8sResourceManager: k8s.NewResourceManager(client).SetLabels(labels),
-		nodev2:             NodeV2Image(stos.Spec.Images.NodeContainer),
 	}
 }

--- a/pkg/storageos/podspec.go
+++ b/pkg/storageos/podspec.go
@@ -136,61 +136,6 @@ func (s *Deployment) addCSI(podSpec *corev1.PodSpec) {
 		// Append volume mounts to the first container, the only container is the node container, at this point.
 		nodeContainer.VolumeMounts = append(nodeContainer.VolumeMounts, volMnts...)
 
-		// V1 passes CSI credentials as env vars.  In V2, CSI credentials are
-		// set in the StorageClass.
-		envVar := []corev1.EnvVar{}
-		if !s.nodev2 {
-			// Append CSI Provision Creds env var if enabled.
-			if s.stos.Spec.CSI.EnableProvisionCreds {
-				envVar = append(
-					envVar,
-					corev1.EnvVar{
-						Name:  csiRequireCredsCreateEnvVar,
-						Value: "true",
-					},
-					corev1.EnvVar{
-						Name:  csiRequireCredsDeleteEnvVar,
-						Value: "true",
-					},
-					getCSICredsEnvVar(csiProvisionCredsUsernameEnvVar, csiProvisionerSecretName, "username"),
-					getCSICredsEnvVar(csiProvisionCredsPasswordEnvVar, csiProvisionerSecretName, "password"),
-				)
-			}
-
-			// Append CSI Controller Publish env var if enabled.
-			if s.stos.Spec.CSI.EnableControllerPublishCreds {
-				envVar = append(
-					envVar,
-					corev1.EnvVar{
-						Name:  csiRequireCredsCtrlPubEnvVar,
-						Value: "true",
-					},
-					corev1.EnvVar{
-						Name:  csiRequireCredsCtrlUnpubEnvVar,
-						Value: "true",
-					},
-					getCSICredsEnvVar(csiControllerPubCredsUsernameEnvVar, csiControllerPublishSecretName, "username"),
-					getCSICredsEnvVar(csiControllerPubCredsPasswordEnvVar, csiControllerPublishSecretName, "password"),
-				)
-			}
-
-			// Append CSI Node Publish env var if enabled.
-			if s.stos.Spec.CSI.EnableNodePublishCreds {
-				envVar = append(
-					envVar,
-					corev1.EnvVar{
-						Name:  csiRequireCredsNodePubEnvVar,
-						Value: "true",
-					},
-					getCSICredsEnvVar(csiNodePubCredsUsernameEnvVar, csiNodePublishSecretName, "username"),
-					getCSICredsEnvVar(csiNodePubCredsPasswordEnvVar, csiNodePublishSecretName, "password"),
-				)
-			}
-		}
-
-		// Append env vars to the first container, node container.
-		nodeContainer.Env = append(nodeContainer.Env, envVar...)
-
 		driverReg := corev1.Container{
 			Image:           s.stos.Spec.GetCSINodeDriverRegistrarImage(CSIV1Supported(s.k8sVersion)),
 			Name:            "csi-driver-registrar",

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -16,8 +16,7 @@ const (
 	policyConfigMapName = "storageos-scheduler-policy"
 	policyConfigKey     = "policy.cfg"
 
-	uriPathV1 = "/v1/scheduler"
-	uriPathV2 = "/v2/k8s/scheduler"
+	uriPath = "/v2/k8s/scheduler"
 
 	// schedulerReplicas is the number of instances of kube-scheduler.
 	schedulerReplicas = 1
@@ -153,10 +152,6 @@ func (s Deployment) createSchedulerPolicy() error {
 `
 	// Service address format: <service-name>.<namespace>.svc.
 	serviceEndpoint := fmt.Sprintf("%s.%s.svc", s.stos.Spec.GetServiceName(), s.stos.Spec.GetResourceNS())
-	uriPath := uriPathV1
-	if s.nodev2 {
-		uriPath = uriPathV2
-	}
 	policyData := schedulerPolicyTemplate{
 		FilterVerb:     "filter",
 		PrioritizeVerb: "prioritize",

--- a/pkg/storageos/storageclass.go
+++ b/pkg/storageos/storageclass.go
@@ -1,17 +1,6 @@
 package storageos
 
 func (s *Deployment) createStorageClass() error {
-	// Provisioner name for in-tree storage plugin.
-	provisioner := IntreeProvisionerName
-
-	if s.stos.Spec.CSI.Enable {
-		provisioner = CSIProvisionerName
-		// Check if it's a v2 deployment and use the appropriate provisioner.
-		if s.nodev2 {
-			provisioner = StorageOSProvisionerName
-		}
-	}
-
 	parameters := map[string]string{
 		"pool": "default",
 	}
@@ -62,5 +51,5 @@ func (s *Deployment) createStorageClass() error {
 		parameters[secretNameKey] = s.stos.Spec.SecretRefName
 	}
 
-	return s.k8sResourceManager.StorageClass(s.stos.Spec.GetStorageClassName(), nil, provisioner, parameters).Create()
+	return s.k8sResourceManager.StorageClass(s.stos.Spec.GetStorageClassName(), nil, StorageOSProvisionerName, parameters).Create()
 }

--- a/pkg/storageos/update_status.go
+++ b/pkg/storageos/update_status.go
@@ -2,25 +2,18 @@ package storageos
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
-	"net/http"
 	"reflect"
 	"strings"
 	"time"
 
 	storageosv1 "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 	storageosapi "github.com/storageos/go-api"
-	"github.com/storageos/go-api/types"
 	v1 "k8s.io/api/core/v1"
 )
 
 var (
-	// nodeHealthTimeout specifies how long we should wait for the api to
-	// return health results.
-	nodeHealthTimeout = time.Second
-
 	// nodeLivenessTimeout specifies how long we should wait for a connection to
 	// the node's api port.
 	nodeLivenessTimeout = time.Second
@@ -65,13 +58,10 @@ func (s *Deployment) getStorageOSStatus() (*storageosv1.StorageOSClusterStatus, 
 		nodeIPs = strings.Split(s.stos.Spec.Join, ",")
 	}
 
-	if s.nodev2 {
-		return s.getStorageOSV2Status(nodeIPs)
-	}
-	return s.getStorageOSV1Status(nodeIPs)
+	return s.getStorageOSV2Status(nodeIPs)
 }
 
-// getStorageOSV2Status queries health of all the nodes in the cluster and
+// getStorageOSStatus queries health of all the nodes in the cluster and
 // returns the cluster status.
 //
 // NodeHealthStatus is deprecated and not set for V2.
@@ -104,46 +94,6 @@ func (s *Deployment) getStorageOSV2Status(nodeIPs []string) (*storageosv1.Storag
 	}, nil
 }
 
-// getStorageOSV1Status queries health of all the nodes in the join token and
-// returns the cluster status.
-func (s *Deployment) getStorageOSV1Status(nodeIPs []string) (*storageosv1.StorageOSClusterStatus, error) {
-	var readyNodes int
-
-	totalNodes := len(nodeIPs)
-	healthStatus := make(map[string]storageosv1.NodeHealth)
-	memberStatus := new(storageosv1.MembersStatus)
-
-	for _, node := range nodeIPs {
-		if status, err := getNodeHealth(node, nodeHealthTimeout); err == nil {
-			healthStatus[node] = *status
-			if isHealthy(status) {
-				readyNodes++
-				memberStatus.Ready = append(memberStatus.Ready, node)
-			} else {
-				memberStatus.Unready = append(memberStatus.Unready, node)
-			}
-		}
-	}
-
-	phase := storageosv1.ClusterPhaseCreating
-	if readyNodes == totalNodes {
-		phase = storageosv1.ClusterPhaseRunning
-	}
-
-	return &storageosv1.StorageOSClusterStatus{
-		Phase:            phase,
-		Nodes:            nodeIPs,
-		NodeHealthStatus: healthStatus,
-		Ready:            fmt.Sprintf("%d/%d", readyNodes, totalNodes),
-		Members:          *memberStatus,
-	}, nil
-}
-
-func isHealthy(health *storageosv1.NodeHealth) bool {
-	return health.DirectfsInitiator+health.Director+health.KV+health.KVWrite+
-		health.Nats+health.Presentation+health.Rdb == strings.Repeat("alive", 7)
-}
-
 func isListening(host string, port string, timeout time.Duration) bool {
 	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), timeout)
 	if err != nil {
@@ -153,39 +103,4 @@ func isListening(host string, port string, timeout time.Duration) bool {
 		defer conn.Close()
 	}
 	return true
-}
-
-func getNodeHealth(address string, timeout time.Duration) (*storageosv1.NodeHealth, error) {
-	healthEndpointFormat := "http://%s:%s/v1/" + storageosapi.HealthAPIPrefix
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	client := &http.Client{}
-
-	var healthStatus types.HealthStatus
-	cpURL := fmt.Sprintf(healthEndpointFormat, address, storageosapi.DefaultPort)
-	cpReq, err := http.NewRequest("GET", cpURL, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	cpResp, err := client.Do(cpReq.WithContext(ctx))
-	if err != nil {
-		return nil, err
-	}
-
-	if err := json.NewDecoder(cpResp.Body).Decode(&healthStatus); err != nil {
-		return nil, err
-	}
-
-	return &storageosv1.NodeHealth{
-		DirectfsInitiator: healthStatus.Submodules.DirectFSClient.Status,
-		Director:          healthStatus.Submodules.Director.Status,
-		KV:                healthStatus.Submodules.KV.Status,
-		KVWrite:           healthStatus.Submodules.KVWrite.Status,
-		Nats:              healthStatus.Submodules.NATS.Status,
-		Presentation:      healthStatus.Submodules.FS.Status,
-		Rdb:               healthStatus.Submodules.FSDriver.Status,
-	}, nil
 }


### PR DESCRIPTION
Previously the operator evaluated the node image tag to determine the StorageOS major version, and to configure accordingly.  Since Red Hat Marketplace rewrites image tags to hashes, evaluation using the tag is no longer possible.

Since there is no reason to deploy v1 with the latest operator we can remove the ability to do so.