### PR TITLE
Toleration defaults for helper pods

### DIFF
--- a/internal/pkg/toleration/toleration.go
+++ b/internal/pkg/toleration/toleration.go
@@ -43,7 +43,7 @@ const (
 	TaintNodePIDPressure = "node.kubernetes.io/pid-pressure"
 )
 
-// GetDefaultNodeTolerations returns a collection of tolerations suiotable for
+// GetDefaultNodeTolerations returns a collection of tolerations suitable for
 // StorageOS node related resources.
 //
 // Node resources should avoid being evicted.

--- a/internal/pkg/toleration/toleration_test.go
+++ b/internal/pkg/toleration/toleration_test.go
@@ -106,26 +106,6 @@ func TestDeepEqual(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "different seconds",
-			a: []corev1.Toleration{
-				{
-					Key:               TaintNodeNotReady,
-					Operator:          corev1.TolerationOpExists,
-					Effect:            corev1.TaintEffectNoExecute,
-					TolerationSeconds: &secondsA,
-				},
-			},
-			b: []corev1.Toleration{
-				{
-					Key:               TaintNodeNotReady,
-					Operator:          corev1.TolerationOpExists,
-					Effect:            corev1.TaintEffectNoExecute,
-					TolerationSeconds: &secondsB,
-				},
-			},
-			want: false,
-		},
-		{
 			name: "different seconds one nil",
 			a: []corev1.Toleration{
 				{
@@ -366,7 +346,7 @@ func TestDeepEqual(t *testing.T) {
 		var tt = tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := DeepEqual(tt.a, tt.b); got != tt.want {
-				t.Errorf("DeepEqual() = %v, want %v", got, tt.want)
+				t.Errorf("DeepEqual() = %t, want %t", got, tt.want)
 			}
 		})
 	}

--- a/internal/pkg/toleration/toleration_test.go
+++ b/internal/pkg/toleration/toleration_test.go
@@ -1,0 +1,373 @@
+package toleration
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestDeepEqual(t *testing.T) {
+	var secondsA int64 = 30
+	var secondsB int64 = 40
+	tests := []struct {
+		name string
+		a    []corev1.Toleration
+		b    []corev1.Toleration
+		want bool
+	}{
+		{
+			name: "both empty",
+			a:    []corev1.Toleration{},
+			b:    []corev1.Toleration{},
+			want: true,
+		},
+		{
+			name: "one empty",
+			a:    []corev1.Toleration{},
+			b: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "other empty",
+			a: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			b:    []corev1.Toleration{},
+			want: false,
+		},
+		{
+			name: "same",
+			a: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			b: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "different seconds",
+			a: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			b: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsB,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "seconds nil",
+			a: []corev1.Toleration{
+				{
+					Key:      TaintNodeNotReady,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+			},
+			b: []corev1.Toleration{
+				{
+					Key:      TaintNodeNotReady,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "different seconds",
+			a: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			b: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsB,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different seconds one nil",
+			a: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			b: []corev1.Toleration{
+				{
+					Key:      TaintNodeNotReady,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different key",
+			a: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			b: []corev1.Toleration{
+				{
+					Key:               TaintNodeUnreachable,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different operator",
+			a: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			b: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpEqual,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different effect",
+			a: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			b: []corev1.Toleration{
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoSchedule,
+					TolerationSeconds: &secondsA,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "multiple same",
+			a: []corev1.Toleration{
+				{
+					Key:      TaintNodeDiskPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeMemoryPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeNetworkUnavailable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeNotReady,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodePIDPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeUnreachable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeUnschedulable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+			},
+			b: []corev1.Toleration{
+				{
+					Key:      TaintNodeDiskPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeMemoryPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeNetworkUnavailable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeNotReady,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodePIDPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeUnreachable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeUnschedulable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "multiple different",
+			a: []corev1.Toleration{
+				{
+					Key:      TaintNodeDiskPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeMemoryPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeNetworkUnavailable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeNotReady,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodePIDPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeUnreachable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeUnschedulable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+			},
+			b: []corev1.Toleration{
+				{
+					Key:      TaintNodeDiskPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeMemoryPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeNetworkUnavailable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:               TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &secondsA,
+				},
+				{
+					Key:      TaintNodePIDPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeUnreachable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      TaintNodeUnschedulable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		var tt = tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DeepEqual(tt.a, tt.b); got != tt.want {
+				t.Errorf("DeepEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -571,7 +571,7 @@ func (s StorageOSClusterSpec) GetHelperTolerations(tolerationSeconds int64) []co
 }
 
 // mergeTolerations merges a slice of tolerations on top of a base slice,
-// overwiting duplicate keys.
+// overwriting duplicate keys.
 func mergeTolerations(base []corev1.Toleration, overlay []corev1.Toleration) []corev1.Toleration {
 	tolerations := make(map[string]corev1.Toleration)
 	for _, t := range append(base, overlay...) {

--- a/pkg/apis/storageos/v1/storageoscluster_types.go
+++ b/pkg/apis/storageos/v1/storageoscluster_types.go
@@ -554,17 +554,35 @@ func (s StorageOSClusterSpec) GetCSIDeploymentStrategy() string {
 	return DefaultCSIDeploymentStrategy
 }
 
-// GetTolerations returns the tolerations applied to all the StorageOS related
-// pods.
-func (s StorageOSClusterSpec) GetTolerations() []corev1.Toleration {
-	tolerations := toleration.GetDefaultTolerations()
+// GetNodeTolerations returns the tolerations applied to all the StorageOS node
+// container pod.  Tolerations are sorted on key name to ensure idempotency.
+func (s StorageOSClusterSpec) GetNodeTolerations() []corev1.Toleration {
+	t := mergeTolerations(toleration.GetDefaultNodeTolerations(), s.Tolerations)
+	toleration.Sort(t)
+	return t
+}
 
-	// Append the tolerations specified in the spec.
-	if len(s.Tolerations) > 0 {
-		tolerations = append(tolerations, s.Tolerations...)
+// GetHelperTolerations returns the tolerations applied to all the StorageOS
+// helper pods.  Tolerations are sorted on key name to ensure idempotency.
+func (s StorageOSClusterSpec) GetHelperTolerations(tolerationSeconds int64) []corev1.Toleration {
+	t := mergeTolerations(toleration.GetDefaultHelperTolerations(tolerationSeconds), s.Tolerations)
+	toleration.Sort(t)
+	return t
+}
+
+// mergeTolerations merges a slice of tolerations on top of a base slice,
+// overwiting duplicate keys.
+func mergeTolerations(base []corev1.Toleration, overlay []corev1.Toleration) []corev1.Toleration {
+	tolerations := make(map[string]corev1.Toleration)
+	for _, t := range append(base, overlay...) {
+		tolerations[t.Key] = t
 	}
 
-	return tolerations
+	var ret []corev1.Toleration
+	for _, t := range tolerations {
+		ret = append(ret, t)
+	}
+	return ret
 }
 
 // ContainerImages contains image names of all the containers used by the operator.

--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -97,10 +97,11 @@ func (s Deployment) createCSIHelperDeployment(replicas int32) error {
 func (s Deployment) addCommonPodProperties(podSpec *corev1.PodSpec) error {
 	s.addPodPriorityClass(podSpec)
 	s.addNodeAffinity(podSpec)
-	if err := s.addTolerations(podSpec); err != nil {
+
+	// Add helper tolerations.
+	if err := s.addHelperTolerations(podSpec, podTolerationSeconds); err != nil {
 		return err
 	}
-	addPodTolerationForRecovery(podSpec)
 	return nil
 }
 

--- a/pkg/storageos/daemonset.go
+++ b/pkg/storageos/daemonset.go
@@ -285,7 +285,7 @@ func (s *Deployment) createDaemonSet() error {
 
 	s.addNodeAffinity(podSpec)
 
-	if err := s.addTolerationsWithDefaults(podSpec); err != nil {
+	if err := s.addNodeTolerations(podSpec); err != nil {
 		return err
 	}
 

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -93,7 +93,7 @@ const (
 
 	// podTolerationSeconds is the time for which a pod tolerates an unfavorable
 	// node condition.
-	podTolerationSeconds = 30
+	podTolerationSeconds int64 = 30
 )
 
 var log = logf.Log.WithName("storageos.cluster")
@@ -423,26 +423,4 @@ func GetFirstAddress(addresses []corev1.NodeAddress) string {
 		return addr.Address
 	}
 	return ""
-}
-
-// addPodTolerationForRecovery adds pod tolerations for cases when a node isn't
-// functional. Usually k8s toleration seconds is five minutes. This sets the
-// toleration seconds to 30 seconds.
-func addPodTolerationForRecovery(podSpec *corev1.PodSpec) {
-	tolerationSeconds := int64(podTolerationSeconds)
-	recoveryTolerations := []corev1.Toleration{
-		{
-			Effect:            corev1.TaintEffectNoExecute,
-			Key:               nodeNotReadyTolKey,
-			Operator:          corev1.TolerationOpExists,
-			TolerationSeconds: &tolerationSeconds,
-		},
-		{
-			Effect:            corev1.TaintEffectNoExecute,
-			Key:               nodeUnreachableTolKey,
-			Operator:          corev1.TolerationOpExists,
-			TolerationSeconds: &tolerationSeconds,
-		},
-	}
-	podSpec.Tolerations = append(podSpec.Tolerations, recoveryTolerations...)
 }

--- a/pkg/storageos/deploy_test.go
+++ b/pkg/storageos/deploy_test.go
@@ -7,6 +7,7 @@ import (
 	glog "log"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -471,11 +472,11 @@ func TestCreateCSIHelper(t *testing.T) {
 			// Check if the recovery tolerations are applied.
 			foundNotReadyTol := false
 			foundUnreachableTol := false
-			for _, toleration := range tolerations {
-				switch toleration.Key {
-				case nodeNotReadyTolKey:
+			for _, tol := range tolerations {
+				switch tol.Key {
+				case toleration.TaintNodeNotReady:
 					foundNotReadyTol = true
-				case nodeUnreachableTolKey:
+				case toleration.TaintNodeUnreachable:
 					foundUnreachableTol = true
 				}
 			}
@@ -991,15 +992,30 @@ func TestDeployNodeAffinity(t *testing.T) {
 }
 
 func TestDeployTolerations(t *testing.T) {
-	defaultTolerations := toleration.GetDefaultTolerations()
+	defaultNodeTolerations := toleration.GetDefaultNodeTolerations()
+	defaultHelperTolerations := toleration.GetDefaultHelperTolerations(podTolerationSeconds)
+	defaultPodTolerationSeconds := int64(30)
+	testSeconds := int64(600)
+
+	tolerationsToString := func(tolerations []corev1.Toleration) string {
+		out := []string{}
+		for _, t := range tolerations {
+			out = append(out, t.String())
+		}
+		return strings.Join(out, "\n")
+	}
 
 	testCases := []struct {
-		name        string
-		tolerations []corev1.Toleration
-		wantError   bool
+		name                  string
+		tolerations           []corev1.Toleration
+		wantNodeTolerations   []corev1.Toleration
+		wantHelperTolerations []corev1.Toleration
+		wantError             bool
 	}{
 		{
-			name: "No tolerations, default",
+			name:                  "No tolerations, default",
+			wantNodeTolerations:   defaultNodeTolerations,
+			wantHelperTolerations: defaultHelperTolerations,
 		},
 		{
 			name: "TolerationOpExists without value",
@@ -1010,6 +1026,16 @@ func TestDeployTolerations(t *testing.T) {
 					Effect:   corev1.TaintEffectNoSchedule,
 				},
 			},
+			wantNodeTolerations: append(defaultNodeTolerations, corev1.Toleration{
+				Key:      "foo",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}),
+			wantHelperTolerations: append(defaultHelperTolerations, corev1.Toleration{
+				Key:      "foo",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}),
 		},
 		{
 			name: "TolerationOpExists with value",
@@ -1031,6 +1057,86 @@ func TestDeployTolerations(t *testing.T) {
 					Operator: corev1.TolerationOpEqual,
 					Value:    "bar",
 					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			wantNodeTolerations: append(defaultNodeTolerations, corev1.Toleration{
+				Key:      "foo",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "bar",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}),
+			wantHelperTolerations: append(defaultHelperTolerations, corev1.Toleration{
+				Key:      "foo",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "bar",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}),
+		},
+		{
+			name: "Overwrite default value",
+			tolerations: []corev1.Toleration{
+				{
+					Key:               corev1.TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &testSeconds,
+				},
+			},
+			wantNodeTolerations: []corev1.Toleration{
+				{
+					Key:      corev1.TaintNodeDiskPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      corev1.TaintNodeMemoryPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      corev1.TaintNodeNetworkUnavailable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:               corev1.TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &testSeconds,
+				},
+				{
+					Key:      corev1.TaintNodePIDPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      corev1.TaintNodeUnreachable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+				{
+					Key:      corev1.TaintNodeUnschedulable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
+				},
+			},
+			wantHelperTolerations: []corev1.Toleration{
+				{
+					Key:               corev1.TaintNodeNotReady,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &testSeconds,
+				},
+				{
+					Key:               corev1.TaintNodeUnreachable,
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &defaultPodTolerationSeconds,
+				},
+				{
+					Key:      corev1.TaintNodeDiskPressure,
+					Operator: corev1.TolerationOpExists,
+					Effect:   "",
 				},
 			},
 		},
@@ -1096,10 +1202,10 @@ func TestDeployTolerations(t *testing.T) {
 			if err := c.Get(context.Background(), nsName, createdDaemonset); err != nil {
 				t.Fatal("failed to get the created daemonset", err)
 			}
-			podSpec := createdDaemonset.Spec.Template.Spec
-			wantTolerations := append(defaultTolerations, tc.tolerations...)
-			if !reflect.DeepEqual(podSpec.Tolerations, wantTolerations) {
-				t.Errorf("unexpected Tolerations value:\n\t(GOT) %v\n\t(WNT) %v", podSpec.Tolerations, wantTolerations)
+
+			gotTolerations := createdDaemonset.Spec.Template.Spec.Tolerations
+			if !toleration.DeepEqual(gotTolerations, tc.wantNodeTolerations) {
+				t.Errorf("unexpected node tolerations:\n(GOT):\n%s\n(WNT):\n%s", tolerationsToString(gotTolerations), tolerationsToString(tc.wantNodeTolerations))
 			}
 
 			// Check csi-helpers tolerations.
@@ -1116,32 +1222,10 @@ func TestDeployTolerations(t *testing.T) {
 			if err := c.Get(context.Background(), nsName, createdCSIHelperDeployment); err != nil {
 				t.Fatal("failed to get the created csi helpers deployment", err)
 			}
-			// Remove extra tolerations (unreachable and not-ready) that are
-			// added by k8s by default before comparison. These tolerations
-			// have non-nil toleration seconds attribute.
-			removeExtraTolerations := func(allTolerations []corev1.Toleration) []corev1.Toleration {
-				result := []corev1.Toleration{}
-				for _, tol := range allTolerations {
-					switch tol.Key {
-					case toleration.TaintNodeUnreachable, toleration.TaintNodeNotReady:
-						if tol.TolerationSeconds == nil {
-							result = append(result, tol)
-						}
-						continue
-					default:
-						result = append(result, tol)
-					}
-				}
-				return result
-			}
-			gotTolerations := removeExtraTolerations(createdCSIHelperDeployment.Spec.Template.Spec.Tolerations)
 
-			if !reflect.DeepEqual(gotTolerations, tc.tolerations) {
-				// Deepequal fails for empty maps. If the maps are empty, don't
-				// fail.
-				if len(gotTolerations) != 0 || len(tc.tolerations) != 0 {
-					t.Errorf("unexpected Tolerations value:\n\t(GOT) %v\n\t(WNT) %v", gotTolerations, tc.tolerations)
-				}
+			gotTolerations = createdCSIHelperDeployment.Spec.Template.Spec.Tolerations
+			if !toleration.DeepEqual(gotTolerations, tc.wantHelperTolerations) {
+				t.Errorf("unexpected csi helper tolerations:\n(GOT):\n%s\n(WNT):\n%s", tolerationsToString(gotTolerations), tolerationsToString(tc.wantHelperTolerations))
 			}
 
 			// Check api-manager tolerations.
@@ -1158,14 +1242,10 @@ func TestDeployTolerations(t *testing.T) {
 			if err := c.Get(context.Background(), nsName, createdAPIManagerDeployment); err != nil {
 				t.Fatal("failed to get the created api-manager deployment", err)
 			}
-			gotTolerations = removeExtraTolerations(createdAPIManagerDeployment.Spec.Template.Spec.Tolerations)
 
-			if !reflect.DeepEqual(gotTolerations, tc.tolerations) {
-				// Deepequal fails for empty maps. If the maps are empty, don't
-				// fail.
-				if len(gotTolerations) != 0 || len(tc.tolerations) != 0 {
-					t.Errorf("unexpected Tolerations value:\n\t(GOT) %v\n\t(WNT) %v", gotTolerations, tc.tolerations)
-				}
+			gotTolerations = createdAPIManagerDeployment.Spec.Template.Spec.Tolerations
+			if !toleration.DeepEqual(gotTolerations, tc.wantHelperTolerations) {
+				t.Errorf("unexpected api-manager tolerations:\n(GOT):\n%s\n(WNT):\n%s", tolerationsToString(gotTolerations), tolerationsToString(tc.wantHelperTolerations))
 			}
 
 			// Check scheduler tolerations.
@@ -1182,14 +1262,10 @@ func TestDeployTolerations(t *testing.T) {
 			if err := c.Get(context.Background(), nsName, createdSchedulerDeployment); err != nil {
 				t.Fatal("failed to get the created scheduler deployment", err)
 			}
-			gotTolerations = removeExtraTolerations(createdSchedulerDeployment.Spec.Template.Spec.Tolerations)
 
-			if !reflect.DeepEqual(gotTolerations, tc.tolerations) {
-				// Deepequal fails for empty maps. If the maps are empty, don't
-				// fail.
-				if len(gotTolerations) != 0 || len(tc.tolerations) != 0 {
-					t.Errorf("unexpected Tolerations value:\n\t(GOT) %v\n\t(WNT) %v", gotTolerations, tc.tolerations)
-				}
+			gotTolerations = createdSchedulerDeployment.Spec.Template.Spec.Tolerations
+			if !toleration.DeepEqual(gotTolerations, tc.wantHelperTolerations) {
+				t.Errorf("unexpected scheduler tolerations:\n(GOT):\n%s\n(WNT):\n%s", tolerationsToString(gotTolerations), tolerationsToString(tc.wantHelperTolerations))
 			}
 		})
 	}

--- a/pkg/storageos/podspec.go
+++ b/pkg/storageos/podspec.go
@@ -229,17 +229,19 @@ func (s *Deployment) addNodeAffinity(podSpec *corev1.PodSpec) {
 	}
 }
 
-// addTolerations adds tolerations to the given pod spec from cluster
-// spec Tolerations.
-func (s *Deployment) addTolerations(podSpec *corev1.PodSpec) error {
-	return util.AddTolerations(podSpec, s.stos.Spec.Tolerations)
+// addNodeTolerations adds the default node container tolerations along
+// with the tolerations in the cluster configuration to a given pod spec. The
+// default tolerations prevent pod eviction under various conditions.
+func (s *Deployment) addNodeTolerations(podSpec *corev1.PodSpec) error {
+	return util.AddTolerations(podSpec, s.stos.Spec.GetNodeTolerations())
 }
 
-// addTolerationsWithDefaults adds the default tolerations along with the
-// tolerations in the cluster configuration to a given pod spec. The default
-// tolerations prevent pod eviction under various conditions.
-func (s *Deployment) addTolerationsWithDefaults(podSpec *corev1.PodSpec) error {
-	return util.AddTolerations(podSpec, s.stos.Spec.GetTolerations())
+// addHelperTolerations adds the default helper tolerations along with the
+// tolerations in the cluster configuration to a given pod spec.  The helper
+// tolerations allow pod eviction under various conditions but also tolerate
+// some conditions.
+func (s *Deployment) addHelperTolerations(podSpec *corev1.PodSpec, tolerationSeconds int64) error {
+	return util.AddTolerations(podSpec, s.stos.Spec.GetHelperTolerations(tolerationSeconds))
 }
 
 // addTLSEtcdCerts adds the etcd TLS secret as a secret mount in the given

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -66,8 +66,7 @@ func (s Deployment) createSchedulerDeployment(replicas int32) error {
 		},
 	}
 
-	// Add helper tolerations.
-	if err := s.addHelperTolerations(&spec.Template.Spec, podTolerationSeconds); err != nil {
+	if err := s.addCommonPodProperties(&spec.Template.Spec); err != nil {
 		return err
 	}
 

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -66,13 +66,10 @@ func (s Deployment) createSchedulerDeployment(replicas int32) error {
 		},
 	}
 
-	// Add cluster config tolerations.
-	if err := s.addTolerations(&spec.Template.Spec); err != nil {
+	// Add helper tolerations.
+	if err := s.addHelperTolerations(&spec.Template.Spec, podTolerationSeconds); err != nil {
 		return err
 	}
-
-	// Add pod toleration for quick recovery on node failure.
-	addPodTolerationForRecovery(&spec.Template.Spec)
 
 	return s.k8sResourceManager.Deployment(SchedulerExtenderName, s.stos.Spec.GetResourceNS(), nil, spec).Create()
 }


### PR DESCRIPTION
Sets default tolerations on the non-critical helper pods.  

By default, the helpers will tolerate `node.kubernetes.io/disk-pressure` and the default `TolerationSeconds` for `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` is reduced from 300 to 30s.

- Allows defaults to be overridden by tolerations set in the StorageOSCluster spec.  
- Removes the deprecated `node.kubernetes.io/out-of-disk` toleration.
- Sorts tolerations on key name to ensure idempotency.