### PR TITLE
Remove pool from StorageClass params

### DIFF
--- a/pkg/storageos/storageclass.go
+++ b/pkg/storageos/storageclass.go
@@ -1,9 +1,7 @@
 package storageos
 
 func (s *Deployment) createStorageClass() error {
-	parameters := map[string]string{
-		"pool": "default",
-	}
+	parameters := map[string]string{}
 
 	if s.stos.Spec.CSI.Enable {
 		// Add CSI creds secrets in parameters.


### PR DESCRIPTION
In StorageOS v1, CSI requests should include the `pool` param to select the storage pool.  In v2 the `pool` parameter is not used but is still set on the volume as a label.  Once we start syncing labels it will immediately get removed.  Avoid this update by not setting it in the first place.