### PR TITLE
Increase scheduler weight

### DIFF
--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -140,7 +140,7 @@ func (s Deployment) createSchedulerPolicy() error {
         "urlPrefix": "{{.URLPrefix}}",
         "filterVerb": "{{.FilterVerb}}",
         "prioritizeVerb": "{{.PrioritizeVerb}}",
-        "weight": 1,
+        "weight": 1000,
         "enableHttps": {{.EnableHTTPS}},
         "nodeCacheCapable": false
       }]


### PR DESCRIPTION
In `kube-scheduler` scheduler plugins and extender schedulers are in different scale. In some cases Kubernetes schedules a pod far of the master volume, because extender's low numbers can't make any sense. This change introduces the weight of our scheduler to fix pod locality issues.