### PR TITLE
Set recommended max_pids used by the init container

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Parameter | Description | Default
 `secretRefNamespace` | Namespace of storageos secret |
 `namespace` | Namespace where storageos cluster resources are created | `storageos`
 `images.nodeContainer` | StorageOS node container image | `storageos/node:v2.2.0`
-`images.initContainer` | StorageOS init container image | `storageos/init:v2.0.0`
+`images.initContainer` | StorageOS init container image | `storageos/init:v2.1.0`
 `images.csiNodeDriverRegistrarContainer` | CSI Node Driver Registrar Container image | Varies depending on Kubernetes version
 `images.csiClusterDriverRegistrarContainer` | CSI Cluster Driver Registrar Container image |  Varies depending on Kubernetes version
 `images.csiExternalProvisionerContainer` | CSI External Provisioner Container image |  Varies depending on Kubernetes version

--- a/internal/pkg/image/image.go
+++ b/internal/pkg/image/image.go
@@ -5,7 +5,7 @@ import "os"
 // Default image constant variables.
 const (
 	DefaultNodeContainerImage                 = "storageos/node:v2.2.0"
-	DefaultInitContainerImage                 = "storageos/init:v2.0.0"
+	DefaultInitContainerImage                 = "storageos/init:v2.1.0"
 	CSIv1ClusterDriverRegistrarContainerImage = "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1"
 	CSIv1NodeDriverRegistrarContainerImage    = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
 	CSIv1ExternalProvisionerContainerImageV1  = "storageos/csi-provisioner:v1.4.0"

--- a/pkg/storageos/configmap.go
+++ b/pkg/storageos/configmap.go
@@ -99,6 +99,11 @@ const (
 	// Logger format: default or json.
 	logFormatEnvVar = "LOG_FORMAT"
 
+	// recommendedPidLimitEnvVar sets the minimum max_pids limit recommended by
+	// StorageOS. The init container detects the effective limit and will warn
+	// if not met.
+	recommendedPidLimitEnvVar = "RECOMMENDED_MAX_PIDS_LIMIT"
+
 	// Tracing configuration.  Intended for internal development use only and
 	// should not be documented externally.
 	jaegerEndpointEnvVar    = "JAEGER_ENDPOINT"
@@ -190,6 +195,9 @@ func configFromSpec(spec storageosv1.StorageOSClusterSpec, csiv1 bool) map[strin
 	if spec.Debug {
 		config[logLevelEnvVar] = debugVal
 	}
+
+	// Always set max_pids recommendation.
+	config[recommendedPidLimitEnvVar] = fmt.Sprint(recommendedPidLimit)
 
 	// Set Jaeger configuration, only if set as an env var in the operator. We
 	// do this because we don't want to publish configuration options in the CRD

--- a/pkg/storageos/configmap_test.go
+++ b/pkg/storageos/configmap_test.go
@@ -21,6 +21,7 @@ func Test_configFromSpec(t *testing.T) {
 		namespaceEnvVar:             "kube-system",
 		logFormatEnvVar:             "json",
 		logLevelEnvVar:              "info",
+		recommendedPidLimitEnvVar:   "32768",
 		// disableFencingEnvVar:        "false",
 	}
 

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -82,6 +82,10 @@ const (
 	defaultUsername = "storageos"
 	defaultPassword = "storageos"
 
+	// recommendedPidLimit is passed to the init container to warn if a lower
+	// limit is set.  It can't be overridden.
+	recommendedPidLimit = "32768"
+
 	// k8s distribution vendor specific keywords.
 
 	// K8SDistroOpenShift is k8s distribution name for OpenShift.


### PR DESCRIPTION
Set `RECOMMENDED_MAX_PIDS_LIMIT` to default 32,768, used by the init container to verify StorageOS requirements are met prior to starting the node container.  The init container will log warnings when the limit is lower than the effective limit.