### PR TITLE
Avoid travis toomanyrequests docker hub error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,16 +51,18 @@ jobs:
       env:
         - "INSTALL_METHOD=none"
       name: KinD (k8s-1.19)
+      before_script:
+        - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
       script: ./test/e2e.sh $INSTALL_METHOD
     - stage: deploy
       go: "1.14"
       sudo: required
       name: Publish Container Image
+      before_script:
+        - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
       script:
         - make operator-image
         - OPERATOR_IMAGE=storageos/cluster-operator:$TRAVIS_TAG make install-manifest
-      before_deploy:
-        - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
       deploy:
         - provider: script
           script: bash scripts/deploy.sh tagged

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -82,7 +82,7 @@ func main() {
 	// TODO: Expose metrics port after SDK uses controller-runtime's dynamic client
 	// sdk.ExposeMetricsPort()
 
-	// Get a config to talk to the apiserver
+	// Get a config to talk to the apiserver.
 	cfg, err := config.GetConfig()
 	if err != nil {
 		fatal(err)
@@ -107,7 +107,7 @@ func main() {
 
 	log.Info("Registering Components")
 
-	// Setup Scheme for all resources
+	// Setup Scheme for all resources.
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		fatal(err)
 	}


### PR DESCRIPTION
Travis jobs should logon to the Docker Hub prior to running commands that pull images.

This avoids recent CI errors:
```
1.15.2: Pulling from library/golang
toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
Makefile:159: recipe for target 'operator-image' failed
make: *** [operator-image] Error 1
The command "make operator-image" exited with 2.
```