### PR TITLE
CSV: correct the replaces version for v2.4.0

### DIFF
--- a/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.clusterserviceversion.yaml
@@ -722,4 +722,4 @@ spec:
           with the NFS Server. If not specified, a new PVC is provisioned and used.
         displayName: Persistent Volume Claim
         path: persistentVolumeClaim
-  replaces: storageosoperator.v2.3.0
+  replaces: storageosoperator.v2.3.4

--- a/deploy/olm/csv-rhel/storageos.v2.4.0.clusterserviceversion.yaml
+++ b/deploy/olm/csv-rhel/storageos.v2.4.0.clusterserviceversion.yaml
@@ -722,4 +722,4 @@ spec:
           with the NFS Server. If not specified, a new PVC is provisioned and used.
         displayName: Persistent Volume Claim
         path: persistentVolumeClaim
-  replaces: storageosoperator.v2.3.0
+  replaces: storageosoperator.v2.3.4

--- a/deploy/olm/storageos/storageos.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.clusterserviceversion.yaml
@@ -678,4 +678,4 @@ spec:
           with the NFS Server. If not specified, a new PVC is provisioned and used.
         displayName: Persistent Volume Claim
         path: persistentVolumeClaim
-  replaces: storageosoperator.v2.3.0
+  replaces: storageosoperator.v2.3.4

--- a/deploy/olm/storageos/storageos.v2.4.0.clusterserviceversion.yaml
+++ b/deploy/olm/storageos/storageos.v2.4.0.clusterserviceversion.yaml
@@ -678,4 +678,4 @@ spec:
           with the NFS Server. If not specified, a new PVC is provisioned and used.
         displayName: Persistent Volume Claim
         path: persistentVolumeClaim
-  replaces: storageosoperator.v2.3.0
+  replaces: storageosoperator.v2.3.4


### PR DESCRIPTION
This caused CI failure in the community operators.
2.4.0 replaces 2.3.4.