### PR TITLE
Create roles for scheduling

### DIFF
--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -109,6 +109,14 @@ func (s *Deployment) Deploy() error {
 		return err
 	}
 
+	if err := s.createClusterRoleForScheduling(); err != nil {
+		return err
+	}
+
+	if err := s.createClusterRoleBindingForScheduling(); err != nil {
+		return err
+	}
+
 	if err := s.createClusterRoleForKeyMgmt(); err != nil {
 		return err
 	}

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -109,11 +109,11 @@ func (s *Deployment) Deploy() error {
 		return err
 	}
 
-	if err := s.createClusterRoleForScheduling(); err != nil {
+	if err := s.createClusterRoleForSchedulerExtender(); err != nil {
 		return err
 	}
 
-	if err := s.createClusterRoleBindingForScheduling(); err != nil {
+	if err := s.createClusterRoleBindingForSchedulerExtender(); err != nil {
 		return err
 	}
 

--- a/pkg/storageos/deploy.go
+++ b/pkg/storageos/deploy.go
@@ -109,11 +109,11 @@ func (s *Deployment) Deploy() error {
 		return err
 	}
 
-	if err := s.createClusterRoleForSchedulerExtender(); err != nil {
+	if err := s.createClusterRoleForSchedulerExtenderVolumeChecker(); err != nil {
 		return err
 	}
 
-	if err := s.createClusterRoleBindingForSchedulerExtender(); err != nil {
+	if err := s.createClusterRoleBindingForSchedulerExtenderVolumeChecker(); err != nil {
 		return err
 	}
 

--- a/pkg/storageos/rbac.go
+++ b/pkg/storageos/rbac.go
@@ -38,11 +38,11 @@ const (
 	NFSClusterRoleName    = "storageos:nfs-provisioner"
 	NFSClusterBindingName = "storageos:nfs-provisioner"
 
-	KubeSchedulerClusterRoleName    = "storageos:kube-scheduler"
-	KubeSchedulerClusterBindingName = "storageos:kube-scheduler"
-
 	SchedulerExtenderClusterRoleName    = "storageos:scheduler-extender"
 	SchedulerExtenderClusterBindingName = "storageos:scheduler-extender"
+
+	SchedulerExtenderVolumeCheckerClusterRoleName    = "storageos:scheduler-extender-vol-checker"
+	SchedulerExtenderVolumeCheckerClusterBindingName = "storageos:scheduler-extender-vol-checker"
 
 	InitClusterRoleName    = "storageos:init"
 	InitClusterBindingName = "storageos:init"
@@ -342,9 +342,9 @@ func (s *Deployment) createClusterRoleForResizer() error {
 	return s.k8sResourceManager.ClusterRole(CSIResizerClusterRoleName, nil, rules).Create()
 }
 
-// createClusterRoleForKubeScheduler creates a ClusterRole resource for scheduler
+// createClusterRoleForSchedulerExtender creates a ClusterRole resource for scheduler
 // extender with all the permissions required by kube-scheduler.
-func (s *Deployment) createClusterRoleForKubeScheduler() error {
+func (s *Deployment) createClusterRoleForSchedulerExtender() error {
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
@@ -389,12 +389,12 @@ func (s *Deployment) createClusterRoleForKubeScheduler() error {
 			Verbs:     []string{"get", "create", "update"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(KubeSchedulerClusterRoleName, nil, rules).Create()
+	return s.k8sResourceManager.ClusterRole(SchedulerExtenderClusterRoleName, nil, rules).Create()
 }
 
-// createClusterRoleForSchedulerExtender creates a ClusterRole resource for scheduler
+// createClusterRoleForSchedulerExtenderVolumeChecker creates a ClusterRole resource for scheduler
 // extender with all the permissions required by custom scheduler extender.
-func (s *Deployment) createClusterRoleForSchedulerExtender() error {
+func (s *Deployment) createClusterRoleForSchedulerExtenderVolumeChecker() error {
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
@@ -410,7 +410,7 @@ func (s *Deployment) createClusterRoleForSchedulerExtender() error {
 			Verbs:     []string{"get"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(SchedulerExtenderClusterRoleName, nil, rules).Create()
+	return s.k8sResourceManager.ClusterRole(SchedulerExtenderVolumeCheckerClusterRoleName, nil, rules).Create()
 }
 
 func (s *Deployment) createClusterRoleBindingForKeyMgmt() error {
@@ -606,9 +606,9 @@ func (s *Deployment) createClusterRoleBindingForSCC() error {
 	return s.k8sResourceManager.ClusterRoleBinding(OpenShiftSCCClusterBindingName, nil, subjects, roleRef).Create()
 }
 
-// createClusterRoleBindingForKubeScheduler creates a cluster role binding for the
+// createClusterRoleBindingForSchedulerExtender creates a cluster role binding for the
 // kube-scheduler.
-func (s *Deployment) createClusterRoleBindingForKubeScheduler() error {
+func (s *Deployment) createClusterRoleBindingForSchedulerExtender() error {
 	subjects := []rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
@@ -618,15 +618,15 @@ func (s *Deployment) createClusterRoleBindingForKubeScheduler() error {
 	}
 	roleRef := &rbacv1.RoleRef{
 		Kind:     "ClusterRole",
-		Name:     KubeSchedulerClusterRoleName,
+		Name:     SchedulerExtenderClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(KubeSchedulerClusterBindingName, nil, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(SchedulerExtenderClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 // createClusterRoleBindingForScheduler creates a cluster role binding for the
 // custom scheduler extender.
-func (s *Deployment) createClusterRoleBindingForSchedulerExtender() error {
+func (s *Deployment) createClusterRoleBindingForSchedulerExtenderVolumeChecker() error {
 	subjects := []rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
@@ -636,10 +636,10 @@ func (s *Deployment) createClusterRoleBindingForSchedulerExtender() error {
 	}
 	roleRef := &rbacv1.RoleRef{
 		Kind:     "ClusterRole",
-		Name:     SchedulerExtenderClusterRoleName,
+		Name:     SchedulerExtenderVolumeCheckerClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(SchedulerExtenderClusterBindingName, nil, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(SchedulerExtenderVolumeCheckerClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 // createClusterRoleForInit creates cluster role for the init container. This is

--- a/pkg/storageos/rbac.go
+++ b/pkg/storageos/rbac.go
@@ -38,11 +38,11 @@ const (
 	NFSClusterRoleName    = "storageos:nfs-provisioner"
 	NFSClusterBindingName = "storageos:nfs-provisioner"
 
-	SchedulerClusterRoleName    = "storageos:scheduler-extender"
-	SchedulerClusterBindingName = "storageos:scheduler-extender"
+	KubeSchedulerClusterRoleName    = "storageos:kube-scheduler"
+	KubeSchedulerClusterBindingName = "storageos:kube-scheduler"
 
-	SchedulingClusterRoleName    = "storageos:scheduling-extender"
-	SchedulingClusterBindingName = "storageos:scheduling-extender"
+	SchedulerExtenderClusterRoleName    = "storageos:scheduler-extender"
+	SchedulerExtenderClusterBindingName = "storageos:scheduler-extender"
 
 	InitClusterRoleName    = "storageos:init"
 	InitClusterBindingName = "storageos:init"
@@ -342,9 +342,9 @@ func (s *Deployment) createClusterRoleForResizer() error {
 	return s.k8sResourceManager.ClusterRole(CSIResizerClusterRoleName, nil, rules).Create()
 }
 
-// createClusterRoleForScheduler creates a ClusterRole resource for scheduler
+// createClusterRoleForKubeScheduler creates a ClusterRole resource for scheduler
 // extender with all the permissions required by kube-scheduler.
-func (s *Deployment) createClusterRoleForScheduler() error {
+func (s *Deployment) createClusterRoleForKubeScheduler() error {
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
@@ -389,12 +389,12 @@ func (s *Deployment) createClusterRoleForScheduler() error {
 			Verbs:     []string{"get", "create", "update"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(SchedulerClusterRoleName, nil, rules).Create()
+	return s.k8sResourceManager.ClusterRole(KubeSchedulerClusterRoleName, nil, rules).Create()
 }
 
-// createClusterRoleForScheduling creates a ClusterRole resource for scheduler
+// createClusterRoleForSchedulerExtender creates a ClusterRole resource for scheduler
 // extender with all the permissions required by custom scheduler extender.
-func (s *Deployment) createClusterRoleForScheduling() error {
+func (s *Deployment) createClusterRoleForSchedulerExtender() error {
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
@@ -410,7 +410,7 @@ func (s *Deployment) createClusterRoleForScheduling() error {
 			Verbs:     []string{"get"},
 		},
 	}
-	return s.k8sResourceManager.ClusterRole(SchedulingClusterRoleName, nil, rules).Create()
+	return s.k8sResourceManager.ClusterRole(SchedulerExtenderClusterRoleName, nil, rules).Create()
 }
 
 func (s *Deployment) createClusterRoleBindingForKeyMgmt() error {
@@ -606,9 +606,9 @@ func (s *Deployment) createClusterRoleBindingForSCC() error {
 	return s.k8sResourceManager.ClusterRoleBinding(OpenShiftSCCClusterBindingName, nil, subjects, roleRef).Create()
 }
 
-// createClusterRoleBindingForScheduler creates a cluster role binding for the
+// createClusterRoleBindingForKubeScheduler creates a cluster role binding for the
 // kube-scheduler.
-func (s *Deployment) createClusterRoleBindingForScheduler() error {
+func (s *Deployment) createClusterRoleBindingForKubeScheduler() error {
 	subjects := []rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
@@ -618,15 +618,15 @@ func (s *Deployment) createClusterRoleBindingForScheduler() error {
 	}
 	roleRef := &rbacv1.RoleRef{
 		Kind:     "ClusterRole",
-		Name:     SchedulerClusterRoleName,
+		Name:     KubeSchedulerClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(SchedulerClusterBindingName, nil, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(KubeSchedulerClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 // createClusterRoleBindingForScheduler creates a cluster role binding for the
 // custom scheduler extender.
-func (s *Deployment) createClusterRoleBindingForScheduling() error {
+func (s *Deployment) createClusterRoleBindingForSchedulerExtender() error {
 	subjects := []rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
@@ -636,10 +636,10 @@ func (s *Deployment) createClusterRoleBindingForScheduling() error {
 	}
 	roleRef := &rbacv1.RoleRef{
 		Kind:     "ClusterRole",
-		Name:     SchedulingClusterRoleName,
+		Name:     SchedulerExtenderClusterRoleName,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
-	return s.k8sResourceManager.ClusterRoleBinding(SchedulingClusterBindingName, nil, subjects, roleRef).Create()
+	return s.k8sResourceManager.ClusterRoleBinding(SchedulerExtenderClusterBindingName, nil, subjects, roleRef).Create()
 }
 
 // createClusterRoleForInit creates cluster role for the init container. This is

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -29,13 +29,13 @@ func (s *Deployment) createSchedulerExtender() error {
 	}
 
 	// Create RBAC related resources.
-	if err := s.createClusterRoleForKubeScheduler(); err != nil {
+	if err := s.createClusterRoleForSchedulerExtender(); err != nil {
 		return err
 	}
 	if err := s.createServiceAccountForScheduler(); err != nil {
 		return err
 	}
-	if err := s.createClusterRoleBindingForKubeScheduler(); err != nil {
+	if err := s.createClusterRoleBindingForSchedulerExtender(); err != nil {
 		return err
 	}
 
@@ -103,13 +103,13 @@ func (s Deployment) deleteSchedulerExtender() error {
 	if err := s.k8sResourceManager.ConfigMap(policyConfigMapName, namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
-	if err := s.k8sResourceManager.ClusterRoleBinding(KubeSchedulerClusterBindingName, nil, nil, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ClusterRoleBinding(SchedulerExtenderClusterBindingName, nil, nil, nil).Delete(); err != nil {
 		return err
 	}
 	if err := s.k8sResourceManager.ServiceAccount(SchedulerSA, namespace, nil).Delete(); err != nil {
 		return err
 	}
-	if err := s.k8sResourceManager.ClusterRole(KubeSchedulerClusterRoleName, nil, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ClusterRole(SchedulerExtenderClusterRoleName, nil, nil).Delete(); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/storageos/scheduler_extender.go
+++ b/pkg/storageos/scheduler_extender.go
@@ -29,13 +29,13 @@ func (s *Deployment) createSchedulerExtender() error {
 	}
 
 	// Create RBAC related resources.
-	if err := s.createClusterRoleForScheduler(); err != nil {
+	if err := s.createClusterRoleForKubeScheduler(); err != nil {
 		return err
 	}
 	if err := s.createServiceAccountForScheduler(); err != nil {
 		return err
 	}
-	if err := s.createClusterRoleBindingForScheduler(); err != nil {
+	if err := s.createClusterRoleBindingForKubeScheduler(); err != nil {
 		return err
 	}
 
@@ -103,13 +103,13 @@ func (s Deployment) deleteSchedulerExtender() error {
 	if err := s.k8sResourceManager.ConfigMap(policyConfigMapName, namespace, nil, nil).Delete(); err != nil {
 		return err
 	}
-	if err := s.k8sResourceManager.ClusterRoleBinding(SchedulerClusterBindingName, nil, nil, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ClusterRoleBinding(KubeSchedulerClusterBindingName, nil, nil, nil).Delete(); err != nil {
 		return err
 	}
 	if err := s.k8sResourceManager.ServiceAccount(SchedulerSA, namespace, nil).Delete(); err != nil {
 		return err
 	}
-	if err := s.k8sResourceManager.ClusterRole(SchedulerClusterRoleName, nil, nil).Delete(); err != nil {
+	if err := s.k8sResourceManager.ClusterRole(KubeSchedulerClusterRoleName, nil, nil).Delete(); err != nil {
 		return err
 	}
 	return nil

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -211,14 +211,14 @@ operator-sdk-e2e-cleanup() {
     kubectl delete clusterrole storageos:csi-attacher \
         storageos:csi-provisioner storageos:driver-registrar \
         storageos:openshift-scc storageos:pod-fencer \
-        storageos:kube-scheduler storageos:scheduler-extender storageos:init \
+        storageos:scheduler-extender storageos:scheduler-extender-vol-checker storageos:init \
         storageos:nfs-provisioner --ignore-not-found=true
 
     # Delete all the cluster role bindings.
     kubectl delete clusterrolebinding storageos:csi-attacher \
         storageos:csi-provisioner storageos:driver-registrar \
         storageos:k8s-driver-registrar storageos:openshift-scc \
-        storageos:pod-fencer storageos:kube-scheduler storageos:scheduler-extender \
+        storageos:pod-fencer storageos:scheduler-extender storageos:scheduler-extender-vol-checker \
         storageos:init storageos:nfs-provisioner --ignore-not-found=true
 
     # Delete NFSServer statefulset.

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -211,14 +211,14 @@ operator-sdk-e2e-cleanup() {
     kubectl delete clusterrole storageos:csi-attacher \
         storageos:csi-provisioner storageos:driver-registrar \
         storageos:openshift-scc storageos:pod-fencer \
-        storageos:scheduler-extender storageos:scheduling-extender storageos:init \
+        storageos:kube-scheduler storageos:scheduler-extender storageos:init \
         storageos:nfs-provisioner --ignore-not-found=true
 
     # Delete all the cluster role bindings.
     kubectl delete clusterrolebinding storageos:csi-attacher \
         storageos:csi-provisioner storageos:driver-registrar \
         storageos:k8s-driver-registrar storageos:openshift-scc \
-        storageos:pod-fencer storageos:scheduler-extender storageos:scheduling-extender \
+        storageos:pod-fencer storageos:kube-scheduler storageos:scheduler-extender \
         storageos:init storageos:nfs-provisioner --ignore-not-found=true
 
     # Delete NFSServer statefulset.

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -211,14 +211,14 @@ operator-sdk-e2e-cleanup() {
     kubectl delete clusterrole storageos:csi-attacher \
         storageos:csi-provisioner storageos:driver-registrar \
         storageos:openshift-scc storageos:pod-fencer \
-        storageos:scheduler-extender storageos:init \
+        storageos:scheduler-extender storageos:scheduling-extender storageos:init \
         storageos:nfs-provisioner --ignore-not-found=true
 
     # Delete all the cluster role bindings.
     kubectl delete clusterrolebinding storageos:csi-attacher \
         storageos:csi-provisioner storageos:driver-registrar \
         storageos:k8s-driver-registrar storageos:openshift-scc \
-        storageos:pod-fencer storageos:scheduler-extender \
+        storageos:pod-fencer storageos:scheduler-extender storageos:scheduling-extender \
         storageos:init storageos:nfs-provisioner --ignore-not-found=true
 
     # Delete NFSServer statefulset.


### PR DESCRIPTION
New implementation of scheduler uses api server to detect pod volume types, and it needs more rights to do.