### PR TITLE
Remove priorityclass from helper pods

### DIFF
--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -95,7 +95,6 @@ func (s Deployment) createCSIHelperDeployment(replicas int32) error {
 // common pod properties are common for all the pods that are part of storageos
 // deployment, including the CSI helpers pod.
 func (s Deployment) addCommonPodProperties(podSpec *corev1.PodSpec) error {
-	s.addPodPriorityClass(podSpec)
 	s.addNodeAffinity(podSpec)
 	if err := s.addTolerations(podSpec); err != nil {
 		return err


### PR DESCRIPTION
Removes the `system-node-critical` priority class from the helper Pods.  This will allow the pods to failover more quickly when the node is under pressure.