### PR TITLE
Allow api-manager to patch events for leader election

### DIFF
--- a/pkg/storageos/rbac.go
+++ b/pkg/storageos/rbac.go
@@ -135,7 +135,7 @@ func (s *Deployment) createClusterRoleForAPIManager() error {
 		{
 			APIGroups: []string{""},
 			Resources: []string{"events"},
-			Verbs:     []string{"create"},
+			Verbs:     []string{"create", "patch"},
 		},
 		{
 			APIGroups: []string{"coordination.k8s.io"},


### PR DESCRIPTION
Allows api-manager to patch events, needed by leader election.

Fixes:
```
User "system:serviceaccount:mcs-storageos:storageos-api-manager-sa" cannot patch resource "events" in API group "" in the namespace "storageos-load-test"' (will not retry!)
```
Fixed upstream in https://github.com/kubernetes-sigs/kubebuilder/issues/1474