### PR TITLE
Fix apiManagerContainer tag in v1 deploy CRD

### DIFF
--- a/deploy/crds/storageos.com_v1_storageoscluster_cr.yaml
+++ b/deploy/crds/storageos.com_v1_storageoscluster_cr.yaml
@@ -25,7 +25,7 @@ spec:
   #   csiLivenessProbeContainer:
   #   hyperkubeContainer:
   #   nfsContainer:
-  #   apiControllerContainer:
+  #   apiManagerContainer:
   # csi:
   #   enable: true
   #   endpoint: /var/lib/kubelet/device-plugins/


### PR DESCRIPTION
`apiControllerContainer` was an invalid image name.