### PR TITLE
Add rbac needed for csi-resizer v1.0.0

### DIFF
--- a/pkg/storageos/rbac.go
+++ b/pkg/storageos/rbac.go
@@ -327,6 +327,11 @@ func (s *Deployment) createClusterRoleForResizer() error {
 		},
 		{
 			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{""},
 			Resources: []string{"events"},
 			Verbs:     []string{"list", "watch", "create", "update", "patch"},
 		},


### PR DESCRIPTION
The CSI external-resizer v1.0.0 introduced a new RBAC requirement.  This grants read-only access to Pods.

Tested manually and with kubecover.