### PR TITLE
Delete CSI expand secret when cluster is deleted

### DIFF
--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -1413,6 +1413,18 @@ func TestDelete(t *testing.T) {
 				}
 			}
 
+			// Check CSI secret deletion.
+			for _, secretName := range []string{csiProvisionerSecretName, csiControllerPublishSecretName, csiNodePublishSecretName, csiControllerExpandSecretName} {
+				nsNameSecret := types.NamespacedName{
+					Name:      secretName,
+					Namespace: defaultNS,
+				}
+				createdSecret := &corev1.Secret{}
+				if err := c.Get(context.Background(), nsNameSecret, createdSecret); err == nil {
+					t.Fatal("expected the CSI secret to be deleted, but it still exists")
+				}
+			}
+
 			// Check API manager deletion.
 			if err := c.Get(context.Background(), nsNameAPIManagerDeployment, createdAPIManagerDeployment); err == nil {
 				t.Fatal("expected the API manager deployment to be deleted, but it still exists")

--- a/pkg/storageos/secret.go
+++ b/pkg/storageos/secret.go
@@ -152,6 +152,10 @@ func (s *Deployment) deleteCSISecrets() error {
 		return err
 	}
 
+	if err := s.k8sResourceManager.Secret(csiControllerExpandSecretName, namespace, nil, corev1.SecretTypeOpaque, nil).Delete(); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When a StorageOSCluster CR is deleted, the CSI expand secret was leftover.