### PR TITLE
Operator shouldn't tolerate NoSchedule taint

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -45,8 +45,3 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "storageos-cluster-operator"
-      tolerations:
-      - key: "key"
-        operator: "Equal"
-        value: "value"
-        effect: "NoSchedule"


### PR DESCRIPTION
The uber-yaml sets the Operator pod to tolerate NoSchedule, which it doesn't need to do.  Tolerations for the other components are set in the StorageOSCluster CR and remain unchanged.