### PR TITLE
Set priority class for helper pods

### DIFF
--- a/pkg/storageos/csi_helper.go
+++ b/pkg/storageos/csi_helper.go
@@ -91,19 +91,6 @@ func (s Deployment) createCSIHelperDeployment(replicas int32) error {
 	return s.k8sResourceManager.Deployment(csiHelperName, s.stos.Spec.GetResourceNS(), nil, spec).Create()
 }
 
-// addCommonPodProperties adds common pod properties to a given pod spec. The
-// common pod properties are common for all the pods that are part of storageos
-// deployment, including the CSI helpers pod.
-func (s Deployment) addCommonPodProperties(podSpec *corev1.PodSpec) error {
-	s.addNodeAffinity(podSpec)
-
-	// Add helper tolerations.
-	if err := s.addHelperTolerations(podSpec, podTolerationSeconds); err != nil {
-		return err
-	}
-	return nil
-}
-
 // csiHelperContainers returns a list of containers that should be part of the
 // CSI helper pods.
 func (s Deployment) csiHelperContainers() ([]corev1.Container, error) {

--- a/pkg/storageos/daemonset.go
+++ b/pkg/storageos/daemonset.go
@@ -279,7 +279,7 @@ func (s *Deployment) createDaemonSet() error {
 	podSpec := &spec.Template.Spec
 	nodeContainer := &podSpec.Containers[0]
 
-	s.addPodPriorityClass(podSpec)
+	s.addPodPriorityClass(podSpec, nodeCriticalPriorityClass)
 
 	s.addTLSEtcdCerts(podSpec)
 


### PR DESCRIPTION
Sets the `system-cluster-critical` priority class on StorageOS pods that must be running somewhere in the cluster.  This allows the Pod to move to another node if it doesn't tolerate a taint (such as memory pressure) but ensures it runs somewhere.