### PR TITLE
Fix ServiceAccountName in the OLM bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/_output
 build/_test
 build/operator-sdk
 build/yq
+build/yq3
 build/golangci-lint
 deploy/test
 /olm

--- a/bundle/manifests/storageosoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/storageosoperator.clusterserviceversion.yaml
@@ -40,204 +40,204 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Job is the Schema for the jobs API
-      kind: Job
-      name: jobs.storageos.com
-      version: v1
-    - description: NFSServer is the Schema for the nfsservers API
-      kind: NFSServer
-      name: nfsservers.storageos.com
-      version: v1
-    - description: StorageOSCluster is the Schema for the storageosclusters API
-      displayName: StorageOS Cluster
-      kind: StorageOSCluster
-      name: storageosclusters.storageos.com
-      resources:
-      - kind: Namespace
-        name: ''
+      - description: Job is the Schema for the jobs API
+        kind: Job
+        name: jobs.storageos.com
         version: v1
-      - kind: ServiceAccount
-        name: ''
+      - description: NFSServer is the Schema for the nfsservers API
+        kind: NFSServer
+        name: nfsservers.storageos.com
         version: v1
-      - kind: Role
-        name: ''
-        version: rbac.authorization.k8s.io/v1
-      - kind: RoleBinding
-        name: ''
-        version: rbac.authorization.k8s.io/v1
-      - kind: ClusterRole
-        name: ''
-        version: rbac.authorization.k8s.io/v1
-      - kind: ClusterRoleBinding
-        name: ''
-        version: rbac.authorization.k8s.io/v1
-      - kind: Secret
-        name: ''
+      - description: StorageOSCluster is the Schema for the storageosclusters API
+        displayName: StorageOS Cluster
+        kind: StorageOSCluster
+        name: storageosclusters.storageos.com
+        resources:
+        - kind: Namespace
+          name: ''
+          version: v1
+        - kind: ServiceAccount
+          name: ''
+          version: v1
+        - kind: Role
+          name: ''
+          version: rbac.authorization.k8s.io/v1
+        - kind: RoleBinding
+          name: ''
+          version: rbac.authorization.k8s.io/v1
+        - kind: ClusterRole
+          name: ''
+          version: rbac.authorization.k8s.io/v1
+        - kind: ClusterRoleBinding
+          name: ''
+          version: rbac.authorization.k8s.io/v1
+        - kind: Secret
+          name: ''
+          version: v1
+        - kind: DaemonSet
+          name: ''
+          version: apps/v1
+        - kind: Service
+          name: ''
+          version: v1
+        - kind: Ingress
+          name: ''
+          version: extensions/v1beta1
+        - kind: Deployment
+          name: ''
+          version: apps/v1
+        - kind: StatefulSet
+          name: ''
+          version: apps/v1
+        - kind: StorageClass
+          name: ''
+          version: storage.k8s.io/v1
+        - kind: StorageOSCluster
+          name: ''
+          version: v1
+        - kind: Job
+          name: ''
+          version: v1
+        - kind: StorageOSUpgrade
+          name: ''
+          version: v1
+        - kind: NFSServer
+          name: ''
+          version: v1
+        - kind: Node
+          name: ''
+          version: v1
+        - kind: StatefulSet
+          name: ''
+          version: v1
+        - kind: DaemonSet
+          name: ''
+          version: v1
+        specDescriptors:
+        - description: Defines the various container images used in the cluster.
+          displayName: Images
+          path: images
+        - description: The namespace to install the StorageOS cluster into. `kube-system`
+            is recommended so that StorageOS does not get evicted if a node becomes
+            over-allocated.
+          displayName: Namespace
+          path: namespace
+        - description: The name of the secret object that stores the api credentials.
+          displayName: Cluster Secret
+          path: secretRefName
+        - description: The name of the namespace where the secret object that stores
+            the api credentials exists.
+          displayName: Cluster Secret Namespace
+          path: secretRefNamespace
+        - description: The join token is used for cluster discovery.  When used with
+            the Operator, the token will be a comma-separated list of all cluster member
+            IP addresses.  The node that owns the first IP address listed will be responsible
+            for bootsrapping the cluster.
+          displayName: Cluster members
+          path: join
+        - description: KV store configuration to use. Defaults to embedded. `etcd` is
+            recommended for production deployments with the address set to an external
+            etcd instance.
+          displayName: KV Store
+          path: kvBackend
+        - description: Describes the Container Storage Interface (CSI) configuration.
+          displayName: Enable CSI
+          path: csi
+        - description: The cluster Service configuration.
+          displayName: Service configuration
+          path: service
+        - description: The shared directory where storage devices should be created.  This
+            directory must be available to both the StorageOS Node container and the
+            kubelet, and must have mount propagation enabled. When kubelet is running
+            in a container, `/var/lib/kubelet/plugins/kubernetes.io~storageos` should
+            normally be set, otherwise leave empty.
+          displayName: Device directory
+          path: sharedDir
+        - description: Describes the ingress configuration to be configured for the
+            cluster.
+          displayName: Ingress configuration
+          path: ingress
+        - description: The name of the secret object that contains the etcd TLS certificates.
+          displayName: etcd TLS Secret Name
+          path: tlsEtcdSecretRefName
+        - description: The namespace of the secret object that contains the etcd TLS
+            certificates.
+          displayName: etcd TLS Secret Namespace
+          path: tlsEtcdSecretRefNamespace
+        - description: Node selector terms can be set to control the placement of StorageOS
+            pods using node affiinity.
+          displayName: Node Selectors
+          path: nodeSelectorTerms
+        - description: Tolerations can be set to control the placement of StorageOS
+            pods.
+          displayName: Tolerations
+          path: tolerations
+        - description: Name of the Kubernetes distribution in use, e.g. `openshift`.  This
+            will be included in the product telemetry (if enabled), to help focus development
+            efforts.
+          displayName: Kubernetes Distribution Name
+          path: k8sDistro
+        - description: To disable anonymous usage reporting across the cluster, set
+            to true. Defaults to false. To help improve the product, data such as API
+            usage and StorageOS configuration information is collected.
+          displayName: Disable Telemetry
+          path: disableTelemetry
+        - description: When Pod Fencing is disabled, StorageOS will not perform any
+            interaction with Kubernetes when it detects that a node has gone offline.
+            Additionally, the Kubernetes permissions required for Fencing will not be
+            added to the StorageOS role.
+          displayName: Disable Fencing
+          path: disableFencing
+        - description: Disable TCMU can be set to true to disable the TCMU storage driver.  This
+            is required when there are multiple storage systems running on the same
+            node and you wish to avoid conflicts.  Only one TCMU-based storage system
+            can run on a node at a time.  Disabling TCMU will degrade performance.
+          displayName: Disable TCMU
+          path: disableTCMU
+        - description: Force TCMU can be set to true to ensure that TCMU is enabled
+            or cause StorageOS to abort startup.  At startup, StorageOS will automatically
+            fallback to non-TCMU mode if another TCMU-based storage system is running
+            on the node.  Since non-TCMU has performance drawbacks, this may not always
+            be desired.
+          displayName: Force TCMU
+          path: forceTCMU
+        - description: Disable StorageOS scheduler deployment. StorageOS scheduler helps
+            improve the scheduling decision of a pod, considering the location of volumes
+            and their replicas.
+          displayName: Disable Scheduler
+          path: disableScheduler
+        - description: When enabled, the Operator will not perform any actions on the
+            cluster.
+          displayName: Pause Operator
+          path: pause
+        - description: Enables debug logging when set to true.
+          displayName: Enable Debug
+          path: debug
+        statusDescriptors:
+        - description: Set of nodes that are part of the StorageOS Cluster.
+          displayName: Nodes
+          path: nodes
+        - description: The status of each of the members of StorageOS Cluster.
+          displayName: Member Status
+          path: members
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:podStatuses
+        - description: The current status of the StorageOS Cluster.
+          displayName: Status
+          path: phase
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.phase
+        - description: Ready Nodes
+          displayName: Ready
+          path: ready
+        - description: Health status of StorageOS nodes.
+          displayName: Node Health Status
+          path: nodeHealthStatus
         version: v1
-      - kind: DaemonSet
-        name: ''
-        version: apps/v1
-      - kind: Service
-        name: ''
+      - description: StorageOSUpgrade is the Schema for the storageosupgrades API
+        kind: StorageOSUpgrade
+        name: storageosupgrades.storageos.com
         version: v1
-      - kind: Ingress
-        name: ''
-        version: extensions/v1beta1
-      - kind: Deployment
-        name: ''
-        version: apps/v1
-      - kind: StatefulSet
-        name: ''
-        version: apps/v1
-      - kind: StorageClass
-        name: ''
-        version: storage.k8s.io/v1
-      - kind: StorageOSCluster
-        name: ''
-        version: v1
-      - kind: Job
-        name: ''
-        version: v1
-      - kind: StorageOSUpgrade
-        name: ''
-        version: v1
-      - kind: NFSServer
-        name: ''
-        version: v1
-      - kind: Node
-        name: ''
-        version: v1
-      - kind: StatefulSet
-        name: ''
-        version: v1
-      - kind: DaemonSet
-        name: ''
-        version: v1
-      specDescriptors:
-      - description: Defines the various container images used in the cluster.
-        displayName: Images
-        path: images
-      - description: The namespace to install the StorageOS cluster into. `kube-system`
-          is recommended so that StorageOS does not get evicted if a node becomes
-          over-allocated.
-        displayName: Namespace
-        path: namespace
-      - description: The name of the secret object that stores the api credentials.
-        displayName: Cluster Secret
-        path: secretRefName
-      - description: The name of the namespace where the secret object that stores
-          the api credentials exists.
-        displayName: Cluster Secret Namespace
-        path: secretRefNamespace
-      - description: The join token is used for cluster discovery.  When used with
-          the Operator, the token will be a comma-separated list of all cluster member
-          IP addresses.  The node that owns the first IP address listed will be responsible
-          for bootsrapping the cluster.
-        displayName: Cluster members
-        path: join
-      - description: KV store configuration to use. Defaults to embedded. `etcd` is
-          recommended for production deployments with the address set to an external
-          etcd instance.
-        displayName: KV Store
-        path: kvBackend
-      - description: Describes the Container Storage Interface (CSI) configuration.
-        displayName: Enable CSI
-        path: csi
-      - description: The cluster Service configuration.
-        displayName: Service configuration
-        path: service
-      - description: The shared directory where storage devices should be created.  This
-          directory must be available to both the StorageOS Node container and the
-          kubelet, and must have mount propagation enabled. When kubelet is running
-          in a container, `/var/lib/kubelet/plugins/kubernetes.io~storageos` should
-          normally be set, otherwise leave empty.
-        displayName: Device directory
-        path: sharedDir
-      - description: Describes the ingress configuration to be configured for the
-          cluster.
-        displayName: Ingress configuration
-        path: ingress
-      - description: The name of the secret object that contains the etcd TLS certificates.
-        displayName: etcd TLS Secret Name
-        path: tlsEtcdSecretRefName
-      - description: The namespace of the secret object that contains the etcd TLS
-          certificates.
-        displayName: etcd TLS Secret Namespace
-        path: tlsEtcdSecretRefNamespace
-      - description: Node selector terms can be set to control the placement of StorageOS
-          pods using node affiinity.
-        displayName: Node Selectors
-        path: nodeSelectorTerms
-      - description: Tolerations can be set to control the placement of StorageOS
-          pods.
-        displayName: Tolerations
-        path: tolerations
-      - description: Name of the Kubernetes distribution in use, e.g. `openshift`.  This
-          will be included in the product telemetry (if enabled), to help focus development
-          efforts.
-        displayName: Kubernetes Distribution Name
-        path: k8sDistro
-      - description: To disable anonymous usage reporting across the cluster, set
-          to true. Defaults to false. To help improve the product, data such as API
-          usage and StorageOS configuration information is collected.
-        displayName: Disable Telemetry
-        path: disableTelemetry
-      - description: When Pod Fencing is disabled, StorageOS will not perform any
-          interaction with Kubernetes when it detects that a node has gone offline.
-          Additionally, the Kubernetes permissions required for Fencing will not be
-          added to the StorageOS role.
-        displayName: Disable Fencing
-        path: disableFencing
-      - description: Disable TCMU can be set to true to disable the TCMU storage driver.  This
-          is required when there are multiple storage systems running on the same
-          node and you wish to avoid conflicts.  Only one TCMU-based storage system
-          can run on a node at a time.  Disabling TCMU will degrade performance.
-        displayName: Disable TCMU
-        path: disableTCMU
-      - description: Force TCMU can be set to true to ensure that TCMU is enabled
-          or cause StorageOS to abort startup.  At startup, StorageOS will automatically
-          fallback to non-TCMU mode if another TCMU-based storage system is running
-          on the node.  Since non-TCMU has performance drawbacks, this may not always
-          be desired.
-        displayName: Force TCMU
-        path: forceTCMU
-      - description: Disable StorageOS scheduler deployment. StorageOS scheduler helps
-          improve the scheduling decision of a pod, considering the location of volumes
-          and their replicas.
-        displayName: Disable Scheduler
-        path: disableScheduler
-      - description: When enabled, the Operator will not perform any actions on the
-          cluster.
-        displayName: Pause Operator
-        path: pause
-      - description: Enables debug logging when set to true.
-        displayName: Enable Debug
-        path: debug
-      statusDescriptors:
-      - description: Set of nodes that are part of the StorageOS Cluster.
-        displayName: Nodes
-        path: nodes
-      - description: The status of each of the members of StorageOS Cluster.
-        displayName: Member Status
-        path: members
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:podStatuses
-      - description: The current status of the StorageOS Cluster.
-        displayName: Status
-        path: phase
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes.phase
-      - description: Ready Nodes
-        displayName: Ready
-        path: ready
-      - description: Health status of StorageOS nodes.
-        displayName: Node Health Status
-        path: nodeHealthStatus
-      version: v1
-    - description: StorageOSUpgrade is the Schema for the storageosupgrades API
-      kind: StorageOSUpgrade
-      name: storageosupgrades.storageos.com
-      version: v1
   description: |
     StorageOS is a cloud native, software-defined storage platform that
     transforms commodity server or cloud based disk capacity into
@@ -313,253 +313,253 @@ spec:
     information, visit [www.storageos.com](www.storageos.com).
   displayName: StorageOS
   icon:
-  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxOS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9Ii05MCAyODQuNyA0MzAgNDMwIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IC05MCAyODQuNyA0MzAgNDMwIiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxnPg0KCTxwYXRoIGZpbGw9IiM0RjUyNjMiIGQ9Ik0yNzguNSw0MjAuOWgtNzQuMWwtNS42LTkuN2wxMy42LTIzLjZsLTE4LjEtMzEuM0gxODBsMjcuNS00Ny43YzMtNS4xLDEuMi0xMS43LTMuOS0xNC42DQoJCWMtNS4xLTMtMTEuNy0xLjItMTQuNiwzLjlsLTM0LDU4LjhIOTMuMmwtMzQtNTguOGMtMi45LTUuMS05LjUtNi45LTE0LjYtMy45cy02LjksOS41LTMuOSwxNC42bDI3LjUsNDcuN0g1My45bC0xOC4xLDMxLjMNCgkJbDEzLjYsMjMuNmwtNS42LDkuOGgtNzQuMmwtNDMuMyw3NC45bDQzLjMsNzQuOWg3NC4xbDM0LDU4LjlMNzksNjI5bC0xLjIsMC44bDQ2LjQsNzcuMmw0Ni4yLTc3LjNsMCwwbDM0LTU4LjloNzQuMWw0My4zLTc0LjkNCgkJTDI3OC41LDQyMC45eiBNNTUuNSw0MDAuNWwtNy40LTEyLjhMNjAsMzY3aDE0LjNsMC4zLDAuNUw1NS41LDQwMC41eiBNMTczLjQsMzY3LjVsMC4zLTAuNUgxODhsMTEuOSwyMC42bC03LjQsMTIuOUwxNzMuNCwzNjcuNXoiDQoJCS8+DQoJPHBvbHlnb24gZmlsbD0iI0ZGRkZGRiIgcG9pbnRzPSI0My43LDQ0Mi4zIDQyLjgsNDQyLjMgLTE4LjEsNDQyLjMgLTQ4LjksNDk1LjggLTE4LjEsNTQ5LjMgNDMsNTQ5LjMgNDMuNyw1NDkuMyA3NC42LDQ5NS45IAkiLz4NCgk8cG9seWdvbiBmaWxsPSIjRkZGRkZGIiBwb2ludHM9IjI2Ni4xLDQ0Mi4zIDIwNC4zLDQ0Mi4zIDIwNC4zLDQ0Mi41IDE3My40LDQ5NS44IDIwNC4zLDU0OS4zIDIwNC40LDU0OS4zIDI2Ni4xLDU0OS4zIDI5Nyw0OTUuOCAJDQoJCSIvPg0KCTxwb2x5Z29uIGZpbGw9IiM2MUMyMDIiIHBvaW50cz0iMTU0LjksMzc4LjIgOTMuMSwzNzguMiA5My4xLDM3OC4zIDYyLjMsNDMxLjcgOTMuMSw0ODUuMiA5My4yLDQ4NS4yIDE1NC45LDQ4NS4yIDE4NS44LDQzMS43IAkiLz4NCgk8cG9seWdvbiBmaWxsPSIjNjFDMjAyIiBwb2ludHM9IjE1Mi4xLDYxOC40IDE1Mi4xLDYxOC40IDEyNCw2NjUuMiA5Ni4yLDYxOC45IDk2LjIsNjE4LjkgNjIuMiw1NjAuMSA4OC4zLDUxNC45IDkzLjEsNTA2LjYgDQoJCTE1NC45LDUwNi42IDE4NS44LDU2MC4xIAkiLz4NCjwvZz4NCjxyZWN0IHg9Ii0xMDUiIHk9IjI3MC43IiBmaWxsPSJub25lIiB3aWR0aD0iNDU4IiBoZWlnaHQ9IjQ1OCIvPg0KPC9zdmc+DQo=
-    mediatype: image/svg+xml
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxOS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9Ii05MCAyODQuNyA0MzAgNDMwIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IC05MCAyODQuNyA0MzAgNDMwIiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxnPg0KCTxwYXRoIGZpbGw9IiM0RjUyNjMiIGQ9Ik0yNzguNSw0MjAuOWgtNzQuMWwtNS42LTkuN2wxMy42LTIzLjZsLTE4LjEtMzEuM0gxODBsMjcuNS00Ny43YzMtNS4xLDEuMi0xMS43LTMuOS0xNC42DQoJCWMtNS4xLTMtMTEuNy0xLjItMTQuNiwzLjlsLTM0LDU4LjhIOTMuMmwtMzQtNTguOGMtMi45LTUuMS05LjUtNi45LTE0LjYtMy45cy02LjksOS41LTMuOSwxNC42bDI3LjUsNDcuN0g1My45bC0xOC4xLDMxLjMNCgkJbDEzLjYsMjMuNmwtNS42LDkuOGgtNzQuMmwtNDMuMyw3NC45bDQzLjMsNzQuOWg3NC4xbDM0LDU4LjlMNzksNjI5bC0xLjIsMC44bDQ2LjQsNzcuMmw0Ni4yLTc3LjNsMCwwbDM0LTU4LjloNzQuMWw0My4zLTc0LjkNCgkJTDI3OC41LDQyMC45eiBNNTUuNSw0MDAuNWwtNy40LTEyLjhMNjAsMzY3aDE0LjNsMC4zLDAuNUw1NS41LDQwMC41eiBNMTczLjQsMzY3LjVsMC4zLTAuNUgxODhsMTEuOSwyMC42bC03LjQsMTIuOUwxNzMuNCwzNjcuNXoiDQoJCS8+DQoJPHBvbHlnb24gZmlsbD0iI0ZGRkZGRiIgcG9pbnRzPSI0My43LDQ0Mi4zIDQyLjgsNDQyLjMgLTE4LjEsNDQyLjMgLTQ4LjksNDk1LjggLTE4LjEsNTQ5LjMgNDMsNTQ5LjMgNDMuNyw1NDkuMyA3NC42LDQ5NS45IAkiLz4NCgk8cG9seWdvbiBmaWxsPSIjRkZGRkZGIiBwb2ludHM9IjI2Ni4xLDQ0Mi4zIDIwNC4zLDQ0Mi4zIDIwNC4zLDQ0Mi41IDE3My40LDQ5NS44IDIwNC4zLDU0OS4zIDIwNC40LDU0OS4zIDI2Ni4xLDU0OS4zIDI5Nyw0OTUuOCAJDQoJCSIvPg0KCTxwb2x5Z29uIGZpbGw9IiM2MUMyMDIiIHBvaW50cz0iMTU0LjksMzc4LjIgOTMuMSwzNzguMiA5My4xLDM3OC4zIDYyLjMsNDMxLjcgOTMuMSw0ODUuMiA5My4yLDQ4NS4yIDE1NC45LDQ4NS4yIDE4NS44LDQzMS43IAkiLz4NCgk8cG9seWdvbiBmaWxsPSIjNjFDMjAyIiBwb2ludHM9IjE1Mi4xLDYxOC40IDE1Mi4xLDYxOC40IDEyNCw2NjUuMiA5Ni4yLDYxOC45IDk2LjIsNjE4LjkgNjIuMiw1NjAuMSA4OC4zLDUxNC45IDkzLjEsNTA2LjYgDQoJCTE1NC45LDUwNi42IDE4NS44LDU2MC4xIAkiLz4NCjwvZz4NCjxyZWN0IHg9Ii0xMDUiIHk9IjI3MC43IiBmaWxsPSJub25lIiB3aWR0aD0iNDU4IiBoZWlnaHQ9IjQ1OCIvPg0KPC9zdmc+DQo=
+      mediatype: image/svg+xml
   install:
     spec:
       clusterPermissions:
-      - rules:
-        - apiGroups:
-          - storageos.com
-          resources:
-          - storageosclusters
-          - storageosclusters/status
-          - storageosupgrades
-          - storageosupgrades/status
-          - jobs
-          - jobs/status
-          - nfsservers
-          - nfsservers/status
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps
-          resources:
-          - statefulsets
-          - daemonsets
-          - deployments
-          - replicasets
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - nodes
-          verbs:
-          - list
-          - watch
-          - get
-          - update
-          - create
-          - patch
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - list
-          - watch
-          - get
-          - update
-          - patch
-          - delete
-          - create
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          - namespaces
-          - serviceaccounts
-          - secrets
-          - services
-          - services/finalizers
-          - persistentvolumeclaims
-          - persistentvolumeclaims/status
-          - persistentvolumes
-          - configmaps
-          - configmaps/status
-          - replicationcontrollers
-          - pods/binding
-          - pods/status
-          - endpoints
-          verbs:
-          - create
-          - patch
-          - get
-          - list
-          - delete
-          - watch
-          - update
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - roles
-          - rolebindings
-          - clusterroles
-          - clusterrolebindings
-          verbs:
-          - create
-          - delete
-        - apiGroups:
-          - storage.k8s.io
-          resources:
-          - storageclasses
-          - volumeattachments
-          - csinodeinfos
-          - csinodes
-          - csidrivers
-          verbs:
-          - create
-          - delete
-          - watch
-          - list
-          - get
-          - update
-          - patch
-        - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - create
-          - delete
-        - apiGroups:
-          - csi.storage.k8s.io
-          resources:
-          - csidrivers
-          verbs:
-          - create
-          - delete
-        - apiGroups:
-          - policy
-          resources:
-          - poddisruptionbudgets
-          verbs:
-          - list
-          - watch
-        - apiGroups:
-          - security.openshift.io
-          resourceNames:
-          - privileged
-          resources:
-          - securitycontextconstraints
-          verbs:
-          - create
-          - delete
-          - update
-          - get
-          - use
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - mutatingwebhookconfigurations
-          verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps
-          resourceNames:
-          - storageos-cluster-operator
-          resources:
-          - deployments/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - events.k8s.io
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - get
-          - create
-          - update
-        serviceAccountName: storageos-operator
+        - rules:
+            - apiGroups:
+                - storageos.com
+              resources:
+                - storageosclusters
+                - storageosclusters/status
+                - storageosupgrades
+                - storageosupgrades/status
+                - jobs
+                - jobs/status
+                - nfsservers
+                - nfsservers/status
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resources:
+                - statefulsets
+                - daemonsets
+                - deployments
+                - replicasets
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - list
+                - watch
+                - get
+                - update
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - list
+                - watch
+                - get
+                - update
+                - patch
+                - delete
+                - create
+            - apiGroups:
+                - ""
+              resources:
+                - events
+                - namespaces
+                - serviceaccounts
+                - secrets
+                - services
+                - services/finalizers
+                - persistentvolumeclaims
+                - persistentvolumeclaims/status
+                - persistentvolumes
+                - configmaps
+                - configmaps/status
+                - replicationcontrollers
+                - pods/binding
+                - pods/status
+                - endpoints
+              verbs:
+                - create
+                - patch
+                - get
+                - list
+                - delete
+                - watch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+                - rolebindings
+                - clusterroles
+                - clusterrolebindings
+              verbs:
+                - create
+                - delete
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - storageclasses
+                - volumeattachments
+                - csinodeinfos
+                - csinodes
+                - csidrivers
+              verbs:
+                - create
+                - delete
+                - watch
+                - list
+                - get
+                - update
+                - patch
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - create
+                - delete
+            - apiGroups:
+                - csi.storage.k8s.io
+              resources:
+                - csidrivers
+              verbs:
+                - create
+                - delete
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - privileged
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - create
+                - delete
+                - update
+                - get
+                - use
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resourceNames:
+                - storageos-cluster-operator
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - events.k8s.io
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - create
+                - update
+          serviceAccountName: storageoscluster-operator-sa
       deployments:
-      - name: storageos-cluster-operator
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              name: storageos-cluster-operator
-          strategy: {}
-          template:
-            metadata:
-              labels:
+        - name: storageos-cluster-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 name: storageos-cluster-operator
-            spec:
-              containers:
-              - command:
-                - cluster-operator
-                env:
-                - name: WATCH_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: POD_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: OPERATOR_NAME
-                  value: storageos-cluster-operator
-                - name: DISABLE_SCHEDULER_WEBHOOK
-                  value: "false"
-                image: storageos/cluster-operator:test
-                imagePullPolicy: IfNotPresent
-                name: storageos-cluster-operator
-                ports:
-                - containerPort: 8383
-                  name: metrics
-                - containerPort: 8686
-                  name: operatormetrics
-                - containerPort: 5720
-                  name: podschedwebhook
-                resources: {}
-              serviceAccountName: storageoscluster-operator-sa
-              tolerations:
-              - effect: NoSchedule
-                key: key
-                operator: Equal
-                value: value
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: storageos-cluster-operator
+              spec:
+                containers:
+                  - command:
+                      - cluster-operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: OPERATOR_NAME
+                        value: storageos-cluster-operator
+                      - name: DISABLE_SCHEDULER_WEBHOOK
+                        value: "false"
+                    image: storageos/cluster-operator:test
+                    imagePullPolicy: IfNotPresent
+                    name: storageos-cluster-operator
+                    ports:
+                      - containerPort: 8383
+                        name: metrics
+                      - containerPort: 8686
+                        name: operatormetrics
+                      - containerPort: 5720
+                        name: podschedwebhook
+                    resources: {}
+                serviceAccountName: storageoscluster-operator-sa
+                tolerations:
+                  - effect: NoSchedule
+                    key: key
+                    operator: Equal
+                    value: value
     strategy: deployment
   installModes:
-  - supported: true
-    type: OwnNamespace
-  - supported: true
-    type: SingleNamespace
-  - supported: false
-    type: MultiNamespace
-  - supported: true
-    type: AllNamespaces
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
   keywords:
-  - storageos
-  - storage
-  - persistent storage
-  - open source
+    - storageos
+    - storage
+    - persistent storage
+    - open source
   labels:
     operated-by: storageosoperator
   links:
-  - name: Documentation
-    url: https://docs.storageos.com/
-  - name: StorageOS Operator Source Code
-    url: https://github.com/storageos/cluster-operator
+    - name: Documentation
+      url: https://docs.storageos.com/
+    - name: StorageOS Operator Source Code
+      url: https://github.com/storageos/cluster-operator
   maintainers:
-  - email: support@storageos.com
-    name: StorageOS, Inc
+    - email: support@storageos.com
+      name: StorageOS, Inc
   maturity: stable
   minKubeVersion: 1.13.0
   provider:


### PR DESCRIPTION
The bundle generated by operator-sdk v0.17.0 contains incorrect cluster
permission service account name. This issue is fixed in v0.19.0.
Patch using yq with the correct value.

Refer: https://github.com/operator-framework/operator-sdk/pull/3610

Processing the CSV file via yq changes the indentations, resulting in
unrelated changes to the file.