### PR TITLE
Use ubi-minimal base image directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_ENV = GOOS=linux CGO_ENABLED=0
 SDK_VERSION = v0.17.2
 MACHINE = $(shell uname -m)
 BUILD_IMAGE = golang:1.15.2
-BASE_IMAGE = storageos/base-image:0.2.3
+BASE_IMAGE = registry.access.redhat.com/ubi8/ubi-minimal
 BUILD_DIR = "build"
 OPERATOR_SDK = $(BUILD_DIR)/operator-sdk
 YQ = $(BUILD_DIR)/yq

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_IMAGE=golang:1.15.2
-ARG BASE_IMAGE=storageos/base-image:0.2.3
+ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal
 ARG OPERATOR_IMAGE=storageos/cluster-operator:test
 
 FROM ${BUILD_IMAGE} AS build
@@ -39,6 +39,8 @@ RUN chmod -R g+rwX /home/operator
 # Docker is required by the upgrader to pre-load images.  Only `docker pull` is
 # used.  `podman` would be preferred but it's not available in the package repo,
 # and there isn't a binary release that we can easily download into the image.
+RUN microdnf update && \
+    microdnf install gzip openssl tar wget
 RUN \
     wget --no-check-certificate -q https://download.docker.com/linux/static/stable/x86_64/docker-17.03.0-ce.tgz && \
     tar -xvzf docker-17.03.0-ce.tgz && \

--- a/build/rhel-build-service/Dockerfile
+++ b/build/rhel-build-service/Dockerfile
@@ -1,5 +1,5 @@
 # ARG BUILD_IMAGE=golang:1.14.2
-# ARG BASE_IMAGE=storageos/base-image:0.2.3
+# ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal
 # ARG OPERATOR_IMAGE=storageos/cluster-operator:test
 
 FROM golang:1.15.2 AS build
@@ -16,7 +16,7 @@ RUN make operator-sdk
 RUN make go-gen
 RUN make operator OPERATOR_IMAGE=registry.connect.redhat.com/storageos/cluster-operator:2.0.0
 
-FROM storageos/base-image:0.2.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 LABEL name="StorageOS Cluster Operator" \
     maintainer="support@storageos.com" \
     vendor="StorageOS" \
@@ -40,6 +40,8 @@ RUN chmod -R g+rwX /home/operator
 # Docker is required by the upgrader to pre-load images.  Only `docker pull` is
 # used.  `podman` would be preferred but it's not available in the package repo,
 # and there isn't a binary release that we can easily download into the image.
+RUN microdnf update && \
+    microdnf install gzip openssl tar wget
 RUN \
     wget --no-check-certificate -q https://download.docker.com/linux/static/stable/x86_64/docker-17.03.0-ce.tgz && \
     tar -xvzf docker-17.03.0-ce.tgz && \


### PR DESCRIPTION
This helps us keep the base image updated with the latest upstream ubi8 image when we release.