### PR TITLE
Use CSI attacher v3 for k8s 1.17+

### DIFF
--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -394,6 +394,8 @@ spec:
                   value: ""
                 - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2
                   value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V3
+                  value: ""
                 - name: RELATED_IMAGE_CSIV1_EXTERNAL_RESIZER
                   value: ""
                 - name: RELATED_IMAGE_CSIV1_LIVENESS_PROBE

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -350,6 +350,8 @@ spec:
                   value: ""
                 - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2
                   value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V3
+                  value: ""
                 - name: RELATED_IMAGE_CSIV1_EXTERNAL_RESIZER
                   value: ""
                 - name: RELATED_IMAGE_CSIV1_LIVENESS_PROBE

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -97,6 +97,7 @@ rules:
   resources:
   - storageclasses
   - volumeattachments
+  - volumeattachments/status
   - csinodeinfos
   - csinodes
   - csidrivers

--- a/deploy/storageos-operators.configmap.yaml
+++ b/deploy/storageos-operators.configmap.yaml
@@ -1180,6 +1180,7 @@ data:
                 resources:
                 - storageclasses
                 - volumeattachments
+                - volumeattachments/status
                 - csinodeinfos
                 - csinodes
                 - csidrivers
@@ -1292,6 +1293,8 @@ data:
                       - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER
                         value: ""
                       - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2
+                        value: ""
+                      - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V3
                         value: ""
                       - name: RELATED_IMAGE_CSIV1_EXTERNAL_RESIZER
                         value: ""

--- a/internal/pkg/image/image.go
+++ b/internal/pkg/image/image.go
@@ -11,7 +11,8 @@ const (
 	CSIv1ExternalProvisionerContainerImageV1  = "storageos/csi-provisioner:v1.4.0"
 	CSIv1ExternalProvisionerContainerImageV2  = "storageos/csi-provisioner:v1.6.0-patched"
 	CSIv1ExternalAttacherContainerImage       = "quay.io/k8scsi/csi-attacher:v1.2.1"
-	CSIv1ExternalAttacherv2ContainerImage     = "quay.io/k8scsi/csi-attacher:v2.2.0"
+	CSIv1ExternalAttacherContainerImageV2     = "quay.io/k8scsi/csi-attacher:v2.2.0"
+	CSIv1ExternalAttacherContainerImageV3     = "quay.io/k8scsi/csi-attacher:v3.1.0"
 	CSIv1ExternalResizerContainerImage        = "quay.io/k8scsi/csi-resizer:v0.5.0"
 	CSIv1LivenessProbeContainerImage          = "quay.io/k8scsi/livenessprobe:v1.1.0"
 	CSIv0DriverRegistrarContainerImage        = "quay.io/k8scsi/driver-registrar:v0.4.2"
@@ -35,6 +36,7 @@ const (
 	CSIv1ExternalProvisionerImageEnvVar      = "RELATED_IMAGE_CSIV1_EXTERNAL_PROVISIONER"
 	CSIv1ExternalAttacherImageEnvVar         = "RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER"
 	CSIv1ExternalAttacherv2ImageEnvVar       = "RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2"
+	CSIv1ExternalAttacherv3ImageEnvVar       = "RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V3"
 	CSIv1ExternalResizerContainerImageEnvVar = "RELATED_IMAGE_CSIV1_EXTERNAL_RESIZER"
 	CSIv1LivenessProbeImageEnvVar            = "RELATED_IMAGE_CSIV1_LIVENESS_PROBE"
 

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -325,13 +325,18 @@ func (s StorageOSClusterSpec) GetCSIExternalProvisionerImage(csiv1 bool) string 
 // GetCSIExternalAttacherImage returns CSI external attacher container image.
 // CSI v0, CSI v1 on k8s 1.13 and CSI v1 on k8s 1.14+ require different versions
 // of external attacher.
-func (s StorageOSClusterSpec) GetCSIExternalAttacherImage(csiv1 bool, attacherv2Supported bool) string {
+// k8s 1.17+ should use the v3 attacher.  We expect to remove support for k8s
+// 1.14 and earlier soon.
+func (s StorageOSClusterSpec) GetCSIExternalAttacherImage(csiv1 bool, attacherv2Supported bool, attacherV3Supported bool) string {
 	if s.Images.CSIExternalAttacherContainer != "" {
 		return s.Images.CSIExternalAttacherContainer
 	}
 	if csiv1 {
+		if attacherV3Supported {
+			return image.GetDefaultImage(image.CSIv1ExternalAttacherv3ImageEnvVar, image.CSIv1ExternalAttacherContainerImageV3)
+		}
 		if attacherv2Supported {
-			return image.GetDefaultImage(image.CSIv1ExternalAttacherv2ImageEnvVar, image.CSIv1ExternalAttacherv2ContainerImage)
+			return image.GetDefaultImage(image.CSIv1ExternalAttacherv2ImageEnvVar, image.CSIv1ExternalAttacherContainerImageV2)
 		}
 		return image.GetDefaultImage(image.CSIv1ExternalAttacherImageEnvVar, image.CSIv1ExternalAttacherContainerImage)
 	}

--- a/pkg/controller/storageoscluster/storageoscluster_controller.go
+++ b/pkg/controller/storageoscluster/storageoscluster_controller.go
@@ -341,7 +341,7 @@ func (r *ReconcileStorageOSCluster) updateSpec(m *storageosv1.StorageOSCluster) 
 
 	properties[&m.Spec.Images.CSIExternalProvisionerContainer] = m.Spec.GetCSIExternalProvisionerImage(storageos.CSIV1Supported(r.k8sVersion))
 
-	properties[&m.Spec.Images.CSIExternalAttacherContainer] = m.Spec.GetCSIExternalAttacherImage(storageos.CSIV1Supported(r.k8sVersion), storageos.CSIExternalAttacherV2Supported(r.k8sVersion))
+	properties[&m.Spec.Images.CSIExternalAttacherContainer] = m.Spec.GetCSIExternalAttacherImage(storageos.CSIV1Supported(r.k8sVersion), storageos.CSIExternalAttacherV2Supported(r.k8sVersion), storageos.CSIExternalAttacherV3Supported(r.k8sVersion))
 
 	// Add external resizer image if storageos v2 and supported k8s
 	// version.

--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -136,7 +136,7 @@ func (s Deployment) csiHelperContainers() ([]corev1.Container, error) {
 			},
 		},
 		{
-			Image:           s.stos.Spec.GetCSIExternalAttacherImage(CSIV1Supported(s.k8sVersion), CSIExternalAttacherV2Supported(s.k8sVersion)),
+			Image:           s.stos.Spec.GetCSIExternalAttacherImage(CSIV1Supported(s.k8sVersion), CSIExternalAttacherV2Supported(s.k8sVersion), CSIExternalAttacherV3Supported(s.k8sVersion)),
 			Name:            "csi-external-attacher",
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Args: []string{

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -315,6 +315,11 @@ func CSIExternalAttacherV2Supported(version string) bool {
 	return versionSupported(version, "1.14.0")
 }
 
+// CSIExternalAttacherV3Supported returns true for k8s 1.17+.
+func CSIExternalAttacherV3Supported(version string) bool {
+	return versionSupported(version, "1.17.0")
+}
+
 // CSIExternalResizerSupported returns true for k8s 1.16+.
 func CSIExternalResizerSupported(version string) bool {
 	return versionSupported(version, "1.16.0")

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -1866,6 +1866,7 @@ func TestContainerImageSelection(t *testing.T) {
 	getImage := func(name string, spec api.StorageOSClusterSpec, k8sVersion string) string {
 		csiV1Supported := CSIV1Supported(k8sVersion)
 		attacherV2Supported := CSIExternalAttacherV2Supported(k8sVersion)
+		attacherV3Supported := CSIExternalAttacherV3Supported(k8sVersion)
 
 		switch name {
 		case storageOSNodeImage:
@@ -1879,7 +1880,7 @@ func TestContainerImageSelection(t *testing.T) {
 		case csiExternalProvisionerImage:
 			return spec.GetCSIExternalProvisionerImage(csiV1Supported)
 		case csiExternalAttacherImage:
-			return spec.GetCSIExternalAttacherImage(csiV1Supported, attacherV2Supported)
+			return spec.GetCSIExternalAttacherImage(csiV1Supported, attacherV2Supported, attacherV3Supported)
 		case csiLivenessProbeImage:
 			return spec.GetCSILivenessProbeImage()
 		case kubeSchedulerImage:
@@ -1966,21 +1967,6 @@ func TestContainerImageSelection(t *testing.T) {
 			},
 		},
 		{
-			name:       "no env vars, no overrides, fallback images - k8s 1.13, node v2",
-			k8sVersion: "1.13.0",
-			wantImages: map[string]string{
-				storageOSNodeImage:             image.DefaultNodeContainerImage,
-				storageOSInitImage:             image.DefaultInitContainerImage,
-				csiClusterDriverRegistrarImage: image.CSIv1ClusterDriverRegistrarContainerImage,
-				csiNodeDriverRegistrarImage:    image.CSIv1NodeDriverRegistrarContainerImage,
-				csiExternalProvisionerImage:    image.CSIv1ExternalProvisionerContainerImageV2,
-				csiExternalAttacherImage:       image.CSIv1ExternalAttacherContainerImage,
-				csiLivenessProbeImage:          image.CSIv1LivenessProbeContainerImage,
-				kubeSchedulerImage:             fmt.Sprintf("%s:%s", image.DefaultKubeSchedulerContainerRegistry, "v1.13.0"),
-				nfsImage:                       image.DefaultNFSContainerImage,
-			},
-		},
-		{
 			name: "env var images - k8s 1.12 - CSIv0",
 			envVars: map[string]string{
 				image.CSIv0DriverRegistrarImageEnvVar:     "foo/dr:1",
@@ -2006,6 +1992,66 @@ func TestContainerImageSelection(t *testing.T) {
 			// Use attacher v2 image.
 			wantImages: map[string]string{
 				csiExternalAttacherImage: "foo/ea:2",
+			},
+		},
+		{
+			name:       "defaults - k8s 1.13",
+			k8sVersion: "1.13.0",
+			wantImages: map[string]string{
+				storageOSNodeImage:             image.DefaultNodeContainerImage,
+				storageOSInitImage:             image.DefaultInitContainerImage,
+				csiClusterDriverRegistrarImage: image.CSIv1ClusterDriverRegistrarContainerImage,
+				csiNodeDriverRegistrarImage:    image.CSIv1NodeDriverRegistrarContainerImage,
+				csiExternalProvisionerImage:    image.CSIv1ExternalProvisionerContainerImageV2,
+				csiExternalAttacherImage:       image.CSIv1ExternalAttacherContainerImage,
+				csiLivenessProbeImage:          image.CSIv1LivenessProbeContainerImage,
+				kubeSchedulerImage:             fmt.Sprintf("%s:%s", image.DefaultKubeSchedulerContainerRegistry, "v1.13.0"),
+				nfsImage:                       image.DefaultNFSContainerImage,
+			},
+		},
+		{
+			name:       "defaults - k8s 1.14",
+			k8sVersion: "1.14.0",
+			wantImages: map[string]string{
+				storageOSNodeImage:             image.DefaultNodeContainerImage,
+				storageOSInitImage:             image.DefaultInitContainerImage,
+				csiClusterDriverRegistrarImage: image.CSIv1ClusterDriverRegistrarContainerImage,
+				csiNodeDriverRegistrarImage:    image.CSIv1NodeDriverRegistrarContainerImage,
+				csiExternalProvisionerImage:    image.CSIv1ExternalProvisionerContainerImageV2,
+				csiExternalAttacherImage:       image.CSIv1ExternalAttacherContainerImageV2,
+				csiLivenessProbeImage:          image.CSIv1LivenessProbeContainerImage,
+				kubeSchedulerImage:             fmt.Sprintf("%s:%s", image.DefaultKubeSchedulerContainerRegistry, "v1.14.0"),
+				nfsImage:                       image.DefaultNFSContainerImage,
+			},
+		},
+		{
+			name:       "defaults - k8s 1.16",
+			k8sVersion: "1.16.0",
+			wantImages: map[string]string{
+				storageOSNodeImage:             image.DefaultNodeContainerImage,
+				storageOSInitImage:             image.DefaultInitContainerImage,
+				csiClusterDriverRegistrarImage: image.CSIv1ClusterDriverRegistrarContainerImage,
+				csiNodeDriverRegistrarImage:    image.CSIv1NodeDriverRegistrarContainerImage,
+				csiExternalProvisionerImage:    image.CSIv1ExternalProvisionerContainerImageV2,
+				csiExternalAttacherImage:       image.CSIv1ExternalAttacherContainerImageV2,
+				csiLivenessProbeImage:          image.CSIv1LivenessProbeContainerImage,
+				kubeSchedulerImage:             fmt.Sprintf("%s:%s", image.DefaultKubeSchedulerContainerRegistry, "v1.16.0"),
+				nfsImage:                       image.DefaultNFSContainerImage,
+			},
+		},
+		{
+			name:       "defaults - k8s 1.17",
+			k8sVersion: "1.17.0",
+			wantImages: map[string]string{
+				storageOSNodeImage:             image.DefaultNodeContainerImage,
+				storageOSInitImage:             image.DefaultInitContainerImage,
+				csiClusterDriverRegistrarImage: image.CSIv1ClusterDriverRegistrarContainerImage,
+				csiNodeDriverRegistrarImage:    image.CSIv1NodeDriverRegistrarContainerImage,
+				csiExternalProvisionerImage:    image.CSIv1ExternalProvisionerContainerImageV2,
+				csiExternalAttacherImage:       image.CSIv1ExternalAttacherContainerImageV3,
+				csiLivenessProbeImage:          image.CSIv1LivenessProbeContainerImage,
+				kubeSchedulerImage:             fmt.Sprintf("%s:%s", image.DefaultKubeSchedulerContainerRegistry, "v1.17.0"),
+				nfsImage:                       image.DefaultNFSContainerImage,
 			},
 		},
 	}

--- a/pkg/storageos/rbac.go
+++ b/pkg/storageos/rbac.go
@@ -271,6 +271,11 @@ func (s *Deployment) createClusterRoleForAttacher() error {
 		},
 		{
 			APIGroups: []string{"storage.k8s.io"},
+			Resources: []string{"volumeattachments/status"},
+			Verbs:     []string{"get", "patch", "update"},
+		},
+		{
+			APIGroups: []string{"storage.k8s.io"},
 			Resources: []string{"csinodeinfos", "csinodes"},
 			Verbs:     []string{"get", "list", "watch"},
 		},

--- a/scripts/release-helpers/release-gen.sh
+++ b/scripts/release-helpers/release-gen.sh
@@ -77,6 +77,7 @@ spec.install.spec.deployments[0].spec.template.spec.containers[0].env[8].value: 
 spec.install.spec.deployments[0].spec.template.spec.containers[0].env[9].value: ""
 spec.install.spec.deployments[0].spec.template.spec.containers[0].env[10].value: ""
 spec.install.spec.deployments[0].spec.template.spec.containers[0].env[11].value: ""
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[12].value: ""
 spec.replaces: storageosoperator.$PREV_VERSION
 EOF
 echo
@@ -170,6 +171,7 @@ spec.install.spec.deployments[0].spec.template.spec.containers[0].env[8].value: 
 spec.install.spec.deployments[0].spec.template.spec.containers[0].env[9].value: ""
 spec.install.spec.deployments[0].spec.template.spec.containers[0].env[10].value: ""
 spec.install.spec.deployments[0].spec.template.spec.containers[0].env[11].value: ""
+spec.install.spec.deployments[0].spec.template.spec.containers[0].env[12].value: ""
 spec.customresourcedefinitions.owned[2].specDescriptors[0].description: The StorageOS Node image to upgrade to. e.g. \`registry.connect.redhat.com/storageos/node:latest\`
 spec.replaces: storageosoperator.$PREV_VERSION
 EOF


### PR DESCRIPTION
This provides VolumeAttachment reconciliation via the ListVolumes() CSI call.  With reconciliation in place, StorageOS can tell the attacher that a volume is no longer attached and that it requires re-attaching before attempting a mount.

The v3 attacher requires k8s 1.17+ to run.  The reconcile feature was merged in v2, but the patch needed for it to work (https://github.com/kubernetes-csi/external-attacher/pull/244) was only merged in v3.  k8s 1.16 and earlier will use the v2 attacher which does not support reconciliation. 